### PR TITLE
add certificate class for libsodium based sign/verify

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,12 @@ addons:
   apt:
   packages:
 
+before_install:
+  - curl -L -O --insecure https://github.com/jedisct1/libsodium/releases/download/1.0.10/libsodium-1.0.10.tar.gz
+  - tar -xf libsodium-1.0.10.tar.gz
+  - cd libsodium-1.0.10 && ./configure --prefix=$HOME/local && make && make install
+  - export PKG_CONFIG_PATH=$HOME/local/lib/pkgconfig:$HOME/local/share/pkgconfig
+
 script:
   - ./autogen.sh
   - ./configure

--- a/configure.ac
+++ b/configure.ac
@@ -62,6 +62,10 @@ LT_INIT
 #
 AC_HEADER_STDC
 
+#
+#  Checks for packages
+#
+PKG_CHECK_MODULES([SODIUM], [libsodium], [], [])
 
 #
 #  Other checks

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -5,4 +5,12 @@ AM_CFLAGS = \
 AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
-AM_CPPFLAGS =
+AM_CPPFLAGS = \
+	-I$(top_srcdir)
+
+noinst_LTLIBRARIES = \
+	libflux-security.la
+
+libflux_security_la_SOURCES = \
+	sigcert.c \
+	sigcert.h

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -1,12 +1,15 @@
 AM_CFLAGS = \
 	$(WARNING_CFLAGS) \
+	-Wno-unused-parameter \
 	$(CODE_COVERAGE_CFLAGS)
 
 AM_LDFLAGS = \
-	$(CODE_COVERAGE_LIBS)
+	$(CODE_COVERAGE_LIBS) \
+	$(SODIUM_LIBS)
 
 AM_CPPFLAGS = \
-	-I$(top_srcdir)
+	-I$(top_srcdir) \
+	$(SODIUM_CFLAGS)
 
 noinst_LTLIBRARIES = \
 	libflux-security.la
@@ -14,3 +17,24 @@ noinst_LTLIBRARIES = \
 libflux_security_la_SOURCES = \
 	sigcert.c \
 	sigcert.h
+
+TESTS = test_sigcert.t
+
+check_PROGRAMS = $(TESTS)
+
+TEST_EXTENSIONS = .t
+T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
+	$(top_srcdir)/config/tap-driver.sh
+
+test_cppflags = \
+	$(AM_CPPFLAGS)
+
+test_ldadd = \
+	$(top_builddir)/src/lib/libflux-security.la \
+	$(top_builddir)/src/libtomlc99/libtomlc99.la \
+	$(top_builddir)/src/libutil/libutil.la \
+	$(top_builddir)/src/libtap/libtap.la
+
+test_sigcert_t_SOURCES = test/sigcert.c
+test_sigcert_t_LDADD = $(test_ldadd)
+test_sigcert_t_CPPFLAGS = $(test_cppflags)

--- a/src/lib/sigcert.c
+++ b/src/lib/sigcert.c
@@ -1,0 +1,348 @@
+/*****************************************************************************\
+ *  Copyright (c) 2017 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+#include <limits.h>
+#include <sodium.h>
+
+#include "src/libtomlc99/toml.h"
+#include "src/libutil/base64.h"
+#include "sigcert.h"
+
+static char *sigcert_base64_encode (const uint8_t *srcbuf, int srclen);
+static int sigcert_base64_decode (const char *srcbuf,
+                                  uint8_t *dstbuf, int dstlen);
+
+#define FLUX_SIGCERT_MAGIC 0x2349c0ed
+struct flux_sigcert {
+    int magic;
+
+    uint8_t public_key[crypto_sign_PUBLICKEYBYTES];
+    uint8_t secret_key[crypto_sign_SECRETKEYBYTES];
+
+    bool sodium_initialized;
+};
+
+void flux_sigcert_destroy (struct flux_sigcert *cert)
+{
+    if (cert) {
+        int saved_errno = errno;
+        assert (cert->magic == FLUX_SIGCERT_MAGIC);
+        memset (cert->public_key, 0, crypto_sign_PUBLICKEYBYTES);
+        memset (cert->secret_key, 0, crypto_sign_SECRETKEYBYTES);
+        cert->magic = ~FLUX_SIGCERT_MAGIC;
+        free (cert);
+        errno = saved_errno;
+    }
+}
+
+struct flux_sigcert *flux_sigcert_create (void)
+{
+    struct flux_sigcert *cert;
+
+    if (!(cert = calloc (1, sizeof (*cert))))
+        return NULL;
+    cert->magic = FLUX_SIGCERT_MAGIC;
+    if (sodium_init () < 0) {
+        errno = EINVAL;
+        goto error;
+    }
+    cert->sodium_initialized = true;
+    if (crypto_sign_keypair (cert->public_key, cert->secret_key) < 0)
+        goto error;
+    return cert;
+error:
+    flux_sigcert_destroy (cert);
+    return NULL;
+}
+
+/* Given 'srcbuf', a byte sequence 'srclen' bytes long, return
+ * a base64 string encoding of it.  Caller must free.
+ */
+static char *sigcert_base64_encode (const uint8_t *srcbuf, int srclen)
+{
+    char *dstbuf = NULL;
+    int dstlen;
+
+    dstlen = base64_encode_length (srclen);
+    if (!(dstbuf = malloc (dstlen)))
+        return NULL;
+    if (base64_encode_block (dstbuf, &dstlen, srcbuf, srclen) < 0) {
+        free (dstbuf);
+        errno = EINVAL;
+        return NULL;
+    }
+    return dstbuf;
+}
+
+/* Given a base64 string 'srcbuf', decode it and copy the result in
+ * 'dstbuf'.  The decoded length must exactly match 'dstlen'.
+ */
+static int sigcert_base64_decode (const char *srcbuf,
+                                  uint8_t *dstbuf, int dstlen)
+{
+    int srclen, xdstlen;
+    char *xdstbuf;
+
+    srclen = strlen (srcbuf);
+    xdstlen = base64_decode_length (srclen);
+    if (!(xdstbuf = malloc (xdstlen)))
+        return -1;
+    if (base64_decode_block (xdstbuf, &xdstlen, srcbuf, srclen) < 0) {
+        free (xdstbuf);
+        errno = EINVAL;
+        return -1;;
+    }
+    if (xdstlen != dstlen) {
+        free (xdstbuf);
+        errno = EINVAL;
+        return -1;
+    }
+    memcpy (dstbuf, xdstbuf, dstlen);
+    free (xdstbuf);
+    return 0;
+}
+
+/* fopen(w) with mode parameter
+ */
+static FILE *fopen_mode (const char *pathname, mode_t mode)
+{
+    int fd;
+    FILE *fp;
+
+    if ((fd = open (pathname, O_WRONLY | O_TRUNC | O_CREAT, mode)) < 0)
+        return NULL;
+    if (!(fp = fdopen (fd, "w"))) {
+        close (fd);
+        return NULL;
+    }
+    return fp;
+}
+
+int flux_sigcert_store (struct flux_sigcert *cert, const char *name)
+{
+    FILE *fp_sec = NULL;
+    FILE *fp_pub = NULL;
+    char *xsec = NULL;
+    char *xpub = NULL;
+    const int pubsz = PATH_MAX + 1;
+    char name_pub[pubsz];
+    int saved_errno;
+
+    if (!cert || !name || strlen (name) == 0) {
+        errno = EINVAL;
+        goto error;
+    }
+    if (!(xsec = sigcert_base64_encode (cert->secret_key,
+                                                crypto_sign_SECRETKEYBYTES)))
+        goto error;
+    if (!(xpub = sigcert_base64_encode (cert->public_key,
+                                                crypto_sign_PUBLICKEYBYTES)))
+        goto error;
+
+    if (!(fp_sec = fopen_mode (name, 0600)))
+        goto error;
+    if (fprintf (fp_sec, "[curve]\n") < 0)
+        goto error;
+    if (fprintf (fp_sec, "    secret-key = \"%s\"\n", xsec) < 0)
+        goto error;
+    if (fprintf (fp_sec, "    public-key = \"%s\"\n", xpub) < 0)
+        goto error;
+    if (fclose (fp_sec) < 0)
+        goto error;
+    fp_sec = NULL;
+
+    if (snprintf (name_pub, pubsz, "%s.pub", name) >= pubsz)
+        goto error;
+    if (!(fp_pub = fopen_mode (name_pub, 0644)))
+        goto error;
+    if (fprintf (fp_pub, "[curve]\n") < 0)
+        goto error;
+    if (fprintf (fp_pub, "    public-key = \"%s\"\n", xpub) < 0)
+        goto error;
+    if (fclose (fp_pub) < 0)
+        goto error;
+    fp_pub = NULL;
+
+    free (xsec);
+    free (xpub);
+    return 0;
+error:
+    saved_errno = errno;
+    free (xsec);
+    free (xpub);
+    if (fp_pub)
+        (void)fclose (fp_pub);
+    if (fp_sec)
+        (void)fclose (fp_sec);
+    errno = saved_errno;
+    return -1;
+}
+
+struct flux_sigcert *flux_sigcert_load (const char *name)
+{
+    FILE *fp = NULL;
+    toml_table_t *cert_table = NULL;
+    toml_table_t *curve_table;
+    const char *raw;
+    int saved_errno;
+    char errbuf[200];
+    struct flux_sigcert *cert = NULL;
+
+    if (!name)
+        goto inval;
+    if (!(cert = calloc (1, sizeof (*cert))))
+        return NULL;
+    cert->magic = FLUX_SIGCERT_MAGIC;
+
+    /* Try the secret cert file first.
+     * If that doesn't work, try the public cert file.
+     */
+    if (!(fp = fopen (name, "r"))) {
+        const int pubsz = PATH_MAX + 1;
+        char name_pub[pubsz];
+        if (snprintf (name_pub, pubsz, "%s.pub", name) >= pubsz)
+            goto inval;
+        if (!(fp = fopen (name_pub, "r")))
+            goto error;
+    }
+
+    if (!(cert_table = toml_parse_file (fp, errbuf, sizeof (errbuf))))
+        goto inval;
+    if (!(curve_table = toml_table_in (cert_table, "curve")))
+        goto inval;
+    if ((raw = toml_raw_in (curve_table, "secret-key"))) { // optional
+        char *s;
+        if (toml_rtos (raw, &s) < 0)
+            goto inval;
+        if (sigcert_base64_decode (s, cert->secret_key,
+                                   crypto_sign_SECRETKEYBYTES) < 0) {
+            free (s);
+            goto inval;
+        }
+        free (s);
+    }
+    if ((raw = toml_raw_in (curve_table, "public-key"))) { // required
+        char *s;
+        if (toml_rtos (raw, &s) < 0)
+            goto inval;
+        if (sigcert_base64_decode (s, cert->public_key,
+                                   crypto_sign_PUBLICKEYBYTES) < 0) {
+            free (s);
+            goto inval;
+        }
+        free (s);
+    } else
+        goto inval;
+
+    toml_free (cert_table);
+    fclose (fp);
+    return cert;
+inval:
+    errno = EINVAL;
+error:
+    saved_errno = errno;
+    toml_free (cert_table);
+    if (fp)
+        fclose (fp);
+    flux_sigcert_destroy (cert);
+    errno = saved_errno;
+    return NULL;
+}
+
+bool flux_sigcert_equal (struct flux_sigcert *cert1, struct flux_sigcert *cert2)
+{
+    if (!cert1 || !cert2)
+        return false;
+    if (memcmp (cert1->public_key, cert2->public_key,
+                                   crypto_sign_PUBLICKEYBYTES) != 0)
+        return false;
+    if (memcmp (cert1->secret_key, cert2->secret_key,
+                                   crypto_sign_SECRETKEYBYTES) != 0)
+        return false;
+    return true;
+}
+
+char *flux_sigcert_sign (struct flux_sigcert *cert, uint8_t *buf, int len)
+{
+    uint8_t sig[crypto_sign_BYTES];
+
+    if (!cert || len < 0 || (len > 0 && buf == NULL)) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!cert->sodium_initialized) {
+        if (sodium_init () < 0) {
+            errno = EINVAL;
+            return NULL;
+        }
+        cert->sodium_initialized = true;
+    }
+    if (crypto_sign_detached (sig, NULL, buf, len, cert->secret_key) < 0) {
+        errno = EINVAL;
+        return NULL;
+    }
+    return sigcert_base64_encode (sig, crypto_sign_BYTES);
+}
+
+int flux_sigcert_verify (struct flux_sigcert *cert,
+                         const char *sig_base64, uint8_t *buf, int len)
+{
+    uint8_t sig[crypto_sign_BYTES];
+
+    if (!cert || !sig_base64 || len < 0 || (len > 0 && buf == NULL)) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!cert->sodium_initialized) {
+        if (sodium_init () < 0) {
+            errno = EINVAL;
+            return -1;
+        }
+        cert->sodium_initialized = true;
+    }
+    if (sigcert_base64_decode (sig_base64, sig, crypto_sign_BYTES) < 0)
+        return -1;
+    if (crypto_sign_verify_detached (sig, buf, len, cert->public_key) < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/lib/sigcert.h
+++ b/src/lib/sigcert.h
@@ -1,0 +1,66 @@
+#ifndef _FLUX_SIGCERT_H
+#define _FLUX_SIGCERT_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/* Certificate class for signing/verification.
+ *
+ * Keys can be loaded/stored from TOML based certificate files.
+ * The "secret" version of the certificate contains everything.
+ * The "public" version of the certificate contains all but private keys.
+ * The public version is distinguished by a .pub extension (like ssh keys).
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct flux_sigcert;
+
+/* Destroy cert.
+ */
+void flux_sigcert_destroy (struct flux_sigcert *cert);
+
+/* Create cert with new keys
+ */
+struct flux_sigcert *flux_sigcert_create (void);
+
+/* Load cert from file 'name', falling back to 'name.pub'.
+ */
+struct flux_sigcert *flux_sigcert_load (const char *name);
+
+/* Store cert to 'name' and 'name.pub'.
+ */
+int flux_sigcert_store (struct flux_sigcert *cert, const char *name);
+
+/* Return true if two certificates have the same keys.
+ */
+bool flux_sigcert_equal (struct flux_sigcert *cert1,
+                         struct flux_sigcert *cert2);
+
+/* Return a detached signature (base64 string) over buf, len.
+ * Caller must free.
+ */
+char *flux_sigcert_sign (struct flux_sigcert *cert,
+                         uint8_t *buf, int len);
+
+/* Verify a detached signature (base64 string) over buf, len.
+ * Returns 0 on success, -1 on failure.
+ */
+int flux_sigcert_verify (struct flux_sigcert *cert,
+                         const char *signature, uint8_t *buf, int len);
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !_FLUX_SIGCERT_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/lib/test/sigcert.c
+++ b/src/lib/test/sigcert.c
@@ -1,0 +1,295 @@
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <string.h>
+#include <limits.h>
+#include <errno.h>
+
+#include "src/libtap/tap.h"
+#include "sigcert.h"
+
+static char scratch[PATH_MAX + 1];
+static char keypath[PATH_MAX + 1];
+
+/* Create a scratch directory in /tmp
+ */
+static void new_scratchdir (void)
+{
+    unsigned int n;
+    const char *tmpdir = getenv ("TMPDIR");
+    if (!tmpdir)
+        tmpdir = "/tmp";
+    n = snprintf (scratch, sizeof (scratch), "%s/sigcert.XXXXXX", tmpdir);
+    if (n >= sizeof (scratch))
+        BAIL_OUT ("scratch directory overflow");
+    if (!mkdtemp (scratch))
+        BAIL_OUT ("mkdtemp %s failed", scratch);
+}
+
+/* Remove scratch directory, assuming it is empty now.
+ */
+static void cleanup_scratchdir (void)
+{
+    if (rmdir (scratch) < 0)
+        BAIL_OUT ("rmdir %s failed: %s", strerror (errno));
+}
+
+/* Construct a path relative to scratch directory.
+ * Overwrites last result.
+ */
+static const char *new_keypath (const char *name)
+{
+    unsigned int n;
+
+    if (strlen (scratch) == 0)
+        BAIL_OUT ("keypath cannot be called before new_scratchdir");
+    n = snprintf (keypath, sizeof (keypath), "%s/%s", scratch, name);
+    if (n >= sizeof (keypath))
+        BAIL_OUT ("keypath overflow");
+    return keypath;
+}
+
+/* Construct and unlink a path relative to scratch directory.
+ * Overwrites last result.
+ */
+static void cleanup_keypath (const char *name)
+{
+    const char *path = new_keypath (name);
+    (void)unlink (path);
+}
+
+void test_load_store (void)
+{
+    struct flux_sigcert *cert;
+    struct flux_sigcert *cert2;
+    const char *name;
+
+    plan (NO_PLAN);
+
+    new_scratchdir ();
+
+    /* Create a certificate.
+     * Create another one and make sure keys are different.
+     */
+    cert = flux_sigcert_create ();
+    ok (cert != NULL,
+        "flux_sigcert_create works");
+    cert2 = flux_sigcert_create ();
+    ok (cert2 != NULL && flux_sigcert_equal (cert, cert2) == false,
+        "a second cert is different");
+    flux_sigcert_destroy (cert2);
+
+    /* Store the first certificate as TOML files (test, test.pub).
+     * Load it back into a different cert, and make sure keys are the same.
+     */
+    name = new_keypath ("test");
+    ok (flux_sigcert_store (cert, name) == 0,
+        "flux_sigcert_store test, test.pub worked");
+    ok ((cert2 = flux_sigcert_load (name)) != NULL,
+        "flux_sigcert_load test worked");
+    ok (flux_sigcert_equal (cert, cert2) == true,
+        "loaded cert is same as the original");
+    flux_sigcert_destroy (cert2);
+
+    /* Verify file mode on certs.
+     */
+    struct stat sb;
+    name = new_keypath ("test");
+    ok (stat (name, &sb) == 0 && !(sb.st_mode & (S_IRGRP|S_IROTH))
+                              && !(sb.st_mode & (S_IWGRP|S_IWOTH)),
+        "secret cert file is not read/writeable by group,other");
+    name = new_keypath ("test.pub");
+    ok (stat (name, &sb) == 0 && !(sb.st_mode & (S_IWGRP|S_IWOTH)),
+        "public cert file mode not writeable by group,other");
+
+    /* Load just the public key and verify keys are different
+     */
+    name = new_keypath ("test.pub");
+    ok ((cert2 = flux_sigcert_load (name)) != NULL,
+        "flux_sigcert_load test.pub worked");
+    ok (flux_sigcert_equal (cert, cert2) == false,
+        "pub cert differs from secret one");
+    flux_sigcert_destroy (cert2);
+
+    /* Store new cert on top of existing one.
+     */
+    name = new_keypath ("test"); // exists
+    cert2 = flux_sigcert_create ();
+    if (!cert2)
+        BAIL_OUT ("flux_sigcert_create: %s", strerror (errno));
+    ok (flux_sigcert_store (cert2, name) == 0,
+        "flux_sigcert_store overwrites existing cert");
+    flux_sigcert_destroy (cert2);
+
+    /* Store cert using relative path.
+     */
+    char cwd[PATH_MAX + 1];
+    if (!getcwd (cwd, sizeof (cwd)))
+        BAIL_OUT ("getcwd: %s", strerror (errno));
+    if (chdir (scratch) < 0)
+        BAIL_OUT ("chdir %s: %s", scratch, strerror (errno));
+    ok (flux_sigcert_store (cert, "foo") == 0,
+        "flux_sigcert_store works with relative path");
+    cert2 = flux_sigcert_load ("foo");
+    ok (cert2 != NULL,
+        "flux_sigcert_load works with relative path");
+    if (chdir (cwd) < 0)
+        BAIL_OUT ("chdir %s: %s", cwd, strerror (errno));
+    flux_sigcert_destroy (cert2);
+
+    flux_sigcert_destroy (cert);
+
+    cleanup_keypath ("test");
+    cleanup_keypath ("test.pub");
+    cleanup_keypath ("foo");
+    cleanup_keypath ("foo.pub");
+    cleanup_scratchdir ();
+}
+
+void test_sign_verify (void)
+{
+    struct flux_sigcert *cert1;
+    struct flux_sigcert *cert2;
+    uint8_t message[] = "foo-bar-baz";
+    uint8_t tampered[] = "foo-KITTENS-baz";
+    char *sig, *sig2;
+
+    if (!(cert1 = flux_sigcert_create ()))
+        BAIL_OUT ("flux_sigcert_create: %s", strerror (errno));
+    if (!(cert2 = flux_sigcert_create ()))
+        BAIL_OUT ("flux_sigcert_create: %s", strerror (errno));
+
+    /* Sign message with cert1.
+     * Verify message with cert1.
+     * Demonstrate cert2 cannot verify message.
+     * Demonstrate cert1 fails to verify if message changes.
+     */
+    sig = flux_sigcert_sign (cert1, message, sizeof (message));
+    ok (sig != NULL,
+        "flux_sigcert_sign works");
+    diag ("%s", sig ? sig : "NULL");
+    ok (flux_sigcert_verify (cert1, sig, message, sizeof (message)) == 0,
+        "flux_sigcert_verify cert=good works");
+    errno = 0;
+    ok (flux_sigcert_verify (cert2, sig, message, sizeof (message)) < 0
+        && errno == EINVAL,
+        "flux_sigcert_verify cert=bad fails with EINVAL");
+    errno = 0;
+    ok (flux_sigcert_verify (cert1, sig, tampered, sizeof (tampered)) < 0
+        && errno == EINVAL,
+        "flux_sigcert_verify tampered fails with EINVAL");
+    errno = 0;
+    free (sig);
+
+    /* Sign tampered message with cert2.
+     * Verify that this signature cannot verify message.
+     */
+    sig2 = flux_sigcert_sign (cert1, tampered, sizeof (tampered));
+    ok (sig2 != NULL,
+        "flux_sigcert_sign works");
+    errno = 0;
+    ok (flux_sigcert_verify (cert1, sig2, message, sizeof (message)) < 0
+        && errno == EINVAL,
+        "flux_sigcert_verify sig=wrong fails with EINVAL");
+    free (sig2);
+
+    /* Sign/verify a zero-length message.
+     */
+    sig2 = flux_sigcert_sign (cert1, NULL, 0);
+    ok (sig2 != NULL,
+        "flux_sigcert_sign works on zero-length message");
+    ok (flux_sigcert_verify (cert1, sig2, NULL, 0) == 0,
+        "flux_sigcert_verify works on zero-length message");
+    free (sig2);
+
+    flux_sigcert_destroy (cert1);
+    flux_sigcert_destroy (cert2);
+}
+
+void test_corner (void)
+{
+    struct flux_sigcert *cert;
+
+    if (!(cert = flux_sigcert_create ()))
+        BAIL_OUT ("flux_sigcert_create: %s", strerror (errno));
+
+    /* Load/store corner cases
+     */
+    errno = 0;
+    ok (flux_sigcert_store (cert, NULL) < 0 && errno == EINVAL,
+        "flux_sigcert_store name=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_sigcert_store (cert, "") < 0 && errno == EINVAL,
+        "flux_sigcert_store name=\"\" fails with EINVAL");
+    errno = 0;
+    ok (flux_sigcert_store (NULL, "foo") < 0 && errno == EINVAL,
+        "flux_sigcert_store cert=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_sigcert_load (NULL) == NULL && errno == EINVAL,
+        "flux_sigcert_load name=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_sigcert_load ("/noexist") == NULL && errno == ENOENT,
+        "flux_sigcert_load name=/noexist fails with ENOENT");
+    ok (flux_sigcert_equal (NULL, cert) == false,
+        "flux_sigcert_load cert1=NULL returns false");
+    ok (flux_sigcert_equal (cert, NULL) == false,
+        "flux_sigcert_load cert2=NULL returns false");
+    ok (flux_sigcert_equal (NULL, NULL) == false,
+        "flux_sigcert_load both=NULL returns false");
+    ok (flux_sigcert_equal (cert, cert) == true,
+        "flux_sigcert_load both=same returns true");
+
+    /* Sign/verify corner cases
+     */
+    uint8_t data[] = "foo";
+    errno = 0;
+    ok (flux_sigcert_sign (NULL, NULL, 0) == NULL && errno == EINVAL,
+        "flux_sigcet_sign cert=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_sigcert_sign (cert, data, -1) == NULL && errno == EINVAL,
+        "flux_sigcet_sign len<0 fails with EINVAL");
+    errno = 0;
+    ok (flux_sigcert_sign (cert, NULL, 1) == NULL && errno == EINVAL,
+        "flux_sigcet_sign len>0 buf=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_sigcert_verify (NULL, "foo", NULL, 0) < 0 && errno == EINVAL,
+        "flux_sigcert_verify cert=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_sigcert_verify (cert, NULL, NULL, 0) < 0 && errno == EINVAL,
+        "flux_sigcert_verify sig=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_sigcert_verify (cert, "foo", NULL, -1) < 0 && errno == EINVAL,
+        "flux_sigcert_verify len<0 fails with EINVAL");
+    errno = 0;
+    ok (flux_sigcert_verify (cert, "foo", NULL, 1) < 0 && errno == EINVAL,
+        "flux_sigcert_verify len>0 buf=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_sigcert_verify (cert, "....", NULL, 0) < 0 && errno == EINVAL,
+        "flux_sigcert_verify sig=invalid fails with EINVAL");
+
+    /* Destroy NULL
+     */
+    lives_ok ({flux_sigcert_destroy (NULL);},
+        "flux_sigcert_destroy cert=NULL doesn't crash");
+
+    flux_sigcert_destroy (cert);
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    test_load_store ();
+    test_sign_verify();
+    test_corner ();
+
+    done_testing ();
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */
+


### PR DESCRIPTION
This is similar to the "zsigcert" class we used for JSON signing in the IMP prototype, except it is not dependent on czmq.  It uses TOML for the certificate format.

This is very bare bones.  Basically you can
* create a cert with new keys
* save the cert to TOML files (name and name.pub)
* load the cert from a TOML file
* compare two certs (compare their keys, that is)
* create a detached (base64) signature for an arbitrary blob
* verify a detached (base64) signature for an arbitrary blob

Major missing functionality (to be added later)
* JSON sign/verify
* CA certificate sign/verify
* support for data other than keys in the cert

I was hoping maybe we could iterate on basic stuff (like is this the right abstraction, name changing, etc) in this PR and then do the other stuff in another PR.  I don't have a lot invested in this particular design so happy to discuss completely different alternatives if you like.
```c
struct flux_sec_sigcert;

/* Destroy cert.
 */
void flux_sec_sigcert_destroy (struct flux_sec_sigcert *cert);

/* Create cert with new keys
 */
struct flux_sec_sigcert *flux_sec_sigcert_create (void);

/* Load cert from name, falling back to name.pub
 */
struct flux_sec_sigcert *flux_sec_sigcert_load (const char *name);

/* Store cert to name and name.pub
 */
int flux_sec_sigcert_store (struct flux_sec_sigcert *cert, const char *name);

/* Return true if two certificates have the same keys.
 */
bool flux_sec_sigcert_equal (struct flux_sec_sigcert *cert1,
                             struct flux_sec_sigcert *cert2);

/* Return a base64 signature over buf, len.
 * Caller must free.
 */
char *flux_sec_sigcert_sign (struct flux_sec_sigcert *cert,
                             uint8_t *buf, int len);

/* Verify a base64 signature over buf, len using cert.
 * Returns 0 on success, -1 on failure.
 */
int flux_sec_sigcert_verify (struct flux_sec_sigcert *cert,
                             const char *signature, uint8_t *buf, int len);
```