### PR TITLE
sigcert: support all TOML types in metadata accessors, cleanup

### DIFF
--- a/src/lib/sigcert.c
+++ b/src/lib/sigcert.c
@@ -286,6 +286,85 @@ int flux_sigcert_meta_getb (const struct flux_sigcert *cert,
     return 0;
 }
 
+/* Convert time_t (GMT) to ISO 8601 timestamp, e.g. 2003-08-24T05:14:50Z
+ */
+static int timetostr (time_t t, char *buf, int size)
+{
+    struct tm tm;
+    if (!gmtime_r (&t, &tm))
+        return -1;
+    if (strftime (buf, size, "%FT%TZ", &tm) == 0)
+        return -1;
+    return 0;
+}
+
+static int strtotime (const char *s, time_t *tp)
+{
+    struct tm tm;
+    time_t t;
+    if (!strptime (s, "%FT%TZ", &tm))
+        return -1;
+    if ((t = timegm (&tm)) < 0)
+        return -1;
+    *tp = t;
+    return 0;
+}
+
+/* Timestamp is the only TOML type that doesn't have a corresponding
+ * JSON type.  Represent it as a JSON object that looks like this:
+ *   { "iso-8601-ts" : "2003-08-24T05:14:50Z" }
+ * Since this is the only metadata represented as an object, and
+ * metadata is strictly a flat list, this cannot be confused with any
+ * of the other metadata types.
+ */
+int flux_sigcert_meta_setts (struct flux_sigcert *cert,
+                             const char *key, time_t t)
+{
+    json_t *val;
+    char timebuf[80];
+
+    if (!cert || !key || strchr (key, '.')) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (timetostr (t, timebuf, sizeof (timebuf)) < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(val = json_pack ("{s:s}", "iso-8601-ts", timebuf)))
+        goto nomem;
+    if (json_object_set_new (cert->meta, key, val) < 0)
+        goto nomem;
+    return 0;
+nomem:
+    json_decref (val);
+    errno = ENOMEM;
+    return -1;
+}
+
+int flux_sigcert_meta_getts (const struct flux_sigcert *cert,
+                             const char *key, time_t *tp)
+{
+    json_t *val;
+    const char *s;
+    time_t t;
+
+    if (!cert || !key || strchr (key, '.') || !tp) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(val = json_object_get (cert->meta, key))) {
+        errno = ENOENT;
+        return -1;
+    }
+    if (json_unpack (val, "{s:s}", "iso-8601-ts", &s) < 0
+                                    || strtotime (s, &t) < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    *tp = t;
+    return 0;
+}
 
 /* Given 'srcbuf', a byte sequence 'srclen' bytes long, return
  * a base64 string encoding of it.  Caller must free.
@@ -394,6 +473,13 @@ static int sigcert_fwrite (const struct flux_sigcert *cert,
                          mkey, json_real_value (val)) < 0)
                 goto error;
         }
+        else if (json_is_object (val)) {
+            const char *s;
+            if (json_unpack (val, "{s:s}", "iso-8601-ts", &s) < 0)
+                goto error;
+            if (fprintf (fp, "    %s = %s\n", mkey, s) < 0)
+                goto error;
+        }
         else {
             errno = EINVAL;
             goto error;
@@ -499,6 +585,7 @@ static int parse_toml_meta_set (const char *raw, struct flux_sigcert *cert,
     int64_t i;
     double d;
     int b;
+    toml_timestamp_t ts;
 
     if (toml_rtos (raw, &s) == 0) {
         if (flux_sigcert_meta_sets (cert, key, s) < 0)
@@ -514,6 +601,25 @@ static int parse_toml_meta_set (const char *raw, struct flux_sigcert *cert,
     }
     else if (toml_rtod (raw, &d) == 0) {
         if (flux_sigcert_meta_setd (cert, key, d) < 0)
+            goto done;
+    }
+    else if (toml_rtots (raw, &ts) == 0) {
+        struct tm tm;
+        time_t t;
+        if (!ts.year || !ts.month || !ts.day)
+            goto done;
+        if (!ts.hour || !ts.minute || !ts.second)
+            goto done;
+        memset (&tm, 0, sizeof (tm));
+        tm.tm_year = *ts.year - 1900;
+        tm.tm_mon = *ts.month - 1;
+        tm.tm_mday = *ts.day;
+        tm.tm_hour = *ts.hour;
+        tm.tm_min = *ts.minute;
+        tm.tm_sec = *ts.second;
+        if ((t = timegm (&tm)) < 0)
+            goto done;
+        if (flux_sigcert_meta_setts (cert, key, t) < 0)
             goto done;
     }
     else

--- a/src/lib/sigcert.c
+++ b/src/lib/sigcert.c
@@ -132,7 +132,7 @@ nomem:
     return -1;
 }
 
-const char *flux_sigcert_meta_get (struct flux_sigcert *cert, const char *key)
+const char *flux_sigcert_meta_get (const struct flux_sigcert *cert, const char *key)
 {
     json_t *val;
     const char *s;
@@ -212,7 +212,8 @@ static FILE *fopen_mode (const char *pathname, mode_t mode)
 /* Write cert contents to 'fp' in TOML format.
  * If secret=true, include secret key.
  */
-static int sigcert_fwrite (struct flux_sigcert *cert, FILE *fp, bool secret)
+static int sigcert_fwrite (const struct flux_sigcert *cert,
+                           FILE *fp, bool secret)
 {
     char *key = NULL;
     void *iter;
@@ -260,7 +261,7 @@ error:
     return -1;
 }
 
-int flux_sigcert_store (struct flux_sigcert *cert, const char *name)
+int flux_sigcert_store (const struct flux_sigcert *cert, const char *name)
 {
     FILE *fp = NULL;
     const int pubsz = PATH_MAX + 1;
@@ -431,7 +432,7 @@ error:
     return NULL;
 }
 
-char *flux_sigcert_json_dumps (struct flux_sigcert *cert)
+char *flux_sigcert_json_dumps (const struct flux_sigcert *cert)
 {
     json_t *obj = NULL;
     char *xpub = NULL;
@@ -507,7 +508,8 @@ error:
     return NULL;
 }
 
-bool flux_sigcert_equal (struct flux_sigcert *cert1, struct flux_sigcert *cert2)
+bool flux_sigcert_equal (const struct flux_sigcert *cert1,
+                         const struct flux_sigcert *cert2)
 {
     if (!cert1 || !cert2)
         return false;
@@ -526,7 +528,8 @@ bool flux_sigcert_equal (struct flux_sigcert *cert1, struct flux_sigcert *cert2)
     return true;
 }
 
-char *flux_sigcert_sign (struct flux_sigcert *cert, uint8_t *buf, int len)
+char *flux_sigcert_sign (const struct flux_sigcert *cert,
+                         uint8_t *buf, int len)
 {
     uint8_t sig[crypto_sign_BYTES];
 
@@ -541,7 +544,7 @@ char *flux_sigcert_sign (struct flux_sigcert *cert, uint8_t *buf, int len)
     return sigcert_base64_encode (sig, crypto_sign_BYTES);
 }
 
-int flux_sigcert_verify (struct flux_sigcert *cert,
+int flux_sigcert_verify (const struct flux_sigcert *cert,
                          const char *sig_base64, uint8_t *buf, int len)
 {
     uint8_t sig[crypto_sign_BYTES];

--- a/src/lib/sigcert.c
+++ b/src/lib/sigcert.c
@@ -117,8 +117,8 @@ error:
     return NULL;
 }
 
-int flux_sigcert_meta_set (struct flux_sigcert *cert,
-                           const char *key, const char *s)
+int flux_sigcert_meta_sets (struct flux_sigcert *cert,
+                            const char *key, const char *s)
 {
     json_t *val;
     if (!(val = json_string (s)))
@@ -132,18 +132,22 @@ nomem:
     return -1;
 }
 
-const char *flux_sigcert_meta_get (const struct flux_sigcert *cert, const char *key)
+int flux_sigcert_meta_gets (const struct flux_sigcert *cert,
+                            const char *key, const char **sp)
 {
     json_t *val;
     const char *s;
 
     if (!(val = json_object_get (cert->meta, key))) {
         errno = ENOENT;
-        return NULL;
+        return -1;
     }
-    if (!(s = json_string_value (val)))
+    if (!(s = json_string_value (val))) {
         errno = EINVAL;
-    return s;
+        return -1;
+    }
+    *sp = s;
+    return 0;
 }
 
 /* Given 'srcbuf', a byte sequence 'srclen' bytes long, return
@@ -334,7 +338,7 @@ static int parse_toml_meta_set (const char *raw, struct flux_sigcert *cert,
 
     if (toml_rtos (raw, &s) < 0)
         goto done;
-    if (flux_sigcert_meta_set (cert, key, s) < 0)
+    if (flux_sigcert_meta_sets (cert, key, s) < 0)
         goto done;
     rc = 0;
 done:

--- a/src/lib/sigcert.c
+++ b/src/lib/sigcert.c
@@ -117,10 +117,18 @@ error:
     return NULL;
 }
 
+/* Don't allow '.' in a key or when it's written out to TOML
+ * it will look like TOML hierarchy.
+ */
 int flux_sigcert_meta_sets (struct flux_sigcert *cert,
                             const char *key, const char *s)
 {
     json_t *val;
+
+    if (!cert || !key || strchr (key, '.') || !s) {
+        errno = EINVAL;
+        return -1;
+    }
     if (!(val = json_string (s)))
         goto nomem;
     if (json_object_set_new (cert->meta, key, val) < 0)
@@ -138,6 +146,10 @@ int flux_sigcert_meta_gets (const struct flux_sigcert *cert,
     json_t *val;
     const char *s;
 
+    if (!cert || !key || strchr (key, '.') || !sp) {
+        errno = EINVAL;
+        return -1;
+    }
     if (!(val = json_object_get (cert->meta, key))) {
         errno = ENOENT;
         return -1;

--- a/src/lib/sigcert.c
+++ b/src/lib/sigcert.c
@@ -162,6 +162,47 @@ int flux_sigcert_meta_gets (const struct flux_sigcert *cert,
     return 0;
 }
 
+int flux_sigcert_meta_seti (struct flux_sigcert *cert,
+                            const char *key, int64_t i)
+{
+    json_t *val;
+
+    if (!cert || !key || strchr (key, '.')) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(val = json_integer ((json_int_t)i)))
+        goto nomem;
+    if (json_object_set_new (cert->meta, key, val) < 0)
+        goto nomem;
+    return 0;
+nomem:
+    json_decref (val);
+    errno = ENOMEM;
+    return -1;
+}
+
+int flux_sigcert_meta_geti (const struct flux_sigcert *cert,
+                            const char *key, int64_t *ip)
+{
+    json_t *val;
+
+    if (!cert || !key || strchr (key, '.') || !ip) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(val = json_object_get (cert->meta, key))) {
+        errno = ENOENT;
+        return -1;
+    }
+    if (!json_is_integer (val)) {
+        errno = EINVAL;
+        return -1;
+    }
+    *ip = json_integer_value (val);
+    return 0;
+}
+
 /* Given 'srcbuf', a byte sequence 'srclen' bytes long, return
  * a base64 string encoding of it.  Caller must free.
  */
@@ -241,14 +282,25 @@ static int sigcert_fwrite (const struct flux_sigcert *cert,
     while (iter) {
         const char *mkey = json_object_iter_key (iter);
         json_t *val = json_object_iter_value (iter);
-        const char *s;
 
-        if (!mkey || !val || !(s = json_string_value (val))) {
+        if (!mkey || !val) {
             errno = EINVAL;
             goto error;
         }
-        if (fprintf (fp, "    %s = \"%s\"\n", mkey, s) < 0)
+        if (json_is_string (val)) {
+            if (fprintf (fp, "    %s = \"%s\"\n",
+                         mkey, json_string_value (val)) < 0)
+                goto error;
+        }
+        else if (json_is_integer (val)) {
+            if (fprintf (fp, "    %s = %lld\n",
+                         mkey, (long long)json_integer_value (val)) < 0)
+                goto error;
+        }
+        else {
+            errno = EINVAL;
             goto error;
+        }
         iter = json_object_iter_next (cert->meta, iter);
     }
     if (fprintf (fp, "\n") < 0)
@@ -347,10 +399,17 @@ static int parse_toml_meta_set (const char *raw, struct flux_sigcert *cert,
 {
     char *s = NULL;
     int rc = -1;
+    int64_t i;
 
-    if (toml_rtos (raw, &s) < 0)
-        goto done;
-    if (flux_sigcert_meta_sets (cert, key, s) < 0)
+    if (toml_rtos (raw, &s) == 0) {
+        if (flux_sigcert_meta_sets (cert, key, s) < 0)
+            goto done;
+    }
+    else if (toml_rtoi (raw, &i) == 0) {
+        if (flux_sigcert_meta_seti (cert, key, i) < 0)
+            goto done;
+    }
+    else
         goto done;
     rc = 0;
 done:

--- a/src/lib/sigcert.h
+++ b/src/lib/sigcert.h
@@ -1,6 +1,7 @@
 #ifndef _FLUX_SIGCERT_H
 #define _FLUX_SIGCERT_H
 
+#include <time.h>
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -78,6 +79,10 @@ int flux_sigcert_meta_setb (struct flux_sigcert *cert,
                             const char *key, bool value);
 int flux_sigcert_meta_getb (const struct flux_sigcert *cert,
                             const char *key, bool *value);
+int flux_sigcert_meta_setts (struct flux_sigcert *cert,
+                             const char *key, time_t value);
+int flux_sigcert_meta_getts (const struct flux_sigcert *cert,
+                             const char *key, time_t *value);
 
 #ifdef __cplusplus
 }

--- a/src/lib/sigcert.h
+++ b/src/lib/sigcert.h
@@ -66,6 +66,10 @@ int flux_sigcert_meta_sets (struct flux_sigcert *cert,
                             const char *key, const char *value);
 int flux_sigcert_meta_gets (const struct flux_sigcert *cert,
                             const char *key, const char **value);
+int flux_sigcert_meta_seti (struct flux_sigcert *cert,
+                            const char *key, int64_t value);
+int flux_sigcert_meta_geti (const struct flux_sigcert *cert,
+                            const char *key, int64_t *value);
 
 #ifdef __cplusplus
 }

--- a/src/lib/sigcert.h
+++ b/src/lib/sigcert.h
@@ -32,7 +32,7 @@ struct flux_sigcert *flux_sigcert_load (const char *name);
 
 /* Store cert to 'name' and 'name.pub'.
  */
-int flux_sigcert_store (struct flux_sigcert *cert, const char *name);
+int flux_sigcert_store (const struct flux_sigcert *cert, const char *name);
 
 /* Decode JSON string to cert.
  */
@@ -40,23 +40,23 @@ struct flux_sigcert *flux_sigcert_json_loads (const char *s);
 
 /* Encode public cert to JSON string.  Caller must free.
  */
-char *flux_sigcert_json_dumps (struct flux_sigcert *cert);
+char *flux_sigcert_json_dumps (const struct flux_sigcert *cert);
 
 /* Return true if two certificates have the same keys.
  */
-bool flux_sigcert_equal (struct flux_sigcert *cert1,
-                         struct flux_sigcert *cert2);
+bool flux_sigcert_equal (const struct flux_sigcert *cert1,
+                         const struct flux_sigcert *cert2);
 
 /* Return a detached signature (base64 string) over buf, len.
  * Caller must free.
  */
-char *flux_sigcert_sign (struct flux_sigcert *cert,
+char *flux_sigcert_sign (const struct flux_sigcert *cert,
                          uint8_t *buf, int len);
 
 /* Verify a detached signature (base64 string) over buf, len.
  * Returns 0 on success, -1 on failure.
  */
-int flux_sigcert_verify (struct flux_sigcert *cert,
+int flux_sigcert_verify (const struct flux_sigcert *cert,
                          const char *signature, uint8_t *buf, int len);
 
 
@@ -64,7 +64,7 @@ int flux_sigcert_verify (struct flux_sigcert *cert,
  */
 int flux_sigcert_meta_set (struct flux_sigcert *cert, const char *key,
                            const char *value);
-const char *flux_sigcert_meta_get (struct flux_sigcert *cert, const char *key);
+const char *flux_sigcert_meta_get (const struct flux_sigcert *cert, const char *key);
 
 #ifdef __cplusplus
 }

--- a/src/lib/sigcert.h
+++ b/src/lib/sigcert.h
@@ -66,10 +66,6 @@ int flux_sigcert_meta_set (struct flux_sigcert *cert, const char *key,
                            const char *value);
 const char *flux_sigcert_meta_get (struct flux_sigcert *cert, const char *key);
 
-/*
- * vi:tabstop=4 shiftwidth=4 expandtab
- */
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/lib/sigcert.h
+++ b/src/lib/sigcert.h
@@ -70,6 +70,10 @@ int flux_sigcert_meta_seti (struct flux_sigcert *cert,
                             const char *key, int64_t value);
 int flux_sigcert_meta_geti (const struct flux_sigcert *cert,
                             const char *key, int64_t *value);
+int flux_sigcert_meta_setd (struct flux_sigcert *cert,
+                            const char *key, double value);
+int flux_sigcert_meta_getd (const struct flux_sigcert *cert,
+                            const char *key, double *value);
 
 #ifdef __cplusplus
 }

--- a/src/lib/sigcert.h
+++ b/src/lib/sigcert.h
@@ -62,9 +62,10 @@ int flux_sigcert_verify (const struct flux_sigcert *cert,
 
 /* Get/set metadata
  */
-int flux_sigcert_meta_set (struct flux_sigcert *cert, const char *key,
-                           const char *value);
-const char *flux_sigcert_meta_get (const struct flux_sigcert *cert, const char *key);
+int flux_sigcert_meta_sets (struct flux_sigcert *cert,
+                            const char *key, const char *value);
+int flux_sigcert_meta_gets (const struct flux_sigcert *cert,
+                            const char *key, const char **value);
 
 #ifdef __cplusplus
 }

--- a/src/lib/sigcert.h
+++ b/src/lib/sigcert.h
@@ -74,6 +74,10 @@ int flux_sigcert_meta_setd (struct flux_sigcert *cert,
                             const char *key, double value);
 int flux_sigcert_meta_getd (const struct flux_sigcert *cert,
                             const char *key, double *value);
+int flux_sigcert_meta_setb (struct flux_sigcert *cert,
+                            const char *key, bool value);
+int flux_sigcert_meta_getb (const struct flux_sigcert *cert,
+                            const char *key, bool *value);
 
 #ifdef __cplusplus
 }

--- a/src/lib/test/sigcert.c
+++ b/src/lib/test/sigcert.c
@@ -395,6 +395,34 @@ void test_corner (void)
     ok (flux_sigcert_json_loads ("{\"curve\":{}}") == NULL && errno == EPROTO,
         "flux_sigcert_json_loads s=valid/wrong fails with EPROTO");
 
+    /* meta get/set corner cases
+     */
+    const char *s;
+    errno = 0;
+    ok (flux_sigcert_meta_sets (NULL, "a", "b") < 0 && errno == EINVAL,
+        "flux_sigcert_meta_sets cert=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_sigcert_meta_sets (cert, NULL, "b") < 0 && errno == EINVAL,
+        "flux_sigcert_meta_sets key=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_sigcert_meta_sets (cert, "a.b", "b") < 0 && errno == EINVAL,
+        "flux_sigcert_meta_sets key=a.b fails with EINVAL");
+    errno = 0;
+    ok (flux_sigcert_meta_sets (cert, "a", NULL) < 0 && errno == EINVAL,
+        "flux_sigcert_meta_sets value=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_sigcert_meta_gets (NULL, "a", &s) < 0 && errno == EINVAL,
+        "flux_sigcert_meta_gets cert=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_sigcert_meta_gets (cert, NULL, &s) < 0 && errno == EINVAL,
+        "flux_sigcert_meta_gets key=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_sigcert_meta_gets (cert, ".", &s) < 0 && errno == EINVAL,
+        "flux_sigcert_meta_gets key=. fails with EINVAL");
+    errno = 0;
+    ok (flux_sigcert_meta_gets (cert, "a", NULL) < 0 && errno == EINVAL,
+        "flux_sigcert_meta_gets value=NULL fails with EINVAL");
+
     /* Destroy NULL
      */
     lives_ok ({flux_sigcert_destroy (NULL);},

--- a/src/lib/test/sigcert.c
+++ b/src/lib/test/sigcert.c
@@ -69,16 +69,16 @@ void test_meta (void)
     cert = flux_sigcert_create ();
     ok (cert != NULL,
         "flux_sigcert_create works");
-    ok (flux_sigcert_meta_set (cert, "foo", "bar") == 0,
-        "flux_sigcert_meta_set foo=bar");
-    ok (flux_sigcert_meta_set (cert, "baz", "42") == 0,
-        "flux_sigcert_meta_set baz=42");
-    s = flux_sigcert_meta_get (cert, "foo");
-    ok (s != NULL && !strcmp (s, "bar"),
-        "flux_sigcert_meta_get foo works");
-    s = flux_sigcert_meta_get (cert, "baz");
-    ok (s != NULL && !strcmp (s, "42"),
-        "flux_sigcert_meta_get baz works");
+    ok (flux_sigcert_meta_sets (cert, "foo", "bar") == 0,
+        "flux_sigcert_meta_sets foo=bar");
+    ok (flux_sigcert_meta_sets (cert, "baz", "boink") == 0,
+        "flux_sigcert_meta_sets baz=boink");
+    ok (flux_sigcert_meta_gets (cert, "foo", &s) == 0
+        && !strcmp (s, "bar"),
+        "flux_sigcert_meta_gets foo works");
+    ok (flux_sigcert_meta_gets (cert, "baz", &s) == 0
+        && !strcmp (s, "boink"),
+        "flux_sigcert_meta_gets baz works");
 
     flux_sigcert_destroy (cert);
 }
@@ -106,8 +106,8 @@ void test_load_store (void)
      * Load it back into a different cert, and make sure keys are the same.
      */
     name = new_keypath ("test");
-    ok (flux_sigcert_meta_set (cert, "foo", "bar") == 0,
-        "flux_sigcert_meta_set foo=bar");
+    ok (flux_sigcert_meta_sets (cert, "foo", "bar") == 0,
+        "flux_sigcert_meta_sets foo=bar");
     ok (flux_sigcert_store (cert, name) == 0,
         "flux_sigcert_store test, test.pub worked");
     ok ((cert2 = flux_sigcert_load (name)) != NULL,
@@ -281,10 +281,10 @@ void test_json_load_dump (void)
     name = new_keypath ("test");
     if (!(cert = flux_sigcert_create ()))
         BAIL_OUT ("flux_sigcert_create");
-    ok (flux_sigcert_meta_set (cert, "foo", "42") == 0,
-        "flux_sigcert_meta_set foo=42");
-    ok (flux_sigcert_meta_set (cert, "bar", "3.14") == 0,
-        "flux_sigcert_meta_set bar=3.14");
+    ok (flux_sigcert_meta_sets (cert, "foo", "bar") == 0,
+        "flux_sigcert_meta_sets foo=bar");
+    ok (flux_sigcert_meta_sets (cert, "bar", "baz") == 0,
+        "flux_sigcert_meta_sets bar=baz");
     if (flux_sigcert_store (cert, name) < 0)
         BAIL_OUT ("flux_sigcert_store");
     name = new_keypath ("test.pub");


### PR DESCRIPTION
Add functions to allow all the TOML types to be used in metadata sections.

Some cleanup and test coverage improvement also.