### PR TITLE
sigcert: add certificate signing capability, cleanup

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+ round: down
+ range: "50...100"
+ ignore:
+ - ".*/test/.*"
+ - ".*/libtap/.*"
+
+comment:
+ layout: "header, diff, changes, tree"

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -20,7 +20,9 @@ libflux_security_la_SOURCES = \
 
 TESTS = test_sigcert.t
 
-check_PROGRAMS = $(TESTS)
+check_PROGRAMS = \
+	test_keygen \
+	$(TESTS)
 
 TEST_EXTENSIONS = .t
 T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
@@ -38,3 +40,7 @@ test_ldadd = \
 test_sigcert_t_SOURCES = test/sigcert.c
 test_sigcert_t_LDADD = $(test_ldadd)
 test_sigcert_t_CPPFLAGS = $(test_cppflags)
+
+test_keygen_SOURCES = test/keygen.c
+test_keygen_LDADD = $(test_ldadd)
+test_keygen_CPPFLAGS = $(test_cppflags)

--- a/src/lib/sigcert.c
+++ b/src/lib/sigcert.c
@@ -411,6 +411,8 @@ static int sigcert_base64_decode_public (const char *src, public_t dst)
         goto inval;
     if (base64_decode_block (dst, &dstlen, src, srclen) < 0)
         goto inval;
+    if (dstlen != crypto_sign_PUBLICKEYBYTES)
+        goto inval;
     return 0;
 inval:
     errno = EINVAL;
@@ -442,6 +444,8 @@ int sigcert_base64_decode_secret (const char *src, secret_t dst)
         goto inval;
     if (base64_decode_block (dst, &dstlen, src, srclen) < 0)
         goto inval;
+    if (dstlen != crypto_sign_SECRETKEYBYTES)
+        goto inval;
     return 0;
 inval:
     errno = EINVAL;
@@ -471,6 +475,8 @@ static int sigcert_base64_decode_sign (const char *src, sign_t dst)
     if (dstlen < base64_decode_length (srclen))
         goto inval;
     if (base64_decode_block (dst, &dstlen, src, srclen) < 0)
+        goto inval;
+    if (dstlen != crypto_sign_BYTES)
         goto inval;
     return 0;
 inval:

--- a/src/lib/sigcert.h
+++ b/src/lib/sigcert.h
@@ -60,6 +60,19 @@ char *flux_sigcert_sign (const struct flux_sigcert *cert,
 int flux_sigcert_verify (const struct flux_sigcert *cert,
                          const char *signature, uint8_t *buf, int len);
 
+/* Use cert1 to sign cert2.
+ * The signature covers public key and all metadata.
+ * It does not cover secret key or existing signature, if any.
+ * The signature is embedded in cert2.
+ */
+int flux_sigcert_sign_cert (const struct flux_sigcert *cert1,
+                            struct flux_sigcert *cert2);
+
+/* Use cert1 to verify cert2's embedded signature.
+ */
+int flux_sigcert_verify_cert (const struct flux_sigcert *cert1,
+                              const struct flux_sigcert *cert2);
+
 
 /* Get/set metadata
  */

--- a/src/lib/sigcert.h
+++ b/src/lib/sigcert.h
@@ -8,8 +8,8 @@
 /* Certificate class for signing/verification.
  *
  * Keys can be loaded/stored from TOML based certificate files.
- * The "secret" version of the certificate contains everything.
- * The "public" version of the certificate contains all but private keys.
+ * The "secret" file only contains the secret-key.
+ * The "public" file contains the public-key, metadata and signature.
  * The public version is distinguished by a .pub extension (like ssh keys).
  */
 
@@ -27,9 +27,10 @@ void flux_sigcert_destroy (struct flux_sigcert *cert);
  */
 struct flux_sigcert *flux_sigcert_create (void);
 
-/* Load cert from file 'name', falling back to 'name.pub'.
+/* Load cert from file 'name.pub'.
+ * If secret=true, load secret-key from 'name' also.
  */
-struct flux_sigcert *flux_sigcert_load (const char *name);
+struct flux_sigcert *flux_sigcert_load (const char *name, bool secret);
 
 /* Store cert to 'name' and 'name.pub'.
  */

--- a/src/lib/test/keygen.c
+++ b/src/lib/test/keygen.c
@@ -1,0 +1,169 @@
+/* keygen - generate signing keys */
+
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
+#include <unistd.h>
+#include <sys/types.h>
+#include <pwd.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+#include <getopt.h>
+
+#include "sigcert.h"
+
+void die (const char *fmt, ...)
+{
+    va_list ap;
+    char msg[1024];
+
+    va_start (ap, fmt);
+    (void)vsnprintf (msg, sizeof (msg), fmt, ap);
+    va_end (ap);
+    fprintf (stderr, "keygen: %s%s%s\n",
+             msg, errno > 0 ? ": " : "",
+                  errno > 0 ? strerror (errno) : "");
+    exit (1);
+}
+
+/* Generate a new cert and store it to target_path.
+ * If it exists, it will be overwritten.
+ * Paths leading up to the key files must exist.
+ */
+void generate_cert (const char *target_path)
+{
+    struct flux_sigcert *cert;
+    time_t t;
+
+    if (!(cert = flux_sigcert_create ()))
+        die ("flux_sigcert_create");
+    if (time (&t) == (time_t)-1)
+        die ("time");
+    if (flux_sigcert_meta_setts (cert, "create-time", t) < 0)
+        die ("flux_sigcert_meta_setts");
+    if (flux_sigcert_meta_seti (cert, "userid", getuid ()) < 0)
+        die ("flux_sigcert_meta_seti");
+    fprintf (stderr, "keygen: updating %s\n", target_path);
+    if (flux_sigcert_store (cert, target_path) < 0)
+        die ("flux_sigcert_store");
+    flux_sigcert_destroy (cert);
+}
+
+/* Sign cert at 'target_path' with cert at 'signer_path'.
+ * Add some made up metadata as stand in for CA info.
+ */
+void sign_cert (const char *signer_path, const char *target_path)
+{
+    struct flux_sigcert *cert1;
+    struct flux_sigcert *cert2;
+    time_t t;
+    int64_t userid;
+
+    if (!(cert1 = flux_sigcert_load (signer_path, true)))
+        die ("load %s", signer_path);
+    if (!(cert2 = flux_sigcert_load (target_path, false)))
+        die ("load %s", target_path);
+
+    if (flux_sigcert_meta_geti (cert1, "userid", &userid) < 0)
+        die ("flux_sigcert_meta_setts");
+    if (flux_sigcert_meta_seti (cert2, "ca-userid", userid) < 0)
+        die ("flux_sigcert_meta_setts");
+    if (time (&t) == (time_t)-1)
+        die ("time");
+    if (flux_sigcert_meta_setts (cert2, "ca-signed-time", t) < 0)
+        die ("flux_sigcert_meta_setts");
+
+    if (flux_sigcert_sign_cert (cert1, cert2) < 0)
+        die ("flux_sigcert_sign_cert");
+    fprintf (stderr, "keygen: updating %s\n", target_path);
+    if (flux_sigcert_store (cert2, target_path) < 0)
+        die ("store %s", target_path);
+    flux_sigcert_destroy (cert1);
+    flux_sigcert_destroy (cert2);
+}
+
+/* Verify that cert at 'target_path' was signed by cert at 'signer_path'.
+ */
+void verify_cert (const char *signer_path, const char *target_path)
+{
+    struct flux_sigcert *cert1;
+    struct flux_sigcert *cert2;
+
+    if (!(cert1 = flux_sigcert_load (signer_path, false)))
+        die ("load %s", signer_path);
+    if (!(cert2 = flux_sigcert_load (target_path, false)))
+        die ("load %s", target_path);
+    if (flux_sigcert_verify_cert (cert1, cert2) < 0)
+        fprintf (stderr, "signature verifcation failed\n");
+    else
+        fprintf (stderr, "signature verification succeeded\n");
+    flux_sigcert_destroy (cert1);
+    flux_sigcert_destroy (cert2);
+}
+
+void usage (void)
+{
+    fprintf (stderr, "Usage: keygen [--sign=PATH] [--verify=PATH] [PATH]\n");
+}
+
+#define OPTIONS "+hs:v:"
+static const struct option longopts[] = {
+    {"help",                  no_argument,          0, 'h'},
+    {"sign",                  required_argument,    0, 's'},
+    {"verify",                required_argument,    0, 'v'},
+    { 0, 0, 0, 0 },
+};
+
+int main (int argc, char *argv[])
+{
+    char default_path[PATH_MAX + 1];
+    const char *target_path = NULL;
+    const char *signer_path = NULL;
+    const char *verifier_path = NULL;
+    struct passwd *pw;
+    int ch;
+
+    while ((ch = getopt_long (argc, argv, OPTIONS, longopts, NULL)) != -1) {
+        switch (ch) {
+            case 's':   // --sign=PATH
+                signer_path = optarg;
+                break;
+            case 'v':   // --verify=PATH
+                verifier_path = optarg;
+                break;
+            default:
+                usage ();
+                break;
+        }
+    }
+    if (optind < argc)
+        target_path = argv[optind++];
+    if (optind < argc)
+        usage ();
+
+    if (!target_path) {
+        if (!(pw = getpwuid (getuid ())))
+            die ("who are you?");
+        if (snprintf (default_path, PATH_MAX + 1,
+                      "%s/.flux/curve/sig", pw->pw_dir) >= PATH_MAX + 1)
+            die ("key path buffer overflow");
+        target_path = default_path;
+    }
+
+    if (signer_path)
+        sign_cert (signer_path, target_path);
+    else if (verifier_path)
+        verify_cert (verifier_path, target_path);
+    else
+        generate_cert (target_path);
+
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/lib/test/sigcert.c
+++ b/src/lib/test/sigcert.c
@@ -142,7 +142,7 @@ void test_load_store (void)
         "flux_sigcert_meta_setts time=now");
     ok (flux_sigcert_store (cert, name) == 0,
         "flux_sigcert_store test, test.pub worked");
-    ok ((cert2 = flux_sigcert_load (name)) != NULL,
+    ok ((cert2 = flux_sigcert_load (name, true)) != NULL,
         "flux_sigcert_load test worked");
     diag_cert ("cert", cert);
     diag_cert ("cert2", cert2);
@@ -163,8 +163,8 @@ void test_load_store (void)
 
     /* Load just the public key and verify keys are different
      */
-    name = new_keypath ("test.pub");
-    ok ((cert2 = flux_sigcert_load (name)) != NULL,
+    name = new_keypath ("test");
+    ok ((cert2 = flux_sigcert_load (name, false)) != NULL,
         "flux_sigcert_load test.pub worked");
     ok (flux_sigcert_equal (cert, cert2) == false,
         "pub cert differs from secret one");
@@ -189,7 +189,7 @@ void test_load_store (void)
         BAIL_OUT ("chdir %s: %s", scratch, strerror (errno));
     ok (flux_sigcert_store (cert, "foo") == 0,
         "flux_sigcert_store works with relative path");
-    cert2 = flux_sigcert_load ("foo");
+    cert2 = flux_sigcert_load ("foo", true);
     ok (cert2 != NULL,
         "flux_sigcert_load works with relative path");
     if (chdir (cwd) < 0)
@@ -308,9 +308,8 @@ void test_json_load_dump (void)
 
     new_scratchdir ();
 
-    /* Store a cert to test, test.pub, then load cert_pub from
-     * test.pub so we have one containing only the public key.
-     * (json codec never transfers the secret key)
+    /* Store a cert to test, test.pub, then load cert_pub with
+     * only the public key.
      */
     name = new_keypath ("test");
     if (!(cert = flux_sigcert_create ()))
@@ -327,8 +326,7 @@ void test_json_load_dump (void)
         "flux_sigcert_meta_setb time=now");
     if (flux_sigcert_store (cert, name) < 0)
         BAIL_OUT ("flux_sigcert_store");
-    name = new_keypath ("test.pub");
-    ok ((cert_pub = flux_sigcert_load (name)) != NULL,
+    ok ((cert_pub = flux_sigcert_load (name, false)) != NULL,
         "flux_sigcert_load test.pub worked");
 
     /* Dump cert_pub to json string, then load cert2 from
@@ -385,10 +383,10 @@ void test_corner (void)
     ok (flux_sigcert_store (NULL, "foo") < 0 && errno == EINVAL,
         "flux_sigcert_store cert=NULL fails with EINVAL");
     errno = 0;
-    ok (flux_sigcert_load (NULL) == NULL && errno == EINVAL,
+    ok (flux_sigcert_load (NULL, true) == NULL && errno == EINVAL,
         "flux_sigcert_load name=NULL fails with EINVAL");
     errno = 0;
-    ok (flux_sigcert_load ("/noexist") == NULL && errno == ENOENT,
+    ok (flux_sigcert_load ("/noexist", true) == NULL && errno == ENOENT,
         "flux_sigcert_load name=/noexist fails with ENOENT");
     ok (flux_sigcert_equal (NULL, cert) == false,
         "flux_sigcert_load cert1=NULL returns false");

--- a/src/lib/test/sigcert.c
+++ b/src/lib/test/sigcert.c
@@ -113,8 +113,6 @@ void test_load_store (void)
     struct flux_sigcert *cert2;
     const char *name;
 
-    new_scratchdir ();
-
     /* Create a certificate.
      * Create another one and make sure keys are different.
      */
@@ -202,7 +200,6 @@ void test_load_store (void)
     cleanup_keypath ("test.pub");
     cleanup_keypath ("foo");
     cleanup_keypath ("foo.pub");
-    cleanup_scratchdir ();
 }
 
 void test_sign_verify (void)
@@ -306,8 +303,6 @@ void test_json_load_dump (void)
     char *s;
     const char *name;
 
-    new_scratchdir ();
-
     /* Store a cert to test, test.pub, then load cert_pub with
      * only the public key.
      */
@@ -350,8 +345,6 @@ void test_json_load_dump (void)
 
     cleanup_keypath ("test");
     cleanup_keypath ("test.pub");
-
-    cleanup_scratchdir ();
 }
 
 void test_corner (void)
@@ -691,7 +684,6 @@ void test_sign_cert (void)
 
     /* Verification of a signed cert still works after TOML serialization.
      */
-    new_scratchdir ();
     name = new_keypath ("test");
     ok (flux_sigcert_store (cert, name) == 0,
         "flux_sigcert_store works on signed cert");
@@ -703,7 +695,6 @@ void test_sign_cert (void)
     flux_sigcert_destroy (cert2);
     cleanup_keypath ("test");
     cleanup_keypath ("test.pub");
-    cleanup_scratchdir ();
 
     /* Verification of a signed but modified cert fails.
      */
@@ -720,17 +711,17 @@ void test_sign_cert (void)
 int main (int argc, char *argv[])
 {
     plan (NO_PLAN);
+    new_scratchdir ();
 
     test_meta ();
     test_load_store ();
     test_sign_verify();
     test_json_load_dump_sign ();
     test_json_load_dump ();
-
     test_corner ();
-
     test_sign_cert ();
 
+    cleanup_scratchdir ();
     done_testing ();
 }
 


### PR DESCRIPTION
This pr adds the ability to sign a certificate with another certificate, as preparation for CA functionality.

Some practical concerns were addressed related to getting only the public portion of a cert signed:
* "cert" and "cert.pub" content no longer overlaps (as borrowed from zcert)
* `flux_sigcert_load()` now has a boolean argument to specify whether secret portion is required
* `flux_sigcert_store()` can update "cert.pub" without updating "cert"

The signature is calculated over json-serialized metadata and public key, skipping an existing signature if present.

There is also some internal cleanup to allow keys and signatures to be manipulated and base64-encoded without needing to malloc.

Unit tests updated.

As a bonus and for inspiration, I added a toy keygen program to play with:
```
Usage: ./test_keygen [--sign=PATH] [--verify=PATH] [PATH]
```
certificates can be generated, signed, and verified.  Since certs are agnostic with respect to any kind of CA "schema", I added a couple of dumb things as a demo.  This only builds with make check and isn't meant to be anything but a toy.