### PR TITLE
sigcert: add json_loads/dumps methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ addons:
       - gcc-7
       - clang-4.0
       - lcov
+      - libjansson-dev
 
 before_install:
   - curl -L -O --insecure https://github.com/jedisct1/libsodium/releases/download/1.0.10/libsodium-1.0.10.tar.gz

--- a/configure.ac
+++ b/configure.ac
@@ -66,6 +66,7 @@ AC_HEADER_STDC
 #  Checks for packages
 #
 PKG_CHECK_MODULES([SODIUM], [libsodium], [], [])
+PKG_CHECK_MODULES([JANSSON], [jansson], [], [])
 
 #
 #  Other checks

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -5,11 +5,11 @@ AM_CFLAGS = \
 
 AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS) \
-	$(SODIUM_LIBS)
+	$(SODIUM_LIBS) $(JANSSON_LIBS)
 
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
-	$(SODIUM_CFLAGS)
+	$(SODIUM_CFLAGS) $(JANSSON_CFLAGS)
 
 noinst_LTLIBRARIES = \
 	libflux-security.la

--- a/src/lib/sigcert.h
+++ b/src/lib/sigcert.h
@@ -34,6 +34,14 @@ struct flux_sigcert *flux_sigcert_load (const char *name);
  */
 int flux_sigcert_store (struct flux_sigcert *cert, const char *name);
 
+/* Decode JSON string to cert.
+ */
+struct flux_sigcert *flux_sigcert_json_loads (const char *s);
+
+/* Encode public cert to JSON string.  Caller must free.
+ */
+char *flux_sigcert_json_dumps (struct flux_sigcert *cert);
+
 /* Return true if two certificates have the same keys.
  */
 bool flux_sigcert_equal (struct flux_sigcert *cert1,


### PR DESCRIPTION
This adds `flux_sigcert_json_loads()` and `flux_sigcert_json_dumps()` to load/dump a public version of a cert from/to a JSON string.

Eventually this could be used to include a public cert within a signed request, or to send a public cert to a CA for signing (though that requires some more discussion in #16)

This adds a jansson dependency.  Instead of requiring a newer version like flux-core and then having to build it in travis, I just allow any version and install in travis with apt.  That may be fine for this project, and I didn't want to unnecessarily complicate the travis.yml or our configure script.  We can always go there later if we need to.