### PR TITLE
libuitl/cf: add config class

### DIFF
--- a/src/libutil/Makefile.am
+++ b/src/libutil/Makefile.am
@@ -17,7 +17,9 @@ libutil_la_SOURCES = \
 	base64.h \
 	thread.h \
 	hash.c \
-	hash.h
+	hash.h \
+	tomltk.c \
+	tomltk.h
 
 TESTS = \
 	test_base64.t \

--- a/src/libutil/Makefile.am
+++ b/src/libutil/Makefile.am
@@ -27,7 +27,8 @@ libutil_la_SOURCES = \
 TESTS = \
 	test_base64.t \
 	test_hash.t \
-	test_tomltk.t
+	test_tomltk.t \
+	test_cf.t
 
 test_ldadd = \
 	$(top_builddir)/src/libutil/libutil.la \
@@ -55,3 +56,7 @@ test_hash_t_LDADD = $(test_ldadd)
 test_tomltk_t_SOURCES = test/tomltk.c
 test_tomltk_t_CPPFLAGS = $(test_cppflags)
 test_tomltk_t_LDADD = $(test_ldadd)
+
+test_cf_t_SOURCES = test/cf.c
+test_cf_t_CPPFLAGS = $(test_cppflags)
+test_cf_t_LDADD = $(test_ldadd)

--- a/src/libutil/Makefile.am
+++ b/src/libutil/Makefile.am
@@ -1,6 +1,7 @@
 AM_CFLAGS = \
 	$(WARNING_CFLAGS) \
 	-Wno-sign-compare -Wno-unused-parameter -Wno-parentheses \
+	$(JANSSON_CFLAGS) \
 	$(CODE_COVERAGE_CFLAGS)
 
 AM_LDFLAGS = \
@@ -23,11 +24,14 @@ libutil_la_SOURCES = \
 
 TESTS = \
 	test_base64.t \
-	test_hash.t
+	test_hash.t \
+	test_tomltk.t
 
 test_ldadd = \
 	$(top_builddir)/src/libutil/libutil.la \
-	$(top_builddir)/src/libtap/libtap.la
+	$(top_builddir)/src/libtomlc99/libtomlc99.la \
+	$(top_builddir)/src/libtap/libtap.la \
+	$(JANSSON_LIBS)
 
 test_cppflags = \
 	$(AM_CPPFLAGS)
@@ -45,3 +49,7 @@ test_base64_t_LDADD = $(test_ldadd)
 test_hash_t_SOURCES = test/hash.c
 test_hash_t_CPPFLAGS = $(test_cppflags)
 test_hash_t_LDADD = $(test_ldadd)
+
+test_tomltk_t_SOURCES = test/tomltk.c
+test_tomltk_t_CPPFLAGS = $(test_cppflags)
+test_tomltk_t_LDADD = $(test_ldadd)

--- a/src/libutil/Makefile.am
+++ b/src/libutil/Makefile.am
@@ -20,7 +20,9 @@ libutil_la_SOURCES = \
 	hash.c \
 	hash.h \
 	tomltk.c \
-	tomltk.h
+	tomltk.h \
+	cf.c \
+	cf.h
 
 TESTS = \
 	test_base64.t \

--- a/src/libutil/cf.c
+++ b/src/libutil/cf.c
@@ -1,0 +1,360 @@
+/*****************************************************************************\
+ *  Copyright (c) 2017 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
+#include <errno.h>
+#include <string.h>
+#include <jansson.h>
+
+#include "src/libtomlc99/toml.h"
+#include "tomltk.h"
+#include "cf.h"
+
+#define ERRBUFSZ 200
+
+cf_t *cf_create (void)
+{
+    cf_t *cf;
+
+    if (!(cf = json_object ())) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    return cf;
+}
+
+void cf_destroy (cf_t *cf)
+{
+    if (cf) {
+        json_decref (cf);
+    }
+}
+
+cf_t *cf_copy (cf_t *cf)
+{
+    cf_t *cpy;
+
+    if (!cf) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(cpy = json_deep_copy (cf))) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    return cpy;
+}
+
+static void errprintf (struct cf_error *error,
+                       const char *filename, int lineno,
+                       const char *fmt, ...)
+{
+    va_list ap;
+    int saved_errno = errno;
+
+    if (error) {
+        memset (error, 0, sizeof (*error));
+        va_start (ap, fmt);
+        (void)vsnprintf (error->errbuf, sizeof (error->errbuf), fmt, ap);
+        va_end (ap);
+        if (filename)
+            strncpy (error->filename, filename, PATH_MAX);
+        error->lineno = lineno;
+    }
+    errno = saved_errno;
+}
+
+struct typedesc {
+    enum cf_type type;
+    const char *desc;
+};
+
+static const struct typedesc typetab[] = {
+    { CF_INT64, "int64" },
+    { CF_DOUBLE, "double" },
+    { CF_BOOL, "bool" },
+    { CF_STRING, "string" },
+    { CF_TIMESTAMP, "timestamp" },
+    { CF_TABLE, "table" },
+    { CF_ARRAY, "array" },
+};
+const int typetablen = sizeof (typetab) / sizeof (typetab[0]);
+
+const char *cf_typedesc (enum cf_type type)
+{
+    int i;
+    for (i = 0; i < typetablen; i++)
+        if (typetab[i].type == type)
+            return typetab[i].desc;
+    return "unknown";
+}
+
+enum cf_type cf_typeof (cf_t *cf)
+{
+    if (!cf)
+        return CF_UNKNOWN;
+    switch (json_typeof ((json_t *)cf)) {
+        case JSON_OBJECT:
+            if (tomltk_json_to_epoch (cf, NULL) == 0)
+                return CF_TIMESTAMP;
+            else
+                return CF_TABLE;
+        case JSON_ARRAY:
+            return CF_ARRAY;
+        case JSON_INTEGER:
+            return CF_INT64;
+        case JSON_REAL:
+            return CF_DOUBLE;
+        case JSON_TRUE:
+        case JSON_FALSE:
+            return CF_BOOL;
+        case JSON_STRING:
+            return CF_STRING;
+        default:
+            return CF_UNKNOWN;
+    }
+}
+
+cf_t *cf_get_in (cf_t *cf, const char *key)
+{
+    cf_t *val;
+
+    if (!cf || cf_typeof (cf) != CF_TABLE || !key) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(val = json_object_get (cf, key))) {
+        errno = ENOENT;
+        return NULL;
+    }
+    return val;
+
+}
+
+cf_t *cf_get_at (cf_t *cf, int index)
+{
+    cf_t *val;
+
+    if (!cf || cf_typeof (cf) != CF_ARRAY || index < 0) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(val = json_array_get (cf, index))) {
+        errno = ENOENT;
+        return NULL;
+    }
+    return val;
+}
+
+int64_t cf_int64 (cf_t *cf)
+{
+    return cf ? json_integer_value (cf) : 0;
+}
+
+double cf_double (cf_t *cf)
+{
+    return cf ? json_real_value (cf) : 0.;
+}
+
+const char *cf_string (cf_t *cf)
+{
+    const char *s = cf ? json_string_value (cf) : NULL;
+    return s ? s : "";
+}
+
+bool cf_bool (cf_t *cf)
+{
+    if (cf && json_typeof ((json_t *)cf) == JSON_TRUE)
+        return true;
+    return false;
+}
+
+time_t cf_timestamp (cf_t *cf)
+{
+    time_t t;
+    if (!cf || tomltk_json_to_epoch (cf, &t) < 0)
+        return 0;
+    return t;
+}
+
+int cf_array_size (cf_t *cf)
+{
+    return cf ? json_array_size (cf) : 0;
+}
+
+/* Parse some TOML and merge it with 'cf' object.
+ * If filename is non-NULL, take TOML from file, o/w use buf, len.
+ */
+static int update_object (cf_t *cf,
+                          const char *filename,
+                          const char *buf, int len,
+                          struct cf_error *error)
+{
+    struct tomltk_error toml_error;
+    toml_table_t *tab;
+    json_t *obj = NULL;
+    int saved_errno;
+
+    if (!cf || json_typeof ((json_t *)cf) != JSON_OBJECT) {
+        errprintf (error, filename, -1, "invalid config object");
+        errno = EINVAL;
+        return -1;
+    }
+    if (filename)
+        tab = tomltk_parse_file (filename, &toml_error);
+    else
+        tab = tomltk_parse (buf, len, &toml_error);
+    if (!tab) {
+        errprintf (error, toml_error.filename, toml_error.lineno,
+                   "%s", toml_error.errbuf);
+        goto error;
+    }
+    if (!(obj = tomltk_table_to_json (tab))) {
+        errprintf (error, filename, -1, "converting TOML to JSON: %s",
+                   strerror (errno));
+        goto error;
+    }
+    if (json_object_update (cf, obj) < 0) {
+        errprintf (error, filename, -1, "updating JSON object: out of memory",
+                   strerror (errno));
+        errno = ENOMEM;
+        goto error;
+    }
+    json_decref (obj);
+    toml_free (tab);
+    return 0;
+error:
+    saved_errno = errno;
+    toml_free (tab);
+    json_decref (obj);
+    errno = saved_errno;
+    return -1;
+}
+
+int cf_update (cf_t *cf, const char *buf, int len, struct cf_error *error)
+{
+    return update_object (cf, NULL, buf, len, error);
+}
+
+int cf_update_file (cf_t *cf, const char *filename, struct cf_error *error)
+{
+    return update_object (cf, filename, NULL, 0, error);
+}
+
+static bool is_end_marker (struct cf_option opt)
+{
+    const struct cf_option end = CF_OPTIONS_TABLE_END;
+    return (opt.key == end.key
+            && opt.type == end.type
+            && opt.required == end.required);
+}
+
+static const struct cf_option *find_option (const struct cf_option opts[],
+                                            const char *key)
+{
+    int i;
+    if (opts) {
+        for (i = 0; !is_end_marker (opts[i]); i++) {
+            if (!strcmp (opts[i].key, key))
+                return &opts[i];
+        }
+    }
+    return NULL;
+}
+
+/* Make sure all keys in 'cf' are known in 'opts'.
+ * If 'anytab' is true, keys representing tables need not be known.
+ */
+static int check_unknown_keys (cf_t *cf,
+                               const struct cf_option opts[], bool anytab,
+                               struct cf_error *error)
+{
+    void *iter;
+
+    iter = json_object_iter (cf);
+    while (iter) {
+        const char *key = json_object_iter_key (iter);
+        json_t *obj = json_object_get (cf, key);
+
+        if (!find_option (opts, key)) {
+            if (!json_is_object (obj) || !anytab) {
+                errprintf (error, NULL, -1, "key '%s' is unknown", key);
+                errno = EINVAL;
+                return -1;
+            }
+        }
+        iter = json_object_iter_next (cf, iter);
+    }
+    return 0;
+}
+
+static int check_expected_keys (cf_t *cf,
+                                const struct cf_option opts[],
+                                struct cf_error *error)
+{
+    int i;
+
+    if (opts) {
+        for (i = 0; !is_end_marker (opts[i]); i++) {
+            json_t *obj = json_object_get (cf, opts[i].key);
+
+            if (!obj && opts[i].required) {
+                errprintf (error, NULL, -1, "'%s' must be set", opts[i].key);
+                errno = EINVAL;
+                return -1;
+            }
+            if (obj && cf_typeof (obj) != opts[i].type) {
+                errprintf (error, NULL, -1, "'%s' must be of type %s",
+                           opts[i].key, cf_typedesc (opts[i].type));
+                errno = EINVAL;
+                return -1;
+            }
+        }
+    }
+    return 0;
+}
+
+int cf_check (cf_t *cf,
+              const struct cf_option opts[], int flags,
+              struct cf_error *error)
+{
+    if (!cf || json_typeof ((json_t *)cf) != JSON_OBJECT) {
+        errprintf (error, NULL, -1, "invalid config object");
+        errno = EINVAL;
+        return -1;
+    }
+    if ((flags & CF_STRICT)) {
+        if (check_unknown_keys (cf, opts, (flags & CF_ANYTAB), error) < 0)
+            return -1;
+    }
+    if (check_expected_keys (cf, opts, error) < 0)
+        return -1;
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/libutil/cf.h
+++ b/src/libutil/cf.h
@@ -1,0 +1,76 @@
+#ifndef _UTIL_CF_H
+#define _UTIL_CF_H
+
+#include <time.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <limits.h>
+
+// flags for cf_update
+enum {
+    CF_STRICT = 1,     // parse error on unknown keys
+    CF_ANYTAB = 2,     // allow unknown keys for tables only
+};
+
+// allowed types
+enum cf_type {
+    CF_UNKNOWN      = 0,
+    CF_INT64        = 1,
+    CF_DOUBLE       = 2,
+    CF_BOOL         = 3,
+    CF_STRING       = 4,
+    CF_TIMESTAMP    = 5,
+    CF_TABLE        = 6,
+    CF_ARRAY        = 7,
+};
+
+typedef void cf_t;
+
+struct cf_option {
+    const char *key;
+    enum cf_type type;
+    bool required;
+};
+#define CF_OPTIONS_TABLE_END { NULL, 0, false }
+
+struct cf_error {
+    char filename[PATH_MAX + 1];
+    int lineno;
+    char errbuf[200];
+};
+
+cf_t *cf_create (void);
+void cf_destroy (cf_t *cf);
+cf_t *cf_copy (cf_t *cf);
+enum cf_type cf_typeof (cf_t *cf);
+
+cf_t *cf_get_in (cf_t *cf, const char *key);
+cf_t *cf_get_at (cf_t *cf, int index);
+
+int64_t cf_int64 (cf_t *cf);
+double cf_double (cf_t *cf);
+const char *cf_string (cf_t *cf);
+bool cf_bool (cf_t *cf);
+time_t cf_timestamp (cf_t *cf);
+
+int cf_array_size (cf_t *cf);
+
+/* Update table 'cf' with info parsed from TOML 'buf' or 'filename'.
+ * On success return 0.  On failure, return -1 with errno set.
+ * If error is non-NULL, write error description there.
+ */
+int cf_update (cf_t *cf, const char *buf, int len, struct cf_error *error);
+int cf_update_file (cf_t *cf, const char *filename, struct cf_error *error);
+
+/* Apply 'opts' to table 'cf' according to flags.
+ * On success return 0.  On failure, return -1 with errno set.
+ * If error is non-NULL, write error description there.
+ */
+int cf_check (cf_t *cf, const struct cf_option opts[], int flags,
+              struct cf_error *error);
+
+#endif /* !_UTIL_CF_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/libutil/test/cf.c
+++ b/src/libutil/test/cf.c
@@ -1,0 +1,466 @@
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <string.h>
+#include <limits.h>
+#include <errno.h>
+#include <jansson.h>
+
+#include "src/libtap/tap.h"
+#include "cf.h"
+
+const char *t1 = \
+"i = 1\n" \
+"d = 3.14\n" \
+"s = \"foo\"\n" \
+"b = true\n" \
+"ts = 1979-05-27T07:32:00Z\n" \
+"ai = [ 1, 2, 3]\n" \
+"[tab]\n" \
+"subvalue = 42\n";
+
+const char *tab1 = \
+"[tab1]\n" \
+"id = 1\n";
+
+const char *tab2 = \
+"[tab2]\n" \
+"id = 2\n";
+
+const char *tab3 = \
+"[tab3]\n" \
+"id = 3\n";
+
+const struct cf_option opts[] = {
+    { "i", CF_INT64, true },
+    { "d", CF_DOUBLE, true },
+    { "s", CF_STRING, true },
+    { "b", CF_BOOL, true },
+    { "ts", CF_TIMESTAMP, true },
+    { "ai", CF_ARRAY, true },
+    { "tab", CF_TABLE, true },
+    CF_OPTIONS_TABLE_END,
+};
+
+const struct cf_option opts_multi[] = {
+    { "id", CF_INT64, true },
+    CF_OPTIONS_TABLE_END,
+};
+
+static time_t strtotime (const char *s)
+{
+    struct tm tm;
+    time_t t;
+    if (!strptime (s, "%FT%TZ", &tm))
+        BAIL_OUT ("strptime: %s failed", s);
+    if ((t = timegm (&tm)) < 0)
+        BAIL_OUT ("timegm: %s failed", s);
+    return t;
+}
+
+void cfdiag (int rc, const char *prefix, struct cf_error *error)
+{
+    if (rc < 0)
+        diag ("%s: %s::%d: %s", prefix,
+              error->filename, error->lineno, error->errbuf);
+}
+
+void test_basic (void)
+{
+    cf_t *cf, *cf2;
+    struct cf_error error;
+    int rc;
+    const char *s;
+    time_t t;
+
+    /* Create a new cf object.  It's type should be table.
+     */
+    cf = cf_create ();
+    ok (cf != NULL,
+        "cf_create works");
+    ok (cf_typeof (cf) == CF_TABLE,
+        "cf_typeof says empty cf is CF_TABLE");
+
+    /* Copy a cf object.
+     */
+    cf2 = cf_copy (cf);
+    ok (cf2 != NULL,
+        "cf_copy works");
+    ok (cf_typeof (cf) == CF_TABLE,
+        "cf_typeof says copy is CF_TABLE");
+    cf_destroy (cf2);
+
+    /* Read some TOML into the cf top level table
+     */
+    rc = cf_update (cf, t1, strlen (t1), &error);
+    ok (rc == 0,
+        "cf_update t1 worked");
+    cfdiag (rc, "cf_update t1", &error);
+
+    /* Check the cf object against 'opts'.
+     * All keys and their types must be declared in 'opts' (CF_STRICT).
+     */
+    rc = cf_check (cf, opts, CF_STRICT, &error);
+    ok (rc == 0,
+        "cf_check t1 worked");
+    cfdiag (rc, "cf_check t1", &error);
+
+    /* Access all the simple types and ensure they have the expected values.
+     */
+    ok (cf_int64 (cf_get_in (cf, "i")) == 1,
+        "accessed int64 value");
+    ok (cf_double (cf_get_in (cf, "d")) == 3.14,
+        "accessed double value");
+    s = cf_string (cf_get_in (cf, "s"));
+    ok (s != NULL && !strcmp (s, "foo"),
+        "accessed string value");
+    ok (cf_bool (cf_get_in (cf, "b")) == true,
+        "accessed bool value");
+    t = cf_timestamp (cf_get_in (cf, "ts"));
+    ok (t == strtotime ("1979-05-27T07:32:00Z"),
+        "accessed ts value ");
+    cf2 = cf_get_in (cf, "ai");
+
+    /* Access array and its elements.
+     */
+    ok (cf2 && cf_typeof (cf2) == CF_ARRAY,
+        "accessed array");
+    ok (cf_array_size (cf2) == 3,
+        "array has expected size");
+    ok (cf_int64 (cf_get_at (cf2, 0)) == 1
+        && cf_int64 (cf_get_at (cf2, 1)) == 2
+        && cf_int64 (cf_get_at (cf2, 2)) == 3,
+        "accessed array elements");
+
+    /* Access sub-table and its key (without cf_check on it first)
+     */
+    cf2 = cf_get_in (cf, "tab");
+    ok (cf2 && cf_typeof (cf2) == CF_TABLE,
+        "accessed table");
+    ok (cf_int64 (cf_get_in (cf2, "subvalue")) == 42,
+        "accessed value in table");
+
+    cf_destroy (cf);
+}
+
+void test_multi (void)
+{
+    cf_t *cf, *cf2;
+    int rc;
+    struct cf_error error;
+
+    if (!(cf = cf_create ()))
+        BAIL_OUT ("cf_create: %s", strerror (errno));
+
+    /* Combine three TOML config "files" into one cf.
+     */
+    rc = cf_update (cf, tab1, strlen (tab1), &error);
+    ok (rc == 0,
+        "cf_update tab1 worked");
+    cfdiag (rc, "cf_update tab1", &error);
+
+    rc = cf_update (cf, tab2, strlen (tab2), &error);
+    ok (rc == 0,
+        "cf_update tab2 worked");
+    cfdiag (rc, "cf_update tab2", &error);
+
+    rc = cf_update (cf, tab3, strlen (tab3), &error);
+    ok (rc == 0,
+        "cf_update tab3 worked");
+    cfdiag (rc, "cf_update tab3", &error);
+
+    /* check the cf object against 'opts'.
+     * Since opts=NULL, there should be no keys at this level (CF_STRICT)
+     * unless they are tables (CF_ANYTAB).
+     */
+    rc = cf_check (cf, NULL, CF_STRICT | CF_ANYTAB, &error);
+    ok (rc == 0,
+        "cf_check CF_STRICT|CF_ANYTAB worked");
+    cfdiag (rc, "cf_check multi", &error);
+
+    /* Check first subtable against 'opts_multi' and access content.
+     */
+    cf2 = cf_get_in (cf, "tab1");
+    ok (cf2 && cf_typeof (cf2) == CF_TABLE,
+        "accessed tab1");
+    rc = cf_check (cf2, opts_multi, CF_STRICT, &error);
+    ok (rc == 0,
+        "cf_check tab1 worked");
+    cfdiag (rc, "cf_check tab1", &error);
+    ok (cf_int64 (cf_get_in (cf2, "id")) == 1,
+        "tab1 id key has correct value");
+
+    /* Check second subtable against 'opts_multi' and access content.
+     */
+    cf2 = cf_get_in (cf, "tab2");
+    ok (cf2 && cf_typeof (cf2) == CF_TABLE,
+        "accessed tab2");
+    rc = cf_check (cf2, opts_multi, CF_STRICT, &error);
+    ok (rc == 0,
+        "cf_check tab2 worked");
+    cfdiag (rc, "cf_check tab2", &error);
+    ok (cf_int64 (cf_get_in (cf2, "id")) == 2,
+        "tab2 id key has correct value");
+
+    /* Check third subtable against 'opts_multi' and access content.
+     */
+    cf2 = cf_get_in (cf, "tab3");
+    ok (cf2 && cf_typeof (cf2) == CF_TABLE,
+        "accessed tab3");
+    rc = cf_check (cf2, opts_multi, CF_STRICT, &error);
+    ok (rc == 0,
+        "cf_check tab3 worked");
+    cfdiag (rc, "cf_check tab3", &error);
+    ok (cf_int64 (cf_get_in (cf2, "id")) == 3,
+        "tab3 id key has correct value");
+
+    cf_destroy (cf);
+}
+
+void test_corner (void)
+{
+    cf_t *cf;
+    cf_t *cf_array;
+    struct cf_error error;
+
+    if (!(cf = cf_create ()))
+        BAIL_OUT ("cf_create setup failed");
+    const char *toml = "foo = [1,2,3]";
+    if (cf_update (cf, toml, strlen (toml), NULL) < 0)
+        BAIL_OUT ("cf_update setup failed");
+    if (!(cf_array = cf_get_in (cf, "foo")))
+        BAIL_OUT ("cf_get_in setup failed ");
+
+    /* cf_check
+     */
+    errno = 0;
+    ok (cf_check (NULL, NULL, 0, &error) < 0 && errno == EINVAL,
+         "cf_check cf=NULL fails with EINVAL");
+    errno = 0;
+    ok (cf_check (cf_array, NULL, 0, &error) < 0 && errno == EINVAL,
+         "cf_check cf=(not table) fails with EINVAL");
+
+    /* cf_update
+     */
+    errno = 0;
+    ok (cf_update (NULL, NULL, 0, &error) < 0 && errno == EINVAL,
+        "cf_update cf=NULL fails with EINVAL");
+    errno = 0;
+    ok (cf_update (cf_array, NULL, 0, &error) < 0 && errno == EINVAL,
+        "cf_update cf=(not table) fails with EINVAL");
+    ok (cf_update (cf, NULL, 0, &error) == 0,
+        "cf_update buf=NULL works (no-op)");
+    errno = 0;
+    const char *junk = ",]foo";
+    ok (cf_update (cf, junk, strlen (junk), &error) < 0 && errno == EINVAL,
+        "cf_update buf=\"%s\" fails with EINVAL", junk);
+
+    /* cf_get_in
+     */
+    errno = 0;
+    ok (cf_get_in (NULL, "foo") == NULL && errno == EINVAL,
+        "cf_get_in cf=NULL fails with EINVAL");
+    errno = 0;
+    ok (cf_get_in (cf_array, "foo") == NULL && errno == EINVAL,
+        "cf_get_in cf=(not table) fails with EINVAL");
+    errno = 0;
+    ok (cf_get_in (cf, NULL) == NULL && errno == EINVAL,
+        "cf_get_in key=NULL fails with EINVAL");
+    errno = 0;
+    ok (cf_get_in (cf, "bar") == NULL && errno == ENOENT,
+        "cf_get_in key=(unknown) fails wtih ENOENT");
+
+    /* cf_get_at
+     */
+    errno = 0;
+    ok (cf_get_at (NULL, 0) == NULL && errno == EINVAL,
+        "cf_get_at cf=NULL fails with EINVAL");
+    errno = 0;
+    ok (cf_get_at (cf, 0) == NULL && errno == EINVAL,
+        "cf_get_at cf=(not array) fails with EINVAL");
+    errno = 0;
+    ok (cf_get_at (cf_array, -1) == NULL && errno == EINVAL,
+        "cf_get_at index=-1 fails with EINVAL");
+    errno = 0;
+    ok (cf_get_at (cf_array, 4) == NULL && errno == ENOENT,
+        "cf_get_at index=(too big) fails with ENOENT");
+
+    /* cf_copy
+     */
+    errno = 0;
+    ok (cf_copy (NULL) == NULL && errno == EINVAL,
+        "cf_copy cf=NULL fails with EINVAL");
+
+    /* cf_typeof
+     */
+    ok (cf_typeof (NULL) == CF_UNKNOWN,
+        "cf_typeof cf=NULL returns CF_UNKNOWN");
+
+    /* simple accessors
+     */
+    ok (cf_int64 (NULL) == 0,
+        "cf_int64 cf=NULL returns 0");
+    ok (cf_double (NULL) == 0.,
+        "cf_double cf=NULL returns 0.");
+    ok (strlen (cf_string (NULL)) == 0,
+        "cf_string cf=NULL returns \"\"");
+    ok (cf_bool (NULL) == false,
+        "cf_bool cf=NULL returns false");
+    ok (cf_timestamp (NULL) == 0,
+        "cf_timestamp cf=NULL returns 0");
+
+    /* cf_array_size
+     */
+    ok (cf_array_size (NULL) == 0,
+        "cf_array_size cf=NULL returns 0");
+    ok (cf_array_size (cf) == 0,
+        "cf_array_size cf=(not array) returns 0");
+
+    cf_destroy (cf);
+}
+
+const struct cf_option opts_extra[] = { // for 't1'
+    // { "i", CF_INT64, true },
+    { "d", CF_DOUBLE, true },
+    { "s", CF_STRING, true },
+    { "b", CF_BOOL, true },
+    { "ts", CF_TIMESTAMP, true },
+    { "ai", CF_ARRAY, true },
+    { "tab", CF_TABLE, true },
+    CF_OPTIONS_TABLE_END,
+};
+
+const struct cf_option opts_missing[] = { // for 't1'
+    { "i", CF_INT64, true },
+    { "d", CF_DOUBLE, true },
+    { "s", CF_STRING, true },
+    { "b", CF_BOOL, true },
+    { "ts", CF_TIMESTAMP, true },
+    { "ai", CF_ARRAY, true },
+    { "tab", CF_TABLE, true },
+    { "smurf", CF_INT64, true },
+    CF_OPTIONS_TABLE_END,
+};
+
+const struct cf_option opts_optional[] = { // for 't1'
+    { "i", CF_INT64, true },
+    { "d", CF_DOUBLE, true },
+    { "s", CF_STRING, true },
+    { "b", CF_BOOL, true },
+    { "ts", CF_TIMESTAMP, true },
+    { "ai", CF_ARRAY, true },
+    { "tab", CF_TABLE, true },
+    { "smurf", CF_INT64, false },
+    CF_OPTIONS_TABLE_END,
+};
+
+const struct cf_option opts_wrongtype[] = { // for 't1'
+    { "i", CF_DOUBLE , true }, // changed type
+    { "d", CF_DOUBLE, true },
+    { "s", CF_STRING, true },
+    { "b", CF_BOOL, true },
+    { "ts", CF_TIMESTAMP, true },
+    { "ai", CF_ARRAY, true },
+    { "tab", CF_TABLE, true },
+    CF_OPTIONS_TABLE_END,
+};
+
+void test_update_file (void)
+{
+    char path[PATH_MAX + 1];
+    const char *tmpdir = getenv ("TMPDIR");
+    int fd;
+    cf_t *cf;
+    struct cf_error error;
+
+    if (!(cf = cf_create ()))
+        BAIL_OUT ("cf_create: %s", strerror (errno));
+
+    snprintf (path, sizeof (path), "%s/cf.XXXXXX", tmpdir ? tmpdir : "/tmp");
+    fd = mkstemp (path);
+    if (fd < 0)
+        BAIL_OUT ("mkstemp %s: %s", path, strerror (errno));
+    if (write (fd, t1, strlen (t1)) != strlen (t1))
+        BAIL_OUT ("write %s: %s", path, strerror (errno));
+    if (close (fd) < 0)
+        BAIL_OUT ("close %s: %s", path, strerror (errno));
+
+    ok (cf_update_file (cf, path, &error) == 0,
+        "cf_update_file works");
+    errno = 0;
+    ok (cf_update_file (cf, "/noexist", &error) < 0 && errno == ENOENT,
+        "cf_update_file fails on nonexistent file");
+
+    if (unlink (path) < 0)
+        BAIL_OUT ("unlink %s: %s", path, strerror (errno));
+    cf_destroy (cf);
+}
+
+void test_check (void)
+{
+    cf_t *cf;
+    struct cf_error error;
+    int rc;
+
+    if (!(cf = cf_create ()))
+        BAIL_OUT ("cf_create");
+    if (cf_update (cf, t1, strlen (t1), NULL) < 0)
+        BAIL_OUT ("cf_update");
+
+    /* Extra key.
+     */
+    rc = cf_check (cf, opts_extra, 0, &error);
+    ok (rc == 0,
+        "cf_check flags=0 allows extra key");
+    cfdiag (rc, "cf_check", &error);
+
+    errno = 0;
+    rc = cf_check (cf, opts_extra, CF_STRICT, &error);
+    ok (rc < 0 && errno == EINVAL,
+        "cf_check flags=CF_STRICT fails with extra key");
+    cfdiag (rc, "cf_check", &error);
+
+    /* Missing key.
+     */
+    errno = 0;
+    rc = cf_check (cf, opts_missing, 0, &error);
+    ok (rc < 0 && errno == EINVAL,
+        "cf_check fails on missing required key with EINVAL");
+    cfdiag (rc, "cf_check", &error);
+
+    rc = cf_check (cf, opts_optional, 0, &error);
+    ok (rc == 0,
+        "cf_check succeeds on missing optional key");
+    cfdiag (rc, "cf_check", &error);
+
+    /* Wrong type
+     */
+    errno = 0;
+    rc = cf_check (cf, opts_wrongtype, 0, &error);
+    ok (rc < 0 && errno == EINVAL,
+        "cf_check fails on wrong type");
+    cfdiag (rc, "cf_check", &error);
+
+    cf_destroy (cf);
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    test_basic ();
+    test_multi ();
+    test_corner ();
+    test_update_file ();
+    test_check ();
+
+    done_testing ();
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/libutil/test/tomltk.c
+++ b/src/libutil/test/tomltk.c
@@ -1,0 +1,261 @@
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <string.h>
+#include <limits.h>
+#include <errno.h>
+#include <jansson.h>
+
+#include "src/libtap/tap.h"
+#include "src/libtomlc99/toml.h"
+#include "tomltk.h"
+
+/* simple types only */
+const char *t1 = \
+"i = 1\n" \
+"d = 3.14\n" \
+"s = \"foo\"\n" \
+"b = true\n" \
+"ts = 1979-05-27T07:32:00Z\n";
+
+/* table and array */
+const char *t2 = \
+"[t]\n" \
+"ia = [1, 2, 3]\n";
+
+/* sub-table and value */
+const char *t3 = \
+"[t]\n" \
+"[t.a]\n" \
+"i = 42\n";
+
+/* bad on line 4 */
+const char *bad1 = \
+"# line 1\n" \
+"# line 2\n" \
+"# line 3\n" \
+"'# line 4 <- unbalanced tic\n"
+"# line 5\n";
+
+static void jdiag (const char *prefix, json_t *obj)
+{
+    char *s = json_dumps (obj, JSON_INDENT(2));
+    if (!s)
+        BAIL_OUT ("json_dumps: %s", strerror (errno));
+    diag ("%s: %s", prefix, s);
+    free (s);
+}
+
+/* Check whether json object represents to ISO 8601 time string.
+ */
+static bool check_ts (json_t *ts, const char *timestr)
+{
+    time_t t;
+    struct tm tm;
+    char buf[80];
+
+    if (tomltk_json_to_epoch (ts, &t) < 0)
+        return false;
+    if (!gmtime_r (&t, &tm))
+        return false;
+    if (strftime (buf, sizeof (buf), "%FT%TZ", &tm) == 0)
+        return false;
+    diag ("%s: %s ?= %s", __FUNCTION__, buf, timestr);
+    return !strcmp (buf, timestr);
+}
+
+void test_json_ts(void)
+{
+    time_t t, t2;
+    json_t *obj;
+
+    /* Encode the current time, then decode and ensure it matches.
+     */
+    if (time (&t) < 0)
+        BAIL_OUT ("time: %s", strerror (errno));
+    obj = tomltk_epoch_to_json (t);
+    ok (obj != NULL,
+        "tomltk_epoch_to_json works");
+
+    ok (tomltk_json_to_epoch (obj, &t2) == 0 && t == t2,
+        "tomltk_json_to_epoch works, correct value");
+}
+
+void test_tojson_t1 (void)
+{
+    toml_table_t *tab;
+    json_t *obj;
+    json_int_t i;
+    double d;
+    const char *s;
+    json_t *ts;
+    int b;
+    int rc;
+    struct tomltk_error error;
+
+    tab = tomltk_parse (t1, strlen (t1), &error);
+    ok (tab != NULL,
+        "t1: tomltk_parse works");
+    if (!tab)
+        BAIL_OUT ("t1: parse error line %d: %s", error.lineno, error.errbuf);
+
+    obj = tomltk_table_to_json (tab);
+    ok (obj != NULL,
+        "t1: tomltk_table_to_json works");
+    jdiag ("t1", obj);
+    rc = json_unpack (obj, "{s:I s:f s:s s:b s:o}",
+                     "i", &i,
+                     "d", &d,
+                     "s", &s,
+                     "b", &b,
+                     "ts", &ts);
+    ok (rc == 0,
+        "t1: unpack successful");
+    ok (i == 1 && d == 3.14 && s != NULL && !strcmp (s, "foo") && b != 0
+        && check_ts (ts, "1979-05-27T07:32:00Z"),
+        "t1: has expected values");
+    json_decref (obj);
+    toml_free (tab);
+}
+
+void test_tojson_t2 (void)
+{
+    toml_table_t *tab;
+    json_t *obj;
+    json_int_t ia[3];
+    int rc;
+    struct tomltk_error error;
+
+    tab = tomltk_parse (t2, strlen (t2), &error);
+    ok (tab != NULL,
+        "t2: tomltk_parse works");
+    if (!tab)
+        BAIL_OUT ("t2: parse error line %d: %s", error.lineno, error.errbuf);
+
+    obj = tomltk_table_to_json (tab);
+    ok (obj != NULL,
+        "t2: tomltk_table_to_json works");
+    jdiag ("t2", obj);
+    rc = json_unpack (obj, "{s:{s:[I,I,I]}}",
+                     "t",
+                       "ia", &ia[0], &ia[1], &ia[2]);
+    ok (rc == 0,
+        "t2: unpack successful");
+    ok (ia[0] == 1 && ia[1] == 2 && ia[2] == 3,
+        "t2: has expected values");
+    json_decref (obj);
+    toml_free (tab);
+}
+
+void test_tojson_t3 (void)
+{
+    toml_table_t *tab;
+    json_t *obj;
+    json_int_t i;
+    int rc;
+    struct tomltk_error error;
+
+    tab = tomltk_parse (t3, strlen (t3), &error);
+    ok (tab != NULL,
+        "t3: tomltk_parse works");
+    if (!tab)
+        BAIL_OUT ("t3: parse error line %d: %s", error.lineno, error.errbuf);
+
+    obj = tomltk_table_to_json (tab);
+    ok (obj != NULL,
+        "t3: tomltk_table_to_json works");
+    jdiag ("t3", obj);
+    rc = json_unpack (obj, "{s:{s:{s:I}}}",
+                     "t",
+                       "a",
+                         "i", &i);
+    ok (rc == 0,
+        "t3: unpack successful");
+    ok (i == 42,
+        "t3: has expected values");
+    json_decref (obj);
+    toml_free (tab);
+}
+
+void test_parse_lineno (void)
+{
+    toml_table_t *tab;
+    struct tomltk_error error;
+
+    errno = 0;
+    tab = tomltk_parse (bad1, strlen (bad1), &error);
+    if (!tab)
+        diag ("filename='%s' lineno=%d msg='%s'", error.filename,
+              error.lineno, error.errbuf);
+    ok (tab == NULL && errno == EINVAL,
+        "bad1: parse failed");
+    ok (strlen (error.filename) == 0,
+        "bad1: error.filename is \"\"");
+    ok (error.lineno == 4,
+        "bad1: error.lineno is 4");
+    const char *msg = "unterminated s-quote";
+    ok (!strcmp (error.errbuf, msg),
+        "bad1: error is \"%s\"", msg); // no "line %d: " prefix
+}
+
+void test_corner (void)
+{
+    time_t t;
+    json_t *obj;
+
+    if (!(obj = tomltk_epoch_to_json (time (NULL))))
+        BAIL_OUT ("tomltk_epoch_to_json now: %s", strerror (errno));
+
+    errno = 0;
+    ok (tomltk_parse_file (NULL, NULL) == NULL && errno == EINVAL,
+        "tomltk_parse_file filename=NULL fails with EINVAL");
+    errno = 0;
+    ok (tomltk_parse ("foo", -1, NULL) == NULL  && errno == EINVAL,
+        "tomltk_parse len=-1 fails with EINVAL");
+    errno = 0;
+    ok (tomltk_table_to_json (NULL) == NULL && errno == EINVAL,
+        "tomltk_table_to_json NULL fails with EINVAL");
+
+    errno = 0;
+    ok (tomltk_json_to_epoch (NULL,  &t) < 0 && errno == EINVAL,
+        "tomltk_json_to_epoch obj=NULL fails with EINVAL");
+
+    errno = 0;
+    ok (tomltk_ts_to_epoch (NULL, NULL) < 0 && errno == EINVAL,
+        "tomltk_ts_to_epoch ts=NULL fails with EINVAL");
+
+    errno = 0;
+    ok (tomltk_epoch_to_json (-1) == NULL && errno == EINVAL,
+        "tomltk_epoch_to_json t=-1 fails with EINVAL");
+
+    errno = 0;
+    ok (tomltk_parse_file (NULL, NULL) == NULL && errno == EINVAL,
+        "tomltk_parse_file filename=NULL fails with EINVAL");
+    errno = 0;
+    ok (tomltk_parse_file ("/noexist", NULL) == NULL && errno == ENOENT,
+        "tomltk_parse_file filename=(noexist) fails with ENOENT");
+
+    json_decref (obj);
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    test_json_ts ();
+    test_tojson_t1 ();
+    test_tojson_t2 ();
+    test_tojson_t3 ();
+    test_parse_lineno ();
+    test_corner ();
+
+    done_testing ();
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/libutil/tomltk.c
+++ b/src/libutil/tomltk.c
@@ -1,0 +1,382 @@
+/*****************************************************************************\
+ *  Copyright (c) 2017 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
+
+#include <time.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <errno.h>
+#include <string.h>
+#include <jansson.h>
+
+#include "src/libtomlc99/toml.h"
+#include "tomltk.h"
+
+static int table_to_json (toml_table_t *tab, json_t **op);
+
+static void errprintf (struct tomltk_error *error,
+                       const char *filename, int lineno,
+                       const char *fmt, ...)
+{
+    va_list ap;
+    int saved_errno = errno;
+
+    if (error) {
+        memset (error, 0, sizeof (*error));
+        va_start (ap, fmt);
+        (void)vsnprintf (error->errbuf, sizeof (error->errbuf), fmt, ap);
+        va_end (ap);
+        if (filename)
+            strncpy (error->filename, filename, PATH_MAX);
+        error->lineno = lineno;
+    }
+    errno = saved_errno;
+}
+
+/* Given an error message response from toml_parse(), parse the
+ * error message into line number and message, e.g.
+ *   "line 42: bad key"
+ * is parsed to:
+ *   error->lineno=42, error->errbuf="bad key"
+ */
+static void errfromtoml (struct tomltk_error *error,
+                         const char *filename, char *errstr)
+{
+    if (error) {
+        char *msg = errstr;
+        int lineno = -1;
+        if (!strncmp (errstr, "line ", 5)) {
+            lineno = strtoul (errstr + 5, &msg, 10);
+            if (!strncmp (msg, ": ", 2))
+                msg += 2;
+        }
+        return errprintf (error, filename, lineno, "%s", msg);
+    }
+}
+
+/* Convert time_t (GMT) to ISO 8601 timestamp string,
+ * e.g. "2003-08-24T05:14:50Z"
+ */
+static int timetostr (time_t t, char *buf, int size)
+{
+    struct tm tm;
+    if (t < 0 || !gmtime_r (&t, &tm))
+        return -1;
+    if (strftime (buf, size, "%FT%TZ", &tm) == 0)
+        return -1;
+    return 0;
+}
+
+/* Convert from ISO 8601 string to time_t.
+ */
+static int strtotime (const char *s, time_t *tp)
+{
+    struct tm tm;
+    time_t t;
+    if (!strptime (s, "%FT%TZ", &tm))
+        return -1;
+    if ((t = timegm (&tm)) < 0)
+        return -1;
+    if (tp)
+        *tp = t;
+    return 0;
+}
+
+/* Convert from TOML timestamp to struct tm (POSIX broken out time).
+ */
+static int tstotm (toml_timestamp_t *ts, struct tm *tm)
+{
+    if (!ts || !tm || !ts->year || !ts->month || !ts->day
+                   || !ts->hour  || !ts->minute || !ts->second)
+        return -1;
+    memset (tm, 0, sizeof (*tm));
+    tm->tm_year = *ts->year - 1900;
+    tm->tm_mon = *ts->month - 1;
+    tm->tm_mday = *ts->day;
+    tm->tm_hour = *ts->hour;
+    tm->tm_min = *ts->minute;
+    tm->tm_sec = *ts->second;
+    return 0;
+}
+
+int tomltk_ts_to_epoch (toml_timestamp_t *ts, time_t *tp)
+{
+    struct tm tm;
+    time_t t;
+
+    if (!ts || tstotm (ts, &tm) < 0 || (t = timegm (&tm)) < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (tp)
+        *tp = t;
+    return 0;
+}
+
+int tomltk_json_to_epoch (json_t *obj, time_t *tp)
+{
+    const char *s;
+
+    if (!obj || json_unpack (obj, "{s:s}", "iso-8601-ts", &s) < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (strtotime (s, tp) < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    return 0;
+}
+
+json_t *tomltk_epoch_to_json (time_t t)
+{
+    char timebuf[80];
+    json_t *obj;
+
+    if (timetostr (t, timebuf, sizeof (timebuf)) < 0) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(obj = json_pack ("{s:s}", "iso-8601-ts", timebuf))) {
+        errno = EINVAL;
+        return NULL;
+    }
+    return obj;
+}
+
+/* Convert raw TOML value from toml_raw_in() or toml_raw_at() to JSON.
+ */
+static int value_to_json (const char *raw, json_t **op)
+{
+    char *s = NULL;
+    int b;
+    int64_t i;
+    double d;
+    toml_timestamp_t ts;
+    json_t *obj;
+
+    if (toml_rtos (raw, &s) == 0) {
+        obj = json_string (s);
+        free (s);
+        if (!obj)
+            goto nomem;
+    }
+    else if (toml_rtob (raw, &b) == 0) {
+        if (!(obj = b ? json_true () : json_false ()))
+            goto nomem;
+    }
+    else if (toml_rtoi (raw, &i) == 0) {
+        if (!(obj = json_integer (i)))
+            goto nomem;
+    }
+    else if (toml_rtod (raw, &d) == 0) {
+        if (!(obj = json_real (d)))
+            goto nomem;
+    }
+    else if (toml_rtots (raw, &ts) == 0) {
+        time_t t;
+        if (tomltk_ts_to_epoch (&ts, &t) < 0
+                || !(obj = tomltk_epoch_to_json (t)))
+            goto error;
+    }
+    else {
+        errno = EINVAL;
+        goto error;
+    }
+    *op = obj;
+    return 0;
+nomem:
+    errno = ENOMEM;
+error:
+    return -1;
+}
+
+/* Convert TOML array to JSON.
+ */
+static int array_to_json (toml_array_t *arr, json_t **op)
+{
+    int i;
+    int saved_errno;
+    json_t *obj;
+
+    if (!(obj = json_array ()))
+        goto nomem;
+    for (i = 0; ; i++) {
+        const char *raw;
+        json_t *val;
+        toml_table_t *tab;
+        toml_array_t *subarr;
+
+        if ((raw = toml_raw_at (arr, i))) {
+            if (value_to_json (raw, &val) < 0)
+                goto error;
+        }
+        else if ((tab = toml_table_at (arr, i))) {
+            if (table_to_json (tab, &val) < 0)
+                goto error;
+        }
+        else if ((subarr = toml_array_at (arr, i))) {
+            if (array_to_json (subarr, &val) < 0)
+                goto error;
+        }
+        else
+            break;
+        if (json_array_append_new (obj, val) < 0) {
+            json_decref (val);
+            goto nomem;
+        }
+    }
+    *op = obj;
+    return 0;
+nomem:
+    errno = ENOMEM;
+error:
+    saved_errno = errno;
+    json_decref (obj);
+    errno = saved_errno;
+    return -1;
+}
+
+/* Convert TOML table to JSON.
+ */
+static int table_to_json (toml_table_t *tab, json_t **op)
+{
+    int i;
+    int saved_errno;
+    json_t *obj;
+
+    if (!(obj = json_object ()))
+        goto nomem;
+    for (i = 0; ; i++) {
+        const char *key;
+        const char *raw;
+        toml_table_t *subtab;
+        toml_array_t *arr;
+        json_t *val = NULL;
+
+        if (!(key = toml_key_in (tab, i)))
+            break;
+        if ((raw = toml_raw_in (tab, key))) {
+            if (value_to_json (raw, &val) < 0)
+                goto error;
+        }
+        else if ((subtab = toml_table_in (tab, key))) {
+            if (table_to_json (subtab, &val) < 0)
+                goto error;
+        }
+        else if ((arr = toml_array_in (tab, key))) {
+            if (array_to_json (arr, &val) < 0)
+                goto error;
+        }
+        if (json_object_set_new (obj, key, val) < 0) {
+            json_decref (val);
+            goto nomem;
+        }
+    }
+    *op = obj;
+    return 0;
+nomem:
+    errno = ENOMEM;
+error:
+    saved_errno = errno;
+    json_decref (obj);
+    errno = saved_errno;
+    return -1;
+}
+
+json_t *tomltk_table_to_json (toml_table_t *tab)
+{
+    json_t *obj;
+
+    if (!tab) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (table_to_json (tab, &obj) < 0)
+        return NULL;
+    return obj;
+}
+
+toml_table_t *tomltk_parse (const char *conf, int len,
+                            struct tomltk_error *error)
+{
+    char errbuf[200];
+    char *cpy;
+    toml_table_t *tab;
+
+    if (len < 0 || (!conf && len != 0)) {
+        errprintf (error, NULL, -1, "invalid argument");
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(cpy = calloc (1, len + 1))) {
+        errprintf (error, NULL, -1, "out of memory");
+        errno = ENOMEM;
+        return NULL;
+    }
+    memcpy (cpy, conf, len);
+    tab = toml_parse (cpy, errbuf, sizeof (errbuf));
+    free (cpy);
+    if (!tab) {
+        errfromtoml (error, NULL, errbuf);
+        errno = EINVAL;
+        return NULL;
+    }
+    return tab;
+}
+
+toml_table_t *tomltk_parse_file (const char *filename,
+                                 struct tomltk_error *error)
+{
+    char errbuf[200];
+    FILE *fp;
+    toml_table_t *tab;
+
+    if (!filename) {
+        errprintf (error, NULL, -1, "invalid argument");
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(fp = fopen (filename, "r"))) {
+        errprintf (error, filename, -1, "%s", strerror (errno));
+        return NULL;
+    }
+    // N.B. toml_parse_file() doesn't give us any way to distinguish parse
+    // error from read error
+    tab = toml_parse_file (fp, errbuf, sizeof (errbuf));
+    (void)fclose (fp);
+    if (!tab) {
+        errfromtoml (error, filename, errbuf);
+        errno = EINVAL;
+        return NULL;
+    }
+    return tab;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/libutil/tomltk.h
+++ b/src/libutil/tomltk.h
@@ -1,0 +1,60 @@
+#ifndef _UTIL_TOMLTK_H
+#define _UTIL_TOMLTK_H
+
+/* tomltk - toolkit for tomlc99 and jansson */
+
+#include <jansson.h>
+#include <time.h>
+#include <limits.h>
+#include "src/libtomlc99/toml.h"
+
+struct tomltk_error {
+    char filename[PATH_MAX + 1];
+    int lineno;
+    char errbuf[200];
+};
+
+// TOML timestamp is represented as JSON object like this:
+//   { "iso-8601-ts" : "2003-08-24T05:14:50Z" }
+
+/* Convert TOML table to a JSON object.
+ * Return new object on success, NULL on failure with errno set.
+ */
+json_t *tomltk_table_to_json (toml_table_t *tab);
+
+/* Convert timestamp JSON object to a time_t (UTC).
+ * Return 0 on success, or -1 on failure with errno set.
+ */
+int tomltk_json_to_epoch (json_t *obj, time_t *t);
+
+/* Convert time_t (UTC) to a timestamp JSON object.
+ * Return new object on success, NULL on failure with errno set.
+ */
+json_t *tomltk_epoch_to_json (time_t t);
+
+/* Convert TOML timestamp to a time_t (UTC)
+ * Return 0 on success, or -1 on failure with errno set.
+ */
+int tomltk_ts_to_epoch (toml_timestamp_t *ts, time_t *tp);
+
+/* Wrapper for toml_parse() that internally copies 'conf',
+ * adding NULL termination.  On success, 0 is returned.
+ * On failure -1 is returned with errno set.  If 'error' is
+ * non-NULL, an error description is written there.
+ */
+toml_table_t *tomltk_parse (const char *conf, int len,
+                            struct tomltk_error *error);
+
+/* Wrapper for toml_parse_file() that internally
+ * opens/closes 'filename'.  On success, 0 is returned.
+ * On failure -1 is returned with errno set.  If 'error' is
+ * non-NULL, and error description is written there.
+ */
+toml_table_t *tomltk_parse_file (const char *filename,
+                                 struct tomltk_error *error);
+
+#endif /* !_UTIL_TOMLTK_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */


### PR DESCRIPTION
This is a first cut at a config class.  It has no tests - I'm posting it for early review of API and concepts.  Here's the header for convenient reference:

```c// flags for cf_table_update
enum {
    CF_STRICT = 1,     // parse error on unknown keys
    CF_ANYTAB = 2,     // allow unknown keys if they are tables
};

// allowed types
// CF_ARRAY | <type> means array of <type> elements, where <type>
// is any type except CF_UNKNOWN, CF_TABLE, or CF_ARRAY.
enum cf_type {
    CF_UNKNOWN      = 0,
    CF_TABLE        = 1,
    CF_INT64        = 2,
    CF_DOUBLE       = 3,
    CF_BOOL         = 4,
    CF_TIMESTAMP    = 5,
    CF_STRING       = 6,
    CF_ARRAY        = 0x10,
};

struct cf_table;

struct cf_option {
    const char *key;
    enum cf_type type;
    bool required;
};
#define CF_OPTIONS_TABLE_END { NULL, 0, false }

/* Create an empty table.
 * Returns table on success, or NULL on failure with errno set.
 */
struct cf_table *cf_table_create (void);

/* Destroy a table.
 */
void cf_table_destroy (struct cf_table *cf);

/* Copy a table
 */
struct cf_table *cf_table_copy (const struct cf_table *cf);

/* cf_table_strerror() returns a descriptive error message.  It is valid when
 * cf_table_update() or cf_table_parse() return -1 with errno set to EINVAL.
 */
const char *cf_table_strerror (const struct cf_table *cf);

/* Update table 'cf' with info parsed from TOML 'buf'.
 * On success return 0.  On failure, return -1 with errno set.
 * (If errno == EINVAL, call cf_table_strerror() for descriptive error message).
 */
int cf_table_update (struct cf_table *cf, const char *buf);

/* Apply 'opts' to table 'cf' according to flags.
 * On success return 0.  On failure, return -1 with errno set.
 * (If errno == EINVAL, call cf_table_strerror() for descriptive error message).
 */
int cf_table_parse (struct cf_table *cf,
                    const struct cf_option opts[], int flags);

/* Get sub-table of 'cf' identified by 'key'.  The new table is assigned
 * to 'val' and is a standalone copy that must be freed with cf_table_destroy.
 * Returns 0 on success, or -1 on failure with errno set.
 */
int cf_table_get_table (const struct cf_table *cf,
                        const char *key, struct cf_table **val);

/* Simple accessors for values
 */
int cf_table_get_int64 (const struct cf_table *cf,
                        const char *key, int64_t *val);
int cf_table_get_double (const struct cf_table *cf,
                         const char *key, double *val);
int cf_table_get_bool (const struct cf_table *cf,
                       const char *key, bool *val);
int cf_table_get_timestamp (const struct cf_table *cf,
                            const char *key, time_t *val);
int cf_table_get_string (const struct cf_table *cf,
                         const char *key, const char **val);

/* Simple accessors for array elements.
 */
int cf_table_get_array_size (const struct cf_table *cf,
                             const char *key, int *size);
int cf_table_get_array_int64 (const struct cf_table *cf,
                              const char *key, int index, int64_t *val);
int cf_table_get_array_double (const struct cf_table *cf,
                               const char *key, int index, double *val);
int cf_table_get_array_bool (const struct cf_table *cf,
                             const char *key, int index, bool *val);
int cf_table_get_array_timestamp (const struct cf_table *cf,
                                  const char *key, int index, time_t *val);
int cf_table_get_array_string (const struct cf_table *cf,
                               const char *key, int index, const char **val);
```

