### PR TITLE
build: fix gcc 7.2.0 warnings

### DIFF
--- a/src/libutil/Makefile.am
+++ b/src/libutil/Makefile.am
@@ -1,6 +1,6 @@
 AM_CFLAGS = \
 	$(WARNING_CFLAGS) \
-	-Wno-sign-compare -Wno-unused-parameter \
+	-Wno-sign-compare -Wno-unused-parameter -Wno-parentheses \
 	$(CODE_COVERAGE_CFLAGS)
 
 AM_LDFLAGS = \


### PR DESCRIPTION
Problem: gcc 7.2.0 (Ubuntu 17.10) includes -Wparentheses in -Wall.
This causes compilation of base64.c to fail.

Add -Wno-parentheses to libutil's AM_CFLAGS.