### PR TITLE
libutil/kv: increase size of kv_keybuf_t

### DIFF
--- a/src/libutil/kv.h
+++ b/src/libutil/kv.h
@@ -10,7 +10,7 @@
 
 #define KV_MAX_KEY 128
 
-typedef char kv_keybuf_t[KV_MAX_KEY];
+typedef char kv_keybuf_t[KV_MAX_KEY + 1];
 
 /* Create/destroy/copy kv object.
  */


### PR DESCRIPTION
Just noticed an off by one error in the definition of kv_keybuf_t.  This fixes it.