### PR TITLE
libutil: add base64 support

### DIFF
--- a/config/ax_compiler_vendor.m4
+++ b/config/ax_compiler_vendor.m4
@@ -1,0 +1,88 @@
+# ===========================================================================
+#    https://www.gnu.org/software/autoconf-archive/ax_compiler_vendor.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_COMPILER_VENDOR
+#
+# DESCRIPTION
+#
+#   Determine the vendor of the C/C++ compiler, e.g., gnu, intel, ibm, sun,
+#   hp, borland, comeau, dec, cray, kai, lcc, metrowerks, sgi, microsoft,
+#   watcom, etc. The vendor is returned in the cache variable
+#   $ax_cv_c_compiler_vendor for C and $ax_cv_cxx_compiler_vendor for C++.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Steven G. Johnson <stevenj@alum.mit.edu>
+#   Copyright (c) 2008 Matteo Frigo
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 16
+
+AC_DEFUN([AX_COMPILER_VENDOR],
+[AC_CACHE_CHECK([for _AC_LANG compiler vendor], ax_cv_[]_AC_LANG_ABBREV[]_compiler_vendor,
+  dnl Please add if possible support to ax_compiler_version.m4
+  [# note: don't check for gcc first since some other compilers define __GNUC__
+  vendors="intel:     __ICC,__ECC,__INTEL_COMPILER
+           ibm:       __xlc__,__xlC__,__IBMC__,__IBMCPP__
+           pathscale: __PATHCC__,__PATHSCALE__
+           clang:     __clang__
+           cray:      _CRAYC
+           fujitsu:   __FUJITSU
+           gnu:       __GNUC__
+           sun:       __SUNPRO_C,__SUNPRO_CC
+           hp:        __HP_cc,__HP_aCC
+           dec:       __DECC,__DECCXX,__DECC_VER,__DECCXX_VER
+           borland:   __BORLANDC__,__CODEGEARC__,__TURBOC__
+           comeau:    __COMO__
+           kai:       __KCC
+           lcc:       __LCC__
+           sgi:       __sgi,sgi
+           microsoft: _MSC_VER
+           metrowerks: __MWERKS__
+           watcom:    __WATCOMC__
+           portland:  __PGI
+	   tcc:       __TINYC__
+           unknown:   UNKNOWN"
+  for ventest in $vendors; do
+    case $ventest in
+      *:) vendor=$ventest; continue ;;
+      *)  vencpp="defined("`echo $ventest | sed 's/,/) || defined(/g'`")" ;;
+    esac
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM(,[
+      #if !($vencpp)
+        thisisanerror;
+      #endif
+    ])], [break])
+  done
+  ax_cv_[]_AC_LANG_ABBREV[]_compiler_vendor=`echo $vendor | cut -d: -f1`
+ ])
+])
+

--- a/configure.ac
+++ b/configure.ac
@@ -78,6 +78,7 @@ AC_CONFIG_FILES( \
   src/lib/Makefile \
   src/libtap/Makefile \
   src/libtomlc99/Makefile \
+  src/libutil/Makefile \
   src/imp/Makefile \
 )
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,6 @@
 SUBDIRS = \
 	libtap \
 	libtomlc99 \
+	libutil \
 	lib \
 	imp

--- a/src/libtomlc99/Makefile.am
+++ b/src/libtomlc99/Makefile.am
@@ -1,6 +1,7 @@
 AM_CFLAGS = \
 	-I$(top_srcdir) \
 	$(WARNING_CFLAGS) \
+	-Wno-unused-parameter \
 	$(CODE_COVERAGE_CFLAGS)
 
 AM_LDFLAGS = \

--- a/src/libtomlc99/toml_tap.c
+++ b/src/libtomlc99/toml_tap.c
@@ -139,7 +139,7 @@ void parse_bad_input (void)
     char pattern[PATH_MAX];
     int flags = 0;
     glob_t results;
-    int i;
+    unsigned i;
 
     snprintf (pattern, sizeof (pattern), "%s/*.toml", TEST_BAD_INPUT);
     if (glob (pattern, flags, NULL, &results) != 0)
@@ -189,7 +189,7 @@ void parse_good_input (void)
     char pattern[PATH_MAX];
     int flags = 0;
     glob_t results;
-    int i;
+    unsigned i;
 
     snprintf (pattern, sizeof (pattern), "%s/*.toml", TEST_GOOD_INPUT);
     if (glob (pattern, flags, NULL, &results) != 0)

--- a/src/libutil/Makefile.am
+++ b/src/libutil/Makefile.am
@@ -1,0 +1,36 @@
+AM_CFLAGS = \
+	$(WARNING_CFLAGS) \
+	-Wno-sign-compare -Wno-unused-parameter \
+	$(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+	$(CODE_COVERAGE_LIBS)
+
+AM_CPPFLAGS = \
+	-I$(top_srcdir)
+
+noinst_LTLIBRARIES = \
+	libutil.la
+
+libutil_la_SOURCES = \
+	base64.c \
+	base64.h
+
+TESTS = test_base64.t
+
+test_ldadd = \
+	$(top_builddir)/src/libutil/libutil.la \
+	$(top_builddir)/src/libtap/libtap.la
+
+test_cppflags = \
+	$(AM_CPPFLAGS)
+
+check_PROGRAMS = $(TESTS)
+
+TEST_EXTENSIONS = .t
+T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
+	$(top_srcdir)/config/tap-driver.sh
+
+test_base64_t_SOURCES = test/base64_test.c
+test_base64_t_CPPFLAGS = $(test_cppflags)
+test_base64_t_LDADD = $(test_ldadd)

--- a/src/libutil/base64.c
+++ b/src/libutil/base64.c
@@ -1,0 +1,443 @@
+/*****************************************************************************
+ *  Written by Chris Dunlap <cdunlap@llnl.gov>.
+ *  Copyright (C) 2007-2017 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2002-2007 The Regents of the University of California.
+ *  UCRL-CODE-155910.
+ *
+ *  This file is part of the MUNGE Uid 'N' Gid Emporium (MUNGE).
+ *  For details, see <https://dun.github.io/munge/>.
+ *
+ *  MUNGE is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or (at your option)
+ *  any later version.  Additionally for the MUNGE library (libmunge), you
+ *  can redistribute it and/or modify it under the terms of the GNU Lesser
+ *  General Public License as published by the Free Software Foundation,
+ *  either version 3 of the License, or (at your option) any later version.
+ *
+ *  MUNGE is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  and GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  and GNU Lesser General Public License along with MUNGE.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *****************************************************************************/
+
+
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
+
+#include <assert.h>
+#include <string.h>
+#include "base64.h"
+
+
+/*****************************************************************************
+ *  Notes
+ *****************************************************************************/
+/*
+ *  For details on base64 encoding/decoding, refer to
+ *    rfc2440 (OpenPGP Message Format) sections 6.3-6.5.
+ *
+ *  Why am I not using OpenSSL's base64 encoding/decoding functions?
+ *    Because they have the following fucked functionality:
+ *  For base64-encoding, use of the context results in output that is broken
+ *    into 64-character lines; however, EVP_EncodeBlock() output is not broken.
+ *  For base64-decoding, use of the context returns the correct length of the
+ *    resulting output; however, EVP_DecodeBlock() returns a length that may
+ *    be up to two characters too long.
+ *  Finally, data base64-encoded via a context has to be decoded via a context,
+ *    and data base64-encoded w/o a context has to be decoded w/o a context.
+ *  So fuck it, I wrote my own.  :-P
+ */
+
+/*****************************************************************************
+ *  Constants
+ *****************************************************************************/
+
+#define BASE64_MAGIC    0xDEADBEEF
+#define BASE64_ERR      0xFF
+#define BASE64_IGN      0xFE
+#define BASE64_PAD      0xFD
+#define BASE64_PAD_CHAR '='
+
+
+/*****************************************************************************
+ *  Static Variables
+ *****************************************************************************/
+
+static const unsigned char bin2asc[] = \
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+static const unsigned char asc2bin[256] = {
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe, 0xfe, 0xfe,
+    0xfe, 0xfe, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x3e, 0xff, 0xff, 0xff, 0x3f,
+    0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0xff, 0xff,
+    0xff, 0xfd, 0xff, 0xff, 0xff, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
+    0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12,
+    0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20, 0x21, 0x22, 0x23, 0x24,
+    0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x30,
+    0x31, 0x32, 0x33, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff
+};
+
+
+/*****************************************************************************
+ *  Extern Functions
+ *****************************************************************************/
+
+int
+base64_init (base64_ctx *x)
+{
+    assert (x != NULL);
+
+    x->num = 0;
+    x->pad = 0;
+    assert (x->magic = BASE64_MAGIC);
+    assert (!(x->finalized = 0));
+    return (0);
+}
+
+
+int
+base64_encode_update (base64_ctx *x, void *vdst, int *dstlen,
+                      const void *vsrc, int srclen)
+{
+    int n;
+    int num_read;
+    int num_write;
+    unsigned char *dst = (unsigned char *) vdst;
+    unsigned char *src = (unsigned char *) vsrc;
+
+    assert (x != NULL);
+    assert (x->magic == BASE64_MAGIC);
+    assert (x->finalized != 1);
+    assert (dst != NULL);
+    assert (dstlen != NULL);
+    assert (src != NULL);
+
+    num_write = 0;
+
+    if (srclen <= 0) {
+        return (0);
+    }
+    /*  Encode leftover data if context buffer can be filled.
+     */
+    if ((x->num > 0) && (srclen >= (num_read = 3 - x->num))) {
+        memcpy (&x->buf[x->num], src, num_read);
+        src += num_read;
+        srclen -= num_read;
+        base64_encode_block (dst, &n, x->buf, 3);
+        x->num = 0;
+        dst += n;
+        num_write += n;
+    }
+    /*  Encode maximum amount of data w/o requiring a pad.
+     */
+    if (srclen >= 3) {
+        num_read = (srclen / 3) * 3;
+        base64_encode_block (dst, &n, src, num_read);
+        src += num_read;
+        srclen -= num_read;
+        num_write += n;
+    }
+    /*  Save leftover data for the next update() or final().
+     */
+    if (srclen > 0) {
+        memcpy (&x->buf[x->num], src, srclen);
+        x->num += srclen;
+    }
+    *dstlen = num_write;
+    return (0);
+}
+
+
+int
+base64_encode_final (base64_ctx *x, void *dst, int *dstlen)
+{
+    assert (x != NULL);
+    assert (x->magic == BASE64_MAGIC);
+    assert (x->finalized != 1);
+    assert (dst != NULL);
+    assert (dstlen != NULL);
+
+    /*  Encode leftover data from the previous update().
+     */
+    if (x->num > 0) {
+        base64_encode_block (dst, dstlen, x->buf, x->num);
+        x->num = 0;
+    }
+    else {
+        *dstlen = 0;
+    }
+    assert (x->finalized = 1);
+    return (0);
+}
+
+
+int
+base64_decode_update (base64_ctx *x, void *dst, int *dstlen,
+                      const void *src, int srclen)
+{
+/*  Context [x] should only be NULL when called via base64_decode_block().
+ */
+    int                  i = 0;
+    int                  err = 0;
+    int                  pad = 0;
+    unsigned char       *pdst;
+    const unsigned char *psrc;
+    const unsigned char *psrc_last;
+    unsigned char        c;
+
+    assert ((x == NULL) || (x->magic == BASE64_MAGIC));
+    assert ((x == NULL) || (x->finalized != 1));
+    assert (dst != NULL);
+    assert (dstlen != NULL);
+    assert (src != NULL);
+
+    pdst = dst;
+    psrc = src;
+    psrc_last = psrc + srclen;
+
+    /*  Restore context.
+     */
+    if (x != NULL) {
+        i = x->num;
+        pad = x->pad;
+        *pdst = x->buf[0];
+    }
+    while (psrc < psrc_last) {
+        c = asc2bin[*psrc++];
+        if (c == BASE64_IGN) {
+            continue;
+        }
+        if ((c == BASE64_PAD) && (pad < 2)) {
+            pad++;
+            continue;
+        }
+        if ((c == BASE64_ERR) || (pad > 0)) {
+            err++;
+            break;
+        }
+        switch (i) {
+            case 0:
+                *pdst    = (c << 2) & 0xfc;
+                break;
+            case 1:
+                *pdst++ |= (c >> 4) & 0x03;
+                *pdst    = (c << 4) & 0xf0;
+                break;
+            case 2:
+                *pdst++ |= (c >> 2) & 0x0f;
+                *pdst    = (c << 6) & 0xc0;
+                break;
+            case 3:
+                *pdst++ |= (c     ) & 0x3f;
+                break;
+        }
+        i = (i + 1) % 4;
+    }
+    /*  Save context.
+     */
+    if (x != NULL) {
+        x->num = i;
+        x->pad = pad;
+        x->buf[0] = *pdst;
+    }
+    /*  Check for the correct amount of padding.
+     */
+    else if (!err) {
+        err = (((i + pad) % 4) != 0);
+    }
+    *pdst = '\0';
+    *dstlen = pdst - (unsigned char *) dst;
+    return (err ? -1 : 0);
+}
+
+
+int
+base64_decode_final (base64_ctx *x, void *dst, int *dstlen)
+{
+    int rc = 0;
+
+    assert (x != NULL);
+    assert (x->magic == BASE64_MAGIC);
+    assert (x->finalized != 1);
+
+    if (((x->num + x->pad) % 4) != 0) {
+        rc = -1;
+    }
+    *dstlen = 0;
+    assert (x->finalized = 1);
+    return (rc);
+}
+
+
+int
+base64_cleanup (base64_ctx *x)
+{
+    assert (x != NULL);
+    assert (x->magic == BASE64_MAGIC);
+
+    memset (x, 0, sizeof (*x));
+    assert (x->magic = ~BASE64_MAGIC);
+    return (0);
+}
+
+
+int
+base64_encode_block (void *dst, int *dstlen, const void *src, int srclen)
+{
+    unsigned char       *pdst;
+    const unsigned char *psrc;
+    int                  n;
+
+    pdst = dst;
+    psrc = src;
+    n = 0;
+    while (srclen >= 3) {
+        *pdst++ = bin2asc[ (psrc[0] >> 2) & 0x3f];
+        *pdst++ = bin2asc[((psrc[0] << 4) & 0x30) | ((psrc[1] >> 4) & 0x0f)];
+        *pdst++ = bin2asc[((psrc[1] << 2) & 0x3c) | ((psrc[2] >> 6) & 0x03)];
+        *pdst++ = bin2asc[ (psrc[2]     ) & 0x3f];
+        psrc += 3;
+        srclen -= 3;
+        n += 4;
+    }
+    if (srclen == 2) {
+        *pdst++ = bin2asc[ (psrc[0] >> 2) & 0x3f];
+        *pdst++ = bin2asc[((psrc[0] << 4) & 0x30) | ((psrc[1] >> 4) & 0x0f)];
+        *pdst++ = bin2asc[ (psrc[1] << 2) & 0x3c];
+        *pdst++ = '=';
+        n += 4;
+    }
+    else if (srclen == 1) {
+        *pdst++ = bin2asc[ (psrc[0] >> 2) & 0x3f];
+        *pdst++ = bin2asc[ (psrc[0] << 4) & 0x30];
+        *pdst++ = '=';
+        *pdst++ = '=';
+        n += 4;
+    }
+    *pdst = '\0';
+    *dstlen = n;
+    return (0);
+}
+
+
+int
+base64_decode_block (void *dst, int *dstlen, const void *src, int srclen)
+{
+    return (base64_decode_update (NULL, dst, dstlen, src, srclen));
+}
+
+
+int
+base64_encode_length (int srclen)
+{
+/*  When encoding, 3 bytes are encoded into 4 characters.
+ *  Add 2 bytes to ensure a partial 3-byte chunk will be accounted for
+ *    during integer division, then add 1 byte for the terminating NUL.
+ */
+    return (((srclen + 2) / 3) * 4) + 1;
+}
+
+
+int
+base64_decode_length (int srclen)
+{
+/*  When decoding, 4 characters are decoded into 3 bytes.
+ *  Add 3 bytes to ensure a partial 4-byte chunk will be accounted for
+ *    during integer division, then add 1 byte for the terminating NUL.
+ */
+    return (((srclen + 3) / 4) * 3) + 1;
+}
+
+
+/*****************************************************************************
+ *  Table Initialization Routines
+ *****************************************************************************/
+
+#ifdef BASE64_INIT
+
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+
+#define BASE64_DEF_COLS 12
+
+
+void base64_build_table (unsigned char *data, int len);
+void base64_print_table (unsigned char *data, int len, char *name, int col);
+
+
+int
+main (int argc, char *argv[])
+{
+    int col;
+    unsigned char a2b[256];
+
+    col = (argc > 1) ? atoi (argv[1]) : BASE64_DEF_COLS;
+
+    base64_build_table (a2b, sizeof (a2b));
+    base64_print_table (a2b, sizeof (a2b), "asc2bin", col);
+    exit (EXIT_SUCCESS);
+}
+
+
+void
+base64_build_table (unsigned char *data, int len)
+{
+    int i;
+
+    for (i = 0; i < len; i++)
+        data[i] = (isspace (i)) ? BASE64_IGN : BASE64_ERR;
+    for (i = strlen (bin2asc) - 1; i >= 0; i--)
+        data[bin2asc[i]] = i;
+    data[BASE64_PAD_CHAR] = BASE64_PAD;
+    return;
+}
+
+
+void
+base64_print_table (unsigned char *data, int len, char *name, int col)
+{
+    int i;
+    int n;
+
+    if (col < 1) {
+       col = BASE64_DEF_COLS;
+    }
+    printf ("static const unsigned char %s[%d] = {", name, len);
+
+    for (i=0, n=len-1; ; i++) {
+        if ((i % col) == 0)
+            printf ("\n    ");
+        printf ("0x%02x", data[i]);
+        if (i == n)
+            break;
+        printf (", ");
+    }
+    printf ("\n};\n");
+    return;
+}
+
+
+#endif /* BASE64_INIT */

--- a/src/libutil/base64.h
+++ b/src/libutil/base64.h
@@ -1,0 +1,134 @@
+/*****************************************************************************
+ *  Written by Chris Dunlap <cdunlap@llnl.gov>.
+ *  Copyright (C) 2007-2017 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2002-2007 The Regents of the University of California.
+ *  UCRL-CODE-155910.
+ *
+ *  This file is part of the MUNGE Uid 'N' Gid Emporium (MUNGE).
+ *  For details, see <https://dun.github.io/munge/>.
+ *
+ *  MUNGE is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or (at your option)
+ *  any later version.  Additionally for the MUNGE library (libmunge), you
+ *  can redistribute it and/or modify it under the terms of the GNU Lesser
+ *  General Public License as published by the Free Software Foundation,
+ *  either version 3 of the License, or (at your option) any later version.
+ *
+ *  MUNGE is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  and GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  and GNU Lesser General Public License along with MUNGE.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *****************************************************************************/
+
+
+#ifndef BASE64_H
+#define BASE64_H
+
+
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
+
+
+/*****************************************************************************
+ *  Data Types
+ *****************************************************************************/
+
+typedef struct {
+    unsigned char       buf[3];
+    int                 num;
+    int                 pad;
+#ifndef NDEBUG
+    int                 magic;
+    int                 finalized;
+#endif /* !NDEBUG */
+} base64_ctx;
+
+
+/*****************************************************************************
+ *  Prototypes
+ *****************************************************************************/
+
+int base64_init (base64_ctx *x);
+/*
+ *  Initializes the base64 context [x] for base64 encoding/decoding of data.
+ *  Returns 0 on success, or -1 on error.
+ */
+
+int base64_encode_update (base64_ctx *x, void *dst, int *dstlen,
+                          const void *src, int srclen);
+/*
+ *  Updates the base64 context [x], encoding [srclen] bytes from [src]
+ *    into [dst], and setting [dstlen] to the number of bytes written.
+ *  This can be called multiple times to process successive blocks of data.
+ *  Returns 0 on success, or -1 on error.
+ */
+
+int base64_encode_final (base64_ctx *x, void *dst, int *dstlen);
+/*
+ *  Finalizes the base64 context [x], encoding the "final" data remaining
+ *    in a partial block into [dst], and setting [dstlen] to the number of
+ *    bytes written.
+ *  After calling this function, no further updates should be made to [x]
+ *    without re-initializing it first.
+ *  Returns 0 on success, or -1 on error.
+ */
+
+int base64_decode_update (base64_ctx *x, void *dst, int *dstlen,
+                          const void *src, int srclen);
+/*
+ *  Updates the base64 context [x], decoding [srclen] bytes from [src]
+ *    into [dst], and setting [dstlen] to the number of bytes written.
+ *  This can be called multiple times to process successive blocks of data.
+ *  Returns 0 on success, or -1 on error.
+ */
+
+int base64_decode_final (base64_ctx *x, void *dst, int *dstlen);
+/*
+ *  Finalizes the base64 context [x], decoding the "final" data remaining
+ *    in a partial block into [dst], and setting [dstlen] to the number of
+ *    bytes written.
+ *  After calling this function, no further updates should be made to [x]
+ *    without re-initializing it first.
+ *  Returns 0 on success, or -1 on error.
+ */
+
+int base64_cleanup (base64_ctx *x);
+/*
+ *  Clears the base64 context [x].
+ *  Returns 0 on success, or -1 on error.
+ */
+
+int base64_encode_block (void *dst, int *dstlen, const void *src, int srclen);
+/*
+ *  Base64-encodes [srclen] bytes from the contiguous [src] into [dst],
+ *    and sets [dstlen] to the number of bytes written.
+ *  Returns 0 on success, or -1 on error.
+ */
+
+int base64_decode_block (void *dst, int *dstlen, const void *src, int srclen);
+/*
+ *  Base64-decodes [srclen] bytes from the contiguous [src] into [dst],
+ *    and sets [dstlen] to the number of bytes written.
+ *  Returns 0 on success, or -1 on error.
+ */
+
+int base64_encode_length (int srclen);
+/*
+ *  Returns the size (in bytes) of the destination memory block required
+ *    for base64 encoding a block of [srclen] bytes.
+ */
+
+int base64_decode_length (int srclen);
+/*
+ *  Returns the size (in bytes) of the destination memory block required
+ *    for base64 decoding a block of [srclen] bytes.
+ */
+
+
+#endif /* !BASE64_H */

--- a/src/libutil/test/base64_test.c
+++ b/src/libutil/test/base64_test.c
@@ -1,0 +1,173 @@
+/*****************************************************************************
+ *  Written by Chris Dunlap <cdunlap@llnl.gov>.
+ *  Copyright (C) 2007-2017 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2002-2007 The Regents of the University of California.
+ *  UCRL-CODE-155910.
+ *
+ *  This file is part of the MUNGE Uid 'N' Gid Emporium (MUNGE).
+ *  For details, see <https://dun.github.io/munge/>.
+ *
+ *  MUNGE is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or (at your option)
+ *  any later version.  Additionally for the MUNGE library (libmunge), you
+ *  can redistribute it and/or modify it under the terms of the GNU Lesser
+ *  General Public License as published by the Free Software Foundation,
+ *  either version 3 of the License, or (at your option) any later version.
+ *
+ *  MUNGE is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  and GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  and GNU Lesser General Public License along with MUNGE.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *****************************************************************************/
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "base64.h"
+
+
+/*  Test cases from rfc2440 (OpenPGP Message Format)
+ *    section 6.5 (Examples of Radix-64).
+ */
+
+int validate (const char *dst, const void *src, int srclen);
+int encode_block (char *dst, int *dstlen, const void *src, int srclen);
+int encode_context (char *dst, int *dstlen, const void *src, int srclen);
+int decode_block (char *dst, int *dstlen, const void *src, int srclen);
+int decode_context (char *dst, int *dstlen, const void *src, int srclen);
+
+
+int
+main (int argc, char *argv[])
+{
+    const unsigned char src1[] = { 0x14, 0xfb, 0x9c, 0x03, 0xd9, 0x7e };
+    const unsigned char src2[] = { 0x14, 0xfb, 0x9c, 0x03, 0xd9 };
+    const unsigned char src3[] = { 0x14, 0xfb, 0x9c, 0x03 };
+
+    const char dst1[] = "FPucA9l+";
+    const char dst2[] = "FPucA9k=";
+    const char dst3[] = "FPucAw==";
+
+    if (validate (dst1, src1, sizeof (src1)) < 0) {
+        exit (EXIT_FAILURE);
+    }
+    if (validate (dst2, src2, sizeof (src2)) < 0) {
+        exit (EXIT_FAILURE);
+    }
+    if (validate (dst3, src3, sizeof (src3)) < 0) {
+        exit (EXIT_FAILURE);
+    }
+    exit (EXIT_SUCCESS);
+}
+
+
+int
+validate (const char *dst, const void *src, int srclen)
+{
+    int n;
+    char buf[9];
+
+    if (encode_block (buf, &n, src, srclen) < 0)
+        return (-1);
+    if (n != strlen (dst))
+        return (-1);
+    if (strncmp (dst, buf, n))
+        return (-1);
+
+    if (decode_block (buf, &n, dst, strlen (dst)) < 0)
+        return (-1);
+    if (n != srclen)
+        return (-1);
+    if (strncmp (src, buf, n))
+        return (-1);
+
+    if (encode_context (buf, &n, src, srclen) < 0)
+        return (-1);
+    if (n != strlen (dst))
+        return (-1);
+    if (strncmp (dst, buf, n))
+        return (-1);
+
+    if (decode_context (buf, &n, dst, strlen (dst)) < 0)
+        return (-1);
+    if (n != srclen)
+        return (-1);
+    if (strncmp (src, buf, n))
+        return (-1);
+
+    return (0);
+}
+
+
+int
+encode_block (char *dst, int *dstlen, const void *src, int srclen)
+{
+    return (base64_encode_block (dst, dstlen, src, srclen));
+}
+
+
+int
+encode_context (char *dst, int *dstlen, const void *src, int srclen)
+{
+    base64_ctx x;
+    int i;
+    int n;
+    int m;
+    const unsigned char *p = src;
+
+    if (base64_init (&x) < 0)
+        return (-1);
+    for (i = 0, n = 0; i < srclen; i++) {
+        if (base64_encode_update (&x, dst, &m, p + i, 1) < 0)
+            return (-1);
+        dst += m;
+        n += m;
+    }
+    if (base64_encode_final (&x, dst, &m) < 0)
+        return (-1);
+    if (base64_cleanup (&x) < 0)
+        return (-1);
+    n += m;
+    *dstlen = n;
+    return (0);
+}
+
+
+int
+decode_block (char *dst, int *dstlen, const void *src, int srclen)
+{
+    return (base64_decode_block (dst, dstlen, src, srclen));
+}
+
+
+int
+decode_context (char *dst, int *dstlen, const void *src, int srclen)
+{
+    base64_ctx x;
+    int i;
+    int n;
+    int m;
+    const unsigned char *p = src;
+
+    if (base64_init (&x) < 0)
+        return (-1);
+    for (i = 0, n = 0; i < srclen; i++) {
+        if (base64_decode_update (&x, dst, &m, p + i, 1) < 0)
+            return (-1);
+        dst += m;
+        n += m;
+    }
+    if (base64_decode_final (&x, dst, &m) < 0)
+        return (-1);
+    if (base64_cleanup (&x) < 0)
+        return (-1);
+    n += m;
+    *dstlen = n;
+    return (0);
+}

--- a/src/libutil/test/base64_test.c
+++ b/src/libutil/test/base64_test.c
@@ -31,6 +31,8 @@
 #include <string.h>
 #include "base64.h"
 
+#include "src/libtap/tap.h"
+
 
 /*  Test cases from rfc2440 (OpenPGP Message Format)
  *    section 6.5 (Examples of Radix-64).
@@ -54,16 +56,16 @@ main (int argc, char *argv[])
     const char dst2[] = "FPucA9k=";
     const char dst3[] = "FPucAw==";
 
-    if (validate (dst1, src1, sizeof (src1)) < 0) {
-        exit (EXIT_FAILURE);
-    }
-    if (validate (dst2, src2, sizeof (src2)) < 0) {
-        exit (EXIT_FAILURE);
-    }
-    if (validate (dst3, src3, sizeof (src3)) < 0) {
-        exit (EXIT_FAILURE);
-    }
-    exit (EXIT_SUCCESS);
+    plan (NO_PLAN);
+
+    ok (validate (dst1, src1, sizeof (src1)) >= 0,
+        "base64 pattern 1");
+    ok (validate (dst2, src2, sizeof (src2)) >= 0,
+        "base64 pattern 2");
+    ok (validate (dst3, src3, sizeof (src3)) >= 0,
+        "base64 pattern 3");
+
+    done_testing ();
 }
 
 


### PR DESCRIPTION
This PR pulls in latest base64 and unit tests from MUNGE (current dev branch), and puts them in a new libutil directory.  Relative to flux-core, copyrights have been updated, @chu11's doc fix is in the header, and looks like @dun updated the unit tests to address some -Wall warnings.

I noticed I was compiling without -Werror, so pulled in missing ax_compiler_vendor.m4 and fixed an additional warning that popped up in libtomlc99.

Made the base64 test TAP compliant (as in flux-core) and wired into make check.


