### PR TITLE
add simple key=val encoding capability

### DIFF
--- a/src/libutil/Makefile.am
+++ b/src/libutil/Makefile.am
@@ -30,7 +30,8 @@ TESTS = \
 	test_base64.t \
 	test_hash.t \
 	test_tomltk.t \
-	test_cf.t
+	test_cf.t \
+	test_kv.t
 
 test_ldadd = \
 	$(top_builddir)/src/libutil/libutil.la \
@@ -62,3 +63,7 @@ test_tomltk_t_LDADD = $(test_ldadd)
 test_cf_t_SOURCES = test/cf.c
 test_cf_t_CPPFLAGS = $(test_cppflags)
 test_cf_t_LDADD = $(test_ldadd)
+
+test_kv_t_SOURCES = test/kv.c
+test_kv_t_LDADD = $(test_ldadd)
+test_kv_t_CPPFLAGS = $(test_cppflags)

--- a/src/libutil/Makefile.am
+++ b/src/libutil/Makefile.am
@@ -22,7 +22,9 @@ libutil_la_SOURCES = \
 	tomltk.c \
 	tomltk.h \
 	cf.c \
-	cf.h
+	cf.h \
+	kv.c \
+	kv.h
 
 TESTS = \
 	test_base64.t \

--- a/src/libutil/kv.c
+++ b/src/libutil/kv.c
@@ -1,0 +1,392 @@
+/*****************************************************************************\
+ *  Copyright (c) 2017 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <assert.h>
+
+#include "base64.h"
+#include "kv.h"
+
+#define KV_CHUNK 4096
+
+struct kv {
+    char *buf;
+    int bufsz;
+    int len;
+    char *base64;
+};
+
+void kv_destroy (struct kv *kv)
+{
+    if (kv) {
+        int saved_errno = errno;
+        free (kv->buf);
+        free (kv->base64);
+        free (kv);
+        errno = saved_errno;
+    }
+}
+
+static struct kv *kv_create_from (const char *buf, int len)
+{
+    struct kv *kv;
+
+    if (len < 0 || (len > 0 && !buf)) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(kv = calloc (1, sizeof (*kv))))
+        return NULL;
+    if (len > 0) {
+        if (!(kv->buf = malloc (len))) {
+            kv_destroy (kv);
+            return NULL;
+        }
+        memcpy (kv->buf, buf, len);
+        kv->bufsz = kv->len = len;
+    }
+    return kv;
+}
+
+struct kv *kv_create (void)
+{
+    return kv_create_from (NULL, 0);
+}
+
+struct kv *kv_copy (const struct kv *kv)
+{
+    if (!kv) {
+        errno = EINVAL;
+        return NULL;
+    }
+    return kv_create_from (kv->buf, kv->len);
+}
+
+bool kv_equal (const struct kv *kv1, const struct kv *kv2)
+{
+    if (!kv1 || !kv2)
+        return false;
+    if (kv1->len != kv2->len)
+        return false;
+    if (memcmp (kv1->buf, kv2->buf, kv1->len) != 0)
+        return false;
+    return true;
+}
+
+/* Grow kv buffer until it can accommodate 'needsz' new characters.
+ */
+static int kv_expand (struct kv *kv, int needsz)
+{
+    char *new;
+    while (kv->bufsz - kv->len < needsz) {
+        if (!(new = realloc (kv->buf, kv->bufsz + KV_CHUNK)))
+            return -1;
+        kv->buf = new;
+        kv->bufsz += KV_CHUNK;
+    }
+    return 0;
+}
+
+static bool valid_key (const char *key)
+{
+    if (!key || *key == '\0' || strlen (key) > KV_MAX_KEY || strchr (key, '='))
+        return false;
+    return true;
+}
+
+static const char *kv_find (const struct kv *kv, const char *key)
+{
+    const char *entry;
+    kv_keybuf_t keybuf;
+
+    entry = kv_entry_first (kv);
+    while (entry) {
+        if (!strcmp (key, kv_entry_key (entry, keybuf)))
+            return entry;
+        entry = kv_entry_next (kv, entry);
+    }
+    return NULL;
+}
+
+int kv_delete (struct kv *kv, const char *key)
+{
+    const char *entry;
+    int entry_offset;
+    int entry_len;
+
+    if (!kv || !valid_key (key)) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(entry = kv_find (kv, key))) {
+        errno = ENOENT;
+        return -1;
+    }
+    entry_offset = entry - kv->buf;
+    entry_len = strlen (entry) + 1;
+    memmove (kv->buf + entry_offset,
+             kv->buf + entry_offset + entry_len,
+             kv->len - entry_offset - entry_len);
+    kv->len -= entry_len;
+    return 0;
+}
+
+int kv_put (struct kv *kv, const char *key, const char *val)
+{
+    int needsz;
+
+    if (!kv || !valid_key (key) || !val) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (kv_delete (kv, key) < 0) {
+        if (errno != ENOENT)
+            return -1;
+    }
+    needsz = strlen (key) + strlen (val) + 2; // key=val\0
+    if (kv_expand (kv, needsz) < 0)
+        return -1;
+    strcpy (kv->buf + kv->len, key);
+    strcat (kv->buf + kv->len, "=");
+    strcat (kv->buf + kv->len, val);
+    kv->len += needsz;
+    return 0;
+}
+
+int kv_putf (struct kv *kv, const char *key, const char *fmt, ...)
+{
+    va_list ap;
+    char *val;
+    int rc;
+
+    if (!fmt) { // N.B. kv and key are checked by kv_put
+        errno = EINVAL;
+        return -1;
+    }
+    va_start (ap, fmt);
+    rc = vasprintf (&val, fmt, ap);
+    va_end (ap);
+    if (rc < 0) {
+        errno = ENOMEM;
+        return -1;
+    }
+    if (kv_put (kv, key, val) < 0) {
+        int saved_errno = errno;
+        free (val);
+        errno = saved_errno;
+        return -1;
+    }
+    free (val);
+    return 0;
+}
+
+const char *kv_entry_next (const struct kv *kv, const char *entry)
+{
+    const char *next;
+
+    if (!kv || !entry || entry < kv->buf || entry > kv->buf + kv->len)
+        return NULL;
+    next = entry + strlen (entry) + 1;
+    if (next >= kv->buf + kv->len)
+        return NULL;
+    return next;
+}
+
+const char *kv_entry_first (const struct kv *kv)
+{
+    if (!kv || kv->len == 0)
+        return NULL;
+    return kv->buf;
+}
+
+const char *kv_entry_val (const char *entry)
+{
+    char *delim;
+
+    if (!entry || !(delim = strchr (entry, '=')))
+        return NULL;
+    return delim + 1;
+}
+
+const char *kv_entry_key (const char *entry, kv_keybuf_t keybuf)
+{
+    if (!entry || !keybuf)
+        return NULL;
+    char *delim = strchr (entry, '=');
+    assert (delim != NULL);
+    assert (delim - entry <= KV_MAX_KEY);
+    strncpy (keybuf, entry, delim - entry);
+    keybuf[delim - entry] = '\0';
+    return keybuf;
+}
+
+int kv_get (const struct kv *kv, const char *key, const char **val)
+{
+    const char *entry;
+
+    if (!kv || !valid_key (key)) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(entry = kv_find (kv, key))) {
+        errno = ENOENT;
+        return -1;
+    }
+    if (val)
+        *val = kv_entry_val (entry);
+    return 0;
+}
+
+int kv_getf (const struct kv *kv, const char *key, const char *fmt, ...)
+{
+    va_list ap;
+    const char *val;
+    int rc;
+
+    if (!fmt) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (kv_get (kv, key, &val) < 0)
+        return -1;
+    va_start (ap, fmt);
+    rc = vsscanf (val, fmt, ap);
+    va_end (ap);
+    return rc;
+}
+
+/* Validate a just-decoded kv buffer.
+ * Ensure that it is properly terminated and contains no entries with
+ * missing delimiters or invalid keys.
+ */
+static int kv_check_integrity (struct kv *kv)
+{
+    const char *entry;
+
+    if (kv->len > 0 && kv->buf[kv->len - 1] != '\0')
+        goto inval;
+    entry = kv_entry_first (kv);
+    while (entry) {
+        const char *delim = strchr (entry, '=');
+        if (!delim)
+            goto inval;
+        if (delim - entry == 0)
+            goto inval;
+        if (delim - entry > KV_MAX_KEY)
+            goto inval;
+        entry = kv_entry_next (kv, entry);
+    }
+    return 0;
+inval:
+    errno = EINVAL;
+    return -1;
+}
+
+int kv_raw_encode (const struct kv *kv, const char **buf, int *len)
+{
+    if (!kv || !buf || !len) {
+        errno = EINVAL;
+        return -1;
+    }
+    *buf = kv->buf;
+    *len = kv->len;
+    return 0;
+}
+
+struct kv *kv_raw_decode (const char *buf, int len)
+{
+    struct kv *kv;
+
+    if (!(kv = kv_create_from (buf, len)))
+        return NULL;
+    if (kv_check_integrity (kv) < 0) {
+        kv_destroy (kv);
+        return NULL;
+    }
+    return kv;
+}
+
+const char *kv_base64_encode (const struct kv *kv)
+{
+    char *dst;
+    int dstlen;
+    int rc;
+
+    if (!kv) {
+        errno = EINVAL;
+        return NULL;
+    }
+    dstlen = base64_encode_length (kv->len);
+    if (!(dst = malloc (dstlen)))
+        return NULL;
+    rc = base64_encode_block (dst, &dstlen, kv->buf, kv->len);
+    assert (rc == 0);
+
+    free (kv->base64);
+    /* N.B. cast away const here to allow this function to return
+     * a const value owned by struct kv.  This does not change the "value"
+     * per se, so it is safe.
+     */
+    ((struct kv *)(kv))->base64 = dst;
+    return kv->base64;
+}
+
+struct kv *kv_base64_decode (const char *buf, int len)
+{
+    char *dst;
+    int dstlen;
+    struct kv *kv;
+
+    if (len < 0 || (len > 0 && buf == NULL)) {
+        errno = EINVAL;
+        return NULL;
+    }
+    dstlen = base64_decode_length (len);
+    if (!(dst = malloc (dstlen)))
+        return NULL;
+    if (base64_decode_block (dst, &dstlen, buf, len) < 0) {
+        free (dst);
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(kv = kv_raw_decode (dst, dstlen))) {
+        int saved_errno = errno;
+        free (dst);
+        errno = saved_errno;
+        return NULL;
+    }
+    free (dst);
+    return kv;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/libutil/kv.h
+++ b/src/libutil/kv.h
@@ -1,0 +1,108 @@
+#ifndef _UTIL_KV_H
+#define _UTIL_KV_H
+
+/* Simple serialization:
+ *   key=value\0key=value\0...key=value\0
+ */
+
+#include <stdarg.h>
+#include <stdbool.h>
+
+#define KV_MAX_KEY 128
+
+typedef char kv_keybuf_t[KV_MAX_KEY];
+
+/* Create/destroy/copy kv object.
+ */
+struct kv *kv_create (void);
+void kv_destroy (struct kv *kv);
+struct kv *kv_copy (const struct kv *kv);
+
+/* Return true if kv1 is identical to kv2 (including entry order)
+ */
+bool kv_equal (const struct kv *kv1, const struct kv *kv2);
+
+/* Remove 'key' from kv object.
+ *   EINVAL - invalid argument
+ *   ENOENT - key not found
+ */
+int kv_delete (struct kv *kv, const char *key);
+
+/* Add key=val to kv object.
+ * Return 0 on success, -1 on failure with errno set:
+ *   EINVAL - invalid argument
+ *   ENOMEM - out of memory
+ */
+int kv_put (struct kv *kv, const char *key, const char *val);
+
+/* Find key in kv object and set val (if 'val' is non-NULL).
+ * Return 0 on success, -1 on failure wtih errno set:
+ *   EINVAL - invalid argument
+ *   ENOENT - key not found
+ */
+int kv_get (const struct kv *kv, const char *key, const char **val);
+
+/* Convenience wrapper for kv_put with printf-style args for value.
+ * Return 0 on success, -1 on failure with errno set:
+ *   EINVAL - invalid argument / sscanf problem
+ *   ENOENT - key not found
+ *   ENOMEM - out of memory
+ */
+int kv_putf (struct kv *kv, const char *key, const char *fmt, ...)
+        __attribute__ ((format (printf, 3, 4)));
+
+/* Convenience wrapper for kv_get with scanf-style args for value.
+ * Return number of matches on success, -1 on failure wtih errno set:
+ *   EINVAL - invalid argument
+ *   ENOENT - key not found
+ */
+int kv_getf (const struct kv *kv, const char *key, const char *fmt, ...)
+        __attribute__ ((format (scanf, 3, 4)));
+
+/* Encode kv object as NULL-terminated base64 string (do not free).
+ * String remains valid until the next call to kv_base64_encode()
+ * or kv_destroy().  Return NULL-terminated base64 string on success,
+ * NULL on failure with errno set.
+ */
+const char *kv_base64_encode (const struct kv *kv);
+
+/* Decode base64 string to kv object (destroy with kv_destroy).
+ * Return kv object on success, NULL on failure with errno set.
+ */
+struct kv *kv_base64_decode (const char *s, int len);
+
+/* Access internal binary encoding.
+ * Return 0 on success, -1 on failure with errno set.
+ */
+int kv_raw_encode (const struct kv *kv, const char **buf, int *len);
+
+/* Create kv object from binary encoding.
+ * Return kv object on success, NULL on failure with errno set.
+ */
+struct kv *kv_raw_decode (const char *buf, int len);
+
+/* Iteration example:
+ *
+ *   const char *entry;
+ *   kv_keybuf_t keybuf;
+ *
+ *   entry = kv_entry_first (kv);
+ *   while (entry) {
+ *       const char *key = kv_entry_key (entry, keybuf);
+ *       const char *val = kv_entry_val (entry);
+ *       ...
+ *       entry = kv_entry_next (kv, entry);
+ *   }
+ *
+ * N.B. the object may not be changed during iteration.
+ */
+const char *kv_entry_first (const struct kv *kv);
+const char *kv_entry_next (const struct kv *kv, const char *entry);
+const char *kv_entry_key (const char *entry, kv_keybuf_t keybuf);
+const char *kv_entry_val (const char *entry);
+
+#endif /* !_UTIL_KV_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/libutil/test/kv.c
+++ b/src/libutil/test/kv.c
@@ -1,0 +1,453 @@
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <string.h>
+#include <limits.h>
+#include <errno.h>
+
+#include "src/libtap/tap.h"
+#include "base64.h"
+#include "kv.h"
+
+static void simple_test (void)
+{
+    struct kv *kv;
+    struct kv *kv2;
+    struct kv *kv3;
+    struct kv *kv4;
+    const char *s;
+    int i;
+    kv_keybuf_t keybuf;
+    const char *entry;
+    int len;
+
+    /* Create kv object and set a=foo, b=bar.
+     * Validate values.
+     */
+    kv = kv_create ();
+    ok (kv != NULL,
+        "kv_create works");
+    ok (kv_put (kv, "a", "foo") == 0,
+        "kv_put a=foo works");
+    ok (kv_get (kv, "a", &s) == 0 && !strcmp (s, "foo"),
+        "kv_get a retrieves correct value");
+    ok (kv_put (kv, "b", "bar") == 0,
+        "kv_put b=bar works");
+    ok (kv_putf (kv, "c", "%d", 42) == 0,
+        "kv_putf c=42 works");
+    ok (kv_get (kv, "a", &s) == 0 && !strcmp (s, "foo"),
+        "kv_get a retrieves correct value");
+    ok (kv_get (kv, "b", &s) == 0 && !strcmp (s, "bar"),
+        "kv_get b retrieves correct value");
+    ok (kv_getf (kv, "c", "%d", &i) == 1 && i == 42,
+        "kv_getf c retrieves correct value");
+
+    /* Iterate over entries.
+     */
+    entry = kv_entry_first (kv);
+    ok (entry != NULL,
+        "kv_entry_first works");
+    s = kv_entry_key (entry, keybuf);
+    ok (s != NULL && !strcmp (s, "a"),
+        "kv_entry_key returned correct key");
+    s = kv_entry_val (entry);
+    ok (s != NULL && !strcmp (s, "foo"),
+        "kv_entry_val returned correct value");
+
+    entry = kv_entry_next (kv, entry);
+    ok (entry != NULL,
+        "kv_entry_next works");
+    s = kv_entry_key (entry, keybuf);
+    ok (s != NULL && !strcmp (s, "b"),
+        "kv_entry_key returned correct key");
+    s = kv_entry_val (entry);
+    ok (s != NULL && !strcmp (s, "bar"),
+        "kv_entry_val returned correct value");
+
+    entry = kv_entry_next (kv, entry);
+    ok (entry != NULL,
+        "kv_entry_next works");
+    s = kv_entry_key (entry, keybuf);
+    ok (s != NULL && !strcmp (s, "c"),
+        "kv_entry_key returned correct key");
+    s = kv_entry_val (entry);
+    ok (s != NULL && !strcmp (s, "42"),
+        "kv_entry_val returned correct value");
+
+    ok (kv_entry_next (kv, entry) == NULL,
+        "kv_entry_next returned NULL at end");
+
+
+    /* Create a new copy through base64 codec and check for equality.
+     */
+    s = kv_base64_encode (kv);
+    ok (s != NULL,
+        "kv_base64_encode works");
+    diag ("encoded: %s", s);
+    kv2 = kv_base64_decode (s, strlen (s));
+    ok (kv2 != NULL,
+        "kv_base64_decode works");
+    ok (kv_equal (kv, kv2),
+        "kv_equal says new copy is identical");
+
+    /* Create a new copy through kv_copy() and check for equality.
+     */
+    kv3 = kv_copy (kv);
+    ok (kv3 != NULL,
+        "kv_copy works");
+    ok (kv_equal (kv, kv3),
+        "kv_equal says new copy is identical");
+
+    /* Create a new copy through raw "codec" and check for equality.
+     */
+    ok (kv_raw_encode (kv, &s, &len) == 0,
+        "kv_raw_encode works");
+    kv4 = kv_raw_decode (s, len);
+    ok (kv4 != NULL,
+        "kv_raw_decode works");
+    ok (kv_equal (kv, kv4),
+        "kv_equal says new copy is identical");
+
+    kv_destroy (kv);
+    kv_destroy (kv2);
+    kv_destroy (kv3);
+    kv_destroy (kv4);
+}
+
+static void empty_object (void)
+{
+    struct kv *kv, *kv2;
+    const char *s;
+
+    kv = kv_create ();
+    ok (kv != NULL,
+        "kv_create works");
+    ok (kv_entry_first (kv) == NULL,
+        "kv_entry_first returns NULL");
+    s = kv_base64_encode (kv);
+    ok (s != NULL,
+        "kv_base64_encode works");
+    diag ("empty kv: %s (len=%d)", s, strlen (s));
+
+    kv2 = kv_base64_decode (s, strlen (s));
+    ok (kv2 != NULL,
+        "kv_base64_decode works");
+    ok (kv_equal (kv, kv2),
+        "kv_equal says they are identical");
+
+    kv_destroy (kv);
+    kv_destroy (kv2);
+}
+
+static void check_expansion (void)
+{
+    struct kv *kv;
+    kv_keybuf_t keybuf;
+    int i, j;
+
+    kv = kv_create ();
+    ok (kv != NULL,
+        "kv_create works");
+
+    /* Add entries
+     * Each entry wil be 32+3 + 1 + 32 + 1 = 69 bytes.
+     * Add 100 of them to ensure 4096 byte "chunk size" is exceeded,
+     * so object has to grow at least once.
+     */
+    for (i = 0; i < 100; i++) {
+        snprintf (keybuf, sizeof (keybuf), "key%032d", i);
+        //diag ("key%032d=%032d", i, i);
+        if (kv_putf (kv, keybuf, "%032d", i) < 0)
+            break;
+    }
+    ok (i == 100,
+        "kv_putf added 100 69-byte entries");
+
+    for (j = 0; j < 100; j++) {
+        snprintf (keybuf, sizeof (keybuf), "key%032d", j);
+        if (kv_getf (kv, keybuf, "%d", &i) < 0 || i != j)
+            break;
+    }
+    ok (j == 100,
+        "kv_getf verified 100 69-byte entries");
+
+    kv_destroy (kv);
+}
+
+static void bad_parameters (void)
+{
+    struct kv *kv;
+    struct kv *kv2;
+    const char *s;
+    char giantkey[KV_MAX_KEY + 2];
+    const char *entry;
+    kv_keybuf_t keybuf;
+    char tmpbuf[KV_MAX_KEY * 2];
+    int tmpbuflen;
+    int len;
+
+    /* Create two kv objects:  kv (emtpy), and kv2 (non-empty).
+     */
+    if (!(kv = kv_create ()))
+        BAIL_OUT ("kv_create failed");
+    if (!(kv2 = kv_create ()))
+        BAIL_OUT ("kv_create failed");
+    if (kv_put (kv2, "foo", "bar") < 0)
+        BAIL_OUT ("kv_put failed");
+    if (!(entry = kv_entry_first (kv2)))
+        BAIL_OUT ("kv_entry_first kv=(one entry) returned NULL");
+
+    /* Make key that is one char beyond max key imit
+     */
+    memset (giantkey, 'k', KV_MAX_KEY + 1);
+    giantkey[KV_MAX_KEY + 1] = '\0';
+
+    /* kv_copy
+     */
+    errno = 0;
+    ok (kv_copy (NULL) == NULL && errno == EINVAL,
+        "kv_copy kv=NULL fails with EINVAL");
+
+    /* kv_equal
+     */
+    ok (kv_equal (kv, NULL) == false,
+        "kv_equal kv1=NULL returns false");
+    ok (kv_equal (NULL, kv) == false,
+        "kv_equal kv2=NULL returns false");
+    ok (kv_equal (NULL, NULL) == false,
+        "kv_equal kv1=NULL kv2=NULL returns false");
+
+    /* kv_put, kv_putf
+     */
+    errno = 0;
+    ok (kv_put (NULL, "foo", "bar") < 0 && errno == EINVAL,
+        "kv_put kv=NULL fails with EINVAL");
+    errno = 0;
+    ok (kv_put (kv, NULL, "bar") < 0 && errno == EINVAL,
+        "kv_put key=NULL fails with EINVAL");
+    errno = 0;
+    ok (kv_put (kv, "", NULL) < 0 && errno == EINVAL,
+        "kv_put key="" fails with EINVAL");
+    errno = 0;
+    ok (kv_put (kv, giantkey, "bar") < 0 && errno == EINVAL,
+        "kv_put key=(giant) fails with EINVAL");
+    errno = 0;
+    ok (kv_put (kv, "foo=baz", "bar") < 0 && errno == EINVAL,
+        "kv_put key=(contains =) fails with EINVAL");
+    errno = 0;
+    ok (kv_put (kv, "foo", NULL) < 0 && errno == EINVAL,
+        "kv_put val=NULL fails with EINVAL");
+    errno = 0;
+    ok (kv_putf (NULL, "foo", "bar") < 0 && errno == EINVAL,
+        "kv_putf kv=NULL fails with EINVAL");
+    errno = 0;
+    ok (kv_putf (kv, "foo", NULL) < 0 && errno == EINVAL,
+        "kv_putf fmt=NULL fails with EINVAL");
+
+    /* kv_get, kv_getf
+     */
+    errno = 0;
+    ok (kv_get (NULL, "foo", &s) < 0 && errno == EINVAL,
+        "kv_get kv=NULL fails with EINVAL");
+    errno = 0;
+    ok (kv_get (kv, NULL, &s) < 0 && errno == EINVAL,
+        "kv_get key=NULL fails with EINVAL");
+    errno = 0;
+    ok (kv_get (kv, "", &s) < 0 && errno == EINVAL,
+        "kv_get key="" fails with EINVAL");
+    errno = 0;
+    ok (kv_get (kv, giantkey, &s) < 0 && errno == EINVAL,
+        "kv_get key=(giant) fails with EINVAL");
+    errno = 0;
+    ok (kv_get (kv, "foo=baz", &s) < 0 && errno == EINVAL,
+        "kv_get key=(contains =) fails with EINVAL");
+    errno = 0;
+    ok (kv_getf (kv, "foo", NULL) < 0 && errno == EINVAL,
+        "kv_getf fmt=NULL fails with EINVAL");
+
+    /* iteration
+     */
+    ok (kv_entry_first (NULL) == NULL,
+        "kv_entry_first kv=NULL returns NULL");
+    ok (kv_entry_first (kv) == NULL,
+        "kv_entry_first kv=empty returns NULL");
+
+    ok (kv_entry_next (NULL, entry) == NULL,
+       "kv_entry_next kv=NULL returns NULL");
+    ok (kv_entry_next (kv2, entry) == NULL,
+       "kv_entry_next kv=(one entry) returns NULL");
+    ok (kv_entry_next (kv2, NULL) == NULL,
+       "kv_entry_next entry=NULL returns NULL");
+    ok (kv_entry_next (kv2, entry - 4096) == NULL,
+       "kv_entry_next entry=(< lower bound) == NULL");
+    ok (kv_entry_next (kv2, entry + 4096) == NULL,
+       "kv_entry_next entry=(> upper bound) == NULL");
+
+    ok (kv_entry_val (NULL) == NULL,
+       "kv_entry_val entry=NULL returns NULL");
+    ok (kv_entry_val ("") == NULL,
+       "kv_entry_val entry="" returns NULL");
+    ok (kv_entry_val ("noequal") == NULL,
+       "kv_entry_val entry=(no =) returns NULL");
+
+    ok (kv_entry_key (NULL, keybuf) == NULL,
+       "kv_entry_key entry=NULL returns NULL");
+    ok (kv_entry_key (entry, NULL) == NULL,
+       "kv_entry_key keybuf=NULL returns NULL");
+
+    /* kv_raw_encode
+     */
+    errno = 0;
+    ok (kv_raw_encode (NULL, &s, &len) < 0 && errno == EINVAL,
+        "kv_raw_encode kv=NULL fails with EINVAL");
+    errno = 0;
+    ok (kv_raw_encode (kv, NULL, &len) < 0 && errno == EINVAL,
+        "kv_raw_encode buf=NULL fails with EINVAL");
+    errno = 0;
+    ok (kv_raw_encode (kv, &s, NULL) < 0 && errno == EINVAL,
+        "kv_raw_encode len=NULL fails with EINVAL");
+
+    /* kv_raw_decode
+     */
+    errno = 0;
+    ok (kv_raw_decode ("foo=bar\0", -1) == NULL && errno == EINVAL,
+        "kv_raw_decode len=-1 fails with EINVAL");
+    errno = 0;
+    ok (kv_raw_decode (NULL, 1) == NULL && errno == EINVAL,
+        "kv_raw_decode buf=NULL len=1 fails with EINVAL");
+    errno = 0;
+    ok (kv_raw_decode ("foo=bar", 7) == NULL && errno == EINVAL,
+        "kv_raw_decode buf=(unterm) fails with EINVAL");
+    errno = 0;
+    ok (kv_raw_decode ("foo=bar\0foobar\0", 15) == NULL && errno == EINVAL,
+        "kv_raw_decode buf=(no delim entry) fails with EINVAL");
+    errno = 0;
+    ok (kv_raw_decode ("foo=bar\0=foobar\0", 16) == NULL && errno == EINVAL,
+        "kv_raw_decode buf=(empty key entry) fails with EINVAL");
+
+    tmpbuflen = strlen (giantkey) + 5;
+    strcpy (tmpbuf, giantkey);
+    strcat (tmpbuf, "=baz"); // 5 chars including \0
+    errno = 0;
+    ok (kv_raw_decode (tmpbuf, tmpbuflen) == NULL && errno == EINVAL,
+        "kv_raw_decode buf=(giant key entry) fails with EINVAL");
+
+    /* kv_base64_encode
+     */
+    errno = 0;
+    ok (kv_base64_encode (NULL) == NULL && errno == EINVAL,
+        "kv_base64_encode kv=NULL fails with EINVAL");
+    s = kv_base64_encode (kv);
+    ok (s != NULL,
+        "kv_base64_encode kv=(empty) works");
+    s = kv_base64_encode (kv);
+    ok (s != NULL,
+        "kv_base64_encode kv=(empty) works a second time");
+
+    /* kv_base64_decode (wraps kv_raw_decode)
+     */
+    errno = 0;
+    ok (kv_base64_decode ("", -1) == NULL && errno == EINVAL,
+        "kv_base64_decode len=-1 fails with EINVAL");
+    errno = 0;
+    ok (kv_base64_decode (NULL, 1) == NULL && errno == EINVAL,
+        "kv_base64_decode buf=NULL len=1 fails with EINVAL");
+    errno = 0;
+    ok (kv_base64_decode (".", 1) == NULL && errno == EINVAL,
+        "kv_base64_decode buf=(illegal base64) fails with EINVAL");
+    errno = 0;
+    /* echo -n a=b | base64 */
+    ok (kv_base64_decode ("YT1i", 4) == NULL && errno == EINVAL,
+        "kv_base64_decode buf=(unterm) fails with EINVAL");
+
+    kv_destroy (kv);
+    kv_destroy (kv2);
+}
+
+void key_deletion (void)
+{
+    struct kv *kv;
+
+    if (!(kv = kv_create ()))
+        BAIL_OUT ("kv_create failed");
+    ok (kv_put (kv, "foo", "bar") == 0,
+        "kv_put foo=bar works");
+    ok (kv_delete (kv, "foo") == 0,
+        "kv_delete foo works");
+    errno = 0;
+    ok (kv_delete (kv, "foo") < 0,
+        "kv_delete foo a second time fails with ENOENT");
+    ok (kv_put (kv, "foo", "baz") == 0,
+        "kv_put foo=baz works");
+
+    kv_destroy (kv);
+}
+
+void key_update (void)
+{
+    struct kv *kv;
+    const char *val;
+
+    if (!(kv = kv_create ()))
+        BAIL_OUT ("kv_create failed");
+
+    ok (kv_put (kv, "foo", "bar") == 0,
+        "kv_put foo=bar works");
+
+    /* Update first (only) entry
+     */
+    ok (kv_put (kv, "foo", "baz") == 0,
+        "kv_put foo=baz works");
+    ok (kv_get (kv, "foo", &val) == 0 && !strcmp (val, "baz"),
+        "kv_get foo returns baz");
+
+    ok (kv_put (kv, "bar", "xxx") == 0,
+        "kv_put bar=xxx works");
+
+    /* Update first (of two) entry
+     */
+    ok (kv_put (kv, "foo", "yyy") == 0,
+        "kv_put foo=yyy works");
+    ok (kv_get (kv, "foo", &val) == 0 && !strcmp (val, "yyy"),
+        "kv_get foo returns yyy");
+
+    /* Update second (of two) entry
+     */
+    ok (kv_put (kv, "bar", "zzz") == 0,
+        "kv_put bar=zzz works");
+    ok (kv_get (kv, "bar", &val) == 0 && !strcmp (val, "zzz"),
+        "kv_get bar returns zzz");
+
+    ok (kv_put (kv, "baz", "qqq") == 0,
+        "kv_put baz=qqq works");
+
+    /* Update second (of three) entry
+     */
+    ok (kv_put (kv, "bar", "111") == 0,
+        "kv_put bar=111 works");
+    ok (kv_get (kv, "bar", &val) == 0 && !strcmp (val, "111"),
+        "kv_get bar returns 111");
+
+    kv_destroy (kv);
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    simple_test ();
+    empty_object ();
+    check_expansion ();
+    bad_parameters ();
+    key_deletion ();
+    key_update ();
+
+    done_testing ();
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */


### PR DESCRIPTION
This PR adds a new `struct kv` class that implements a simple "key=value\0" serialization that should be easier to audit than JSON encoding.

In addition, the following changes were made to the `sigcert` class:
* move from `lib` to `libutil`, drop `flux_` namespace prefix
* internally represent "metadata" (arbitrary user data) using `struct kv`
* drop json certificate serialization, add base64 certificate serialization

