### PR TITLE
lib/sigcert: allow user-defined metadata in the cert, and cleanup

### DIFF
--- a/src/lib/sigcert.h
+++ b/src/lib/sigcert.h
@@ -59,6 +59,13 @@ char *flux_sigcert_sign (struct flux_sigcert *cert,
 int flux_sigcert_verify (struct flux_sigcert *cert,
                          const char *signature, uint8_t *buf, int len);
 
+
+/* Get/set metadata
+ */
+int flux_sigcert_meta_set (struct flux_sigcert *cert, const char *key,
+                           const char *value);
+const char *flux_sigcert_meta_get (struct flux_sigcert *cert, const char *key);
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/lib/test/sigcert.c
+++ b/src/lib/test/sigcert.c
@@ -61,6 +61,28 @@ static void cleanup_keypath (const char *name)
     (void)unlink (path);
 }
 
+void test_meta (void)
+{
+    struct flux_sigcert *cert;
+    const char *s;
+
+    cert = flux_sigcert_create ();
+    ok (cert != NULL,
+        "flux_sigcert_create works");
+    ok (flux_sigcert_meta_set (cert, "foo", "bar") == 0,
+        "flux_sigcert_meta_set foo=bar");
+    ok (flux_sigcert_meta_set (cert, "baz", "42") == 0,
+        "flux_sigcert_meta_set baz=42");
+    s = flux_sigcert_meta_get (cert, "foo");
+    ok (s != NULL && !strcmp (s, "bar"),
+        "flux_sigcert_meta_get foo works");
+    s = flux_sigcert_meta_get (cert, "baz");
+    ok (s != NULL && !strcmp (s, "42"),
+        "flux_sigcert_meta_get baz works");
+
+    flux_sigcert_destroy (cert);
+}
+
 void test_load_store (void)
 {
     struct flux_sigcert *cert;
@@ -84,6 +106,8 @@ void test_load_store (void)
      * Load it back into a different cert, and make sure keys are the same.
      */
     name = new_keypath ("test");
+    ok (flux_sigcert_meta_set (cert, "foo", "bar") == 0,
+        "flux_sigcert_meta_set foo=bar");
     ok (flux_sigcert_store (cert, name) == 0,
         "flux_sigcert_store test, test.pub worked");
     ok ((cert2 = flux_sigcert_load (name)) != NULL,
@@ -257,6 +281,10 @@ void test_json_load_dump (void)
     name = new_keypath ("test");
     if (!(cert = flux_sigcert_create ()))
         BAIL_OUT ("flux_sigcert_create");
+    ok (flux_sigcert_meta_set (cert, "foo", "42") == 0,
+        "flux_sigcert_meta_set foo=42");
+    ok (flux_sigcert_meta_set (cert, "bar", "3.14") == 0,
+        "flux_sigcert_meta_set bar=3.14");
     if (flux_sigcert_store (cert, name) < 0)
         BAIL_OUT ("flux_sigcert_store");
     name = new_keypath ("test.pub");
@@ -379,6 +407,7 @@ int main (int argc, char *argv[])
 {
     plan (NO_PLAN);
 
+    test_meta ();
     test_load_store ();
     test_sign_verify();
     test_json_load_dump_sign ();

--- a/src/lib/test/sigcert.c
+++ b/src/lib/test/sigcert.c
@@ -67,8 +67,6 @@ void test_load_store (void)
     struct flux_sigcert *cert2;
     const char *name;
 
-    plan (NO_PLAN);
-
     new_scratchdir ();
 
     /* Create a certificate.


### PR DESCRIPTION
Add methods to get/set arbitrary data in a certificate, like the similar feature in CZMQ zcert.  This allows higher level class users to customize the certificate.

This PR also includes some cleanup, refactoring, and test improvement.