### PR TITLE
libtomlc99/test: fix remaining test problems

### DIFF
--- a/src/libtomlc99/toml.c
+++ b/src/libtomlc99/toml.c
@@ -1140,6 +1140,10 @@ static void parse_select(context_t* ctx)
 	/* [[x.y.z]] -> create z = [] in x.y */
 	toml_array_t* arr = create_keyarray_in_table(ctx, ctx->curtab, z,
 						     1 /*skip_if_exist*/);
+        if (!arr) {
+            e_syntax_error(ctx, z.lineno, "key exists");
+            return;
+        }
 	if (arr->kind == 0) arr->kind = 't';
 	if (arr->kind != 't') {
             e_syntax_error(ctx, z.lineno, "array mismatch");

--- a/src/libtomlc99/toml_tap.c
+++ b/src/libtomlc99/toml_tap.c
@@ -204,7 +204,6 @@ struct entry {
 };
 
 const struct entry bad_input_blacklist[] = {
-    { "table-array-implicit.toml" ,         "segfault, cktan/tomlc99#3" },
     { NULL, NULL },
 };
 


### PR DESCRIPTION
This PR adds a fix to libtomlc99 backported from upstream,
and improves our TAP test so that we no longer need to blacklist
any of the BurntSushi test input.