### PR TITLE
libutil/kv: add varargs get/put

### DIFF
--- a/src/libutil/kv.c
+++ b/src/libutil/kv.c
@@ -188,12 +188,11 @@ int kv_delete (struct kv *kv, const char *key)
     return 0;
 }
 
-/* Put typed key=val (val is in string form).
- * If key already exists, remove it first.
- * Return 0 on success, -1 on failure with errno set.
+/* Put 'val' of a given type that has been already been converted to a string.
+ * Returns 0 on success, -1 on failure with errno set.
  */
-static int kv_put (struct kv *kv, const char *key,
-                   enum kv_type type, const char *val)
+static int kv_put_raw (struct kv *kv, const char *key, enum kv_type type,
+                       const char *val)
 {
     if (!kv || !valid_key (key) || !val) {
         errno = EINVAL;
@@ -215,47 +214,62 @@ static int kv_put (struct kv *kv, const char *key,
     return 0;
 }
 
-int kv_put_string (struct kv *kv, const char *key, const char *val)
+int kv_vput (struct kv *kv, const char *key, enum kv_type type, va_list ap)
 {
-    return kv_put (kv, key, KV_STRING, val);
-}
+    char s[80];
+    const char *val = NULL;
 
-int kv_put_int64 (struct kv *kv, const char *key, int64_t val)
-{
-    char s[64];
-    if (snprintf (s, sizeof (s), "%" PRIi64, val) >= sizeof (s)) {
-        errno = EINVAL;
-        return -1;
+    if (!kv || !valid_key (key))
+        goto inval;
+    switch (type) {
+        case KV_STRING:
+            val = va_arg (ap, const char *);
+            break;
+        case KV_INT64:
+            if (vsnprintf (s, sizeof (s), "%" PRIi64, ap) >= sizeof (s))
+                goto inval;
+            val = s;
+            break;
+        case KV_DOUBLE:
+            if (vsnprintf (s, sizeof (s), "%f", ap) >= sizeof (s))
+                goto inval;
+            val = s;
+            break;
+        case KV_BOOL: {
+            bool b = va_arg (ap, int); // va promotes bool to int
+            val = b ? "true" : "false";
+            break;
+        }
+        case KV_TIMESTAMP: {
+            struct tm tm;
+            time_t t = va_arg (ap, time_t);
+            if (t < 0 || !gmtime_r (&t, &tm))
+                goto inval;
+             if (strftime (s, sizeof (s), "%FT%TZ", &tm) == 0)
+                goto inval;
+            val = s;
+            break;
+        }
+        default:
+            goto inval;
     }
-    return kv_put (kv, key, KV_INT64, s);
+    if (!val)
+        goto inval;
+    return kv_put_raw (kv, key, type, val);
+inval:
+    errno = EINVAL;
+    return -1;
 }
 
-int kv_put_double (struct kv *kv, const char *key, double val)
+int kv_put (struct kv *kv, const char *key, enum kv_type type, ...)
 {
-    char s[64];
-    if (snprintf (s, sizeof (s), "%f", val) >= sizeof (s)) {
-        errno = EINVAL;
-        return -1;
-    }
-    return kv_put (kv, key, KV_DOUBLE, s);
-}
+    va_list ap;
+    int rc;
 
-int kv_put_bool (struct kv *kv, const char *key, bool val)
-{
-    return kv_put (kv, key, KV_BOOL, val ? "true" : "false");
-}
-
-int kv_put_timestamp (struct kv *kv, const char *key, time_t val)
-{
-    char s[64];
-    struct tm tm;
-
-    if (val < 0 || !gmtime_r (&val, &tm)
-                || strftime (s, sizeof (s), "%FT%TZ", &tm) == 0) {
-        errno = EINVAL;
-        return -1;
-    }
-    return kv_put (kv, key, KV_TIMESTAMP, s);
+    va_start (ap, type);
+    rc = kv_vput (kv, key, type, ap);
+    va_end (ap);
+    return rc;
 }
 
 const char *kv_next (const struct kv *kv, const char *key)
@@ -447,7 +461,7 @@ struct kv *kv_raw_decode (const char *buf, int len)
     return kv;
 }
 
-/* Wrapper for kv_put() which adds 'prefix' to key, if non-NULL.
+/* Wrapper for kv_put_raw() which adds 'prefix' to key, if non-NULL.
  * Returns 0 on success, -1 on failure with errno set (ENOMEM).
  */
 static int kv_put_prefix (struct kv *kv, const char *prefix, const char *key,
@@ -460,7 +474,7 @@ static int kv_put_prefix (struct kv *kv, const char *prefix, const char *key,
             return -1;
         key = newkey;
     }
-    if (kv_put (kv, key, type, val) < 0) {
+    if (kv_put_raw (kv, key, type, val) < 0) {
         int saved_errno = errno;
         free (newkey);
         errno = saved_errno;
@@ -492,8 +506,8 @@ struct kv *kv_split (const struct kv *kv1, const char *prefix)
         return NULL;
     while ((key = kv_next (kv1, key))) {
         if (strlen (key) > n && !strncmp (key, prefix, n)) {
-            if (kv_put (kv2, key + n, kv_typeof (key),
-                                      kv_val_string (key)) < 0) {
+            if (kv_put_raw (kv2, key + n, kv_typeof (key),
+                                          kv_val_string (key)) < 0) {
                 kv_destroy (kv2);
                 return NULL;
             }

--- a/src/libutil/kv.h
+++ b/src/libutil/kv.h
@@ -65,11 +65,9 @@ int kv_put_timestamp (struct kv *kv, const char *key, time_t t);
  *   EINVAL - invalid argument
  *   ENOENT - key of requested type not found
  */
-int kv_get_string (const struct kv *kv, const char *key, const char **val);
-int kv_get_int64 (const struct kv *kv, const char *key, int64_t *val);
-int kv_get_double (const struct kv *kv, const char *key, double *val);
-int kv_get_bool (const struct kv *kv, const char *key, bool *val);
-int kv_get_timestamp (const struct kv *kv, const char *key, time_t *val);
+int kv_vget (const struct kv *kv, const char *key,
+             enum kv_type type, va_list ap);
+int kv_get (const struct kv *kv, const char *key, enum kv_type type, ...);
 
 /* Access internal binary encoding.
  * Return 0 on success, -1 on failure with errno set.

--- a/src/libutil/kv.h
+++ b/src/libutil/kv.h
@@ -54,11 +54,8 @@ int kv_delete (struct kv *kv, const char *key);
  *   EINVAL - invalid argument
  *   ENOMEM - out of memory
  */
-int kv_put_string (struct kv *kv, const char *key, const char *val);
-int kv_put_int64 (struct kv *kv, const char *key, int64_t val);
-int kv_put_double (struct kv *kv, const char *key, double val);
-int kv_put_bool (struct kv *kv, const char *key, bool val);
-int kv_put_timestamp (struct kv *kv, const char *key, time_t t);
+int kv_vput (struct kv *kv, const char *key, enum kv_type type, va_list ap);
+int kv_put (struct kv *kv, const char *key, enum kv_type type, ...);
 
 /* Find key in kv object and get val (if non-NULL).
  * Return 0 on success, -1 on failure with errno set:

--- a/src/libutil/test/kv.c
+++ b/src/libutil/test/kv.c
@@ -54,8 +54,8 @@ static void simple_test (void)
         "kv_create works");
     ok (kv_put_string (kv, "a", "foo") == 0,
         "kv_put a=foo works");
-    ok (kv_get_string (kv, "a", &s) == 0 && !strcmp (s, "foo"),
-        "kv_get_string a retrieves correct value: %s", s);
+    ok (kv_get (kv, "a", KV_STRING, &s) == 0 && !strcmp (s, "foo"),
+        "kv_get a retrieves correct value: %s", s);
     ok (kv_put_int64 (kv, "b", 42) == 0,
         "kv_put_int64 b=42 works");
     ok (kv_put_double (kv, "c", 3.14) == 0,
@@ -66,19 +66,19 @@ static void simple_test (void)
         "kv_put_timestamp e=(now) works");
     diag_kv (kv);
 
-    ok (kv_get_string (kv, "a", &s) == 0 && !strcmp (s, "foo"),
-        "kv_get_string a retrieves correct value");
-    ok (kv_get_int64 (kv, "b", &i) == 0 && i == 42,
-        "kv_get_int64 b retrieves correct value");
-    ok (kv_get_double (kv, "c", &d) == 0 && d == 3.14,
-        "kv_get_double c retrieves correct value");
-    ok (kv_get_bool (kv, "d", &b) == 0 && b == true,
-        "kv_get_bool d retrieves correct value");
-    ok (kv_get_timestamp (kv, "e", &t) == 0 && t == now,
-        "kv_get_timestamp e retrieves correct value");
+    ok (kv_get (kv, "a", KV_STRING, &s) == 0 && !strcmp (s, "foo"),
+        "kv_get a retrieves correct value");
+    ok (kv_get (kv, "b", KV_INT64, &i) == 0 && i == 42,
+        "kv_get b retrieves correct value");
+    ok (kv_get (kv, "c", KV_DOUBLE, &d) == 0 && d == 3.14,
+        "kv_get c retrieves correct value");
+    ok (kv_get (kv, "d", KV_BOOL, &b) == 0 && b == true,
+        "kv_get d retrieves correct value");
+    ok (kv_get (kv, "e", KV_TIMESTAMP, &t) == 0 && t == now,
+        "kv_get e retrieves correct value");
     errno = 0;
-    ok (kv_get_string (kv, "f", &s) < 0 && errno == ENOENT,
-        "kv_get_string f fails with ENOENT");
+    ok (kv_get (kv, "f", KV_STRING, &s) < 0 && errno == ENOENT,
+        "kv_get f fails with ENOENT");
 
     /* Iterate over entries.
      */
@@ -201,11 +201,11 @@ static void check_expansion (void)
     for (i = 0; i < 100; i++) {
         snprintf (keybuf, sizeof (keybuf), "key%032d", i);
         snprintf (valbuf, sizeof (valbuf), "%032d", i);
-        if (kv_get_string (kv, keybuf, &s) < 0 || strcmp (s, valbuf) != 0)
+        if (kv_get (kv, keybuf, KV_STRING, &s) < 0 || strcmp (s, valbuf) != 0)
             break;
     }
     ok (i == 100,
-        "kv_get_string verified 100 69-byte entries");
+        "kv_get verified 100 69-byte entries");
 
     kv_destroy (kv);
 }
@@ -264,17 +264,16 @@ static void bad_parameters (void)
     ok (kv_put_timestamp (kv, "foo", -1) < 0 && errno == EINVAL,
         "kv_put_timestamp val=-1 fails with EINVAL");
 
-    /* kv_get_*
-     * bad params caught with type independent common code
+    /* kv_get
      */
     errno = 0;
-    ok (kv_get_string (NULL, "foo", &s) < 0 && errno == EINVAL,
-        "kv_get_string kv=NULL fails with EINVAL");
+    ok (kv_get (NULL, "foo", KV_STRING, &s) < 0 && errno == EINVAL,
+        "kv_get kv=NULL fails with EINVAL");
     errno = 0;
-    ok (kv_get_string (kv, NULL, &s) < 0 && errno == EINVAL,
-        "kv_get_string key=NULL fails with EINVAL");
+    ok (kv_get (kv, NULL, KV_STRING, &s) < 0 && errno == EINVAL,
+        "kv_get key=NULL fails with EINVAL");
     errno = 0;
-    ok (kv_get_string (kv, "", &s) < 0 && errno == EINVAL,
+    ok (kv_get (kv, "", KV_STRING, &s) < 0 && errno == EINVAL,
         "kv_get_string key="" fails with EINVAL");
 
     /* iteration
@@ -370,8 +369,8 @@ void key_update (void)
      */
     ok (kv_put_string (kv, "foo", "baz") == 0,
         "kv_put_string foo=baz works");
-    ok (kv_get_string (kv, "foo", &val) == 0 && !strcmp (val, "baz"),
-        "kv_get_string foo returns baz");
+    ok (kv_get (kv, "foo", KV_STRING, &val) == 0 && !strcmp (val, "baz"),
+        "kv_get foo returns baz");
 
     ok (kv_put_string (kv, "bar", "xxx") == 0,
         "kv_put_string bar=xxx works");
@@ -380,15 +379,15 @@ void key_update (void)
      */
     ok (kv_put_string (kv, "foo", "yyy") == 0,
         "kv_put_string foo=yyy works");
-    ok (kv_get_string (kv, "foo", &val) == 0 && !strcmp (val, "yyy"),
-        "kv_get_string foo returns yyy");
+    ok (kv_get (kv, "foo", KV_STRING, &val) == 0 && !strcmp (val, "yyy"),
+        "kv_get foo returns yyy");
 
     /* Update second (of two) entry
      */
     ok (kv_put_string (kv, "bar", "zzz") == 0,
         "kv_put_string bar=zzz works");
-    ok (kv_get_string (kv, "bar", &val) == 0 && !strcmp (val, "zzz"),
-        "kv_get_string bar returns zzz");
+    ok (kv_get (kv, "bar", KV_STRING, &val) == 0 && !strcmp (val, "zzz"),
+        "kv_get bar returns zzz");
 
     ok (kv_put_string (kv, "baz", "qqq") == 0,
         "kv_put_string baz=qqq works");
@@ -397,8 +396,8 @@ void key_update (void)
      */
     ok (kv_put_string (kv, "bar", "111") == 0,
         "kv_put_string bar=111 works");
-    ok (kv_get_string (kv, "bar", &val) == 0 && !strcmp (val, "111"),
-        "kv_get_string bar returns 111");
+    ok (kv_get (kv, "bar", KV_STRING, &val) == 0 && !strcmp (val, "111"),
+        "kv_get bar returns 111");
 
     kv_destroy (kv);
 }

--- a/src/libutil/test/kv.c
+++ b/src/libutil/test/kv.c
@@ -55,7 +55,7 @@ static void simple_test (void)
     ok (kv_put (kv, "a", KV_STRING, "foo") == 0,
         "kv_put a=foo works");
     ok (kv_get (kv, "a", KV_STRING, &s) == 0 && !strcmp (s, "foo"),
-        "kv_get a retrieves correct value: %s", s);
+        "kv_get a retrieves correct value");
     ok (kv_put (kv, "b", KV_INT64, 42LL) == 0,
         "kv_put b=42 works");
     ok (kv_put (kv, "c", KV_DOUBLE, 3.14) == 0,

--- a/src/libutil/test/kv.c
+++ b/src/libutil/test/kv.c
@@ -52,18 +52,18 @@ static void simple_test (void)
     kv = kv_create ();
     ok (kv != NULL,
         "kv_create works");
-    ok (kv_put_string (kv, "a", "foo") == 0,
+    ok (kv_put (kv, "a", KV_STRING, "foo") == 0,
         "kv_put a=foo works");
     ok (kv_get (kv, "a", KV_STRING, &s) == 0 && !strcmp (s, "foo"),
         "kv_get a retrieves correct value: %s", s);
-    ok (kv_put_int64 (kv, "b", 42) == 0,
-        "kv_put_int64 b=42 works");
-    ok (kv_put_double (kv, "c", 3.14) == 0,
-        "kv_put_double c=3.14 works");
-    ok (kv_put_bool (kv, "d", true) == 0,
-        "kv_put_bool d=true works");
-    ok (kv_put_timestamp (kv, "e", now) == 0,
-        "kv_put_timestamp e=(now) works");
+    ok (kv_put (kv, "b", KV_INT64, 42LL) == 0,
+        "kv_put b=42 works");
+    ok (kv_put (kv, "c", KV_DOUBLE, 3.14) == 0,
+        "kv_put c=3.14 works");
+    ok (kv_put (kv, "d", KV_BOOL, true) == 0,
+        "kv_put d=true works");
+    ok (kv_put (kv, "e", KV_TIMESTAMP, now) == 0,
+        "kv_put e=(now) works");
     diag_kv (kv);
 
     ok (kv_get (kv, "a", KV_STRING, &s) == 0 && !strcmp (s, "foo"),
@@ -192,11 +192,11 @@ static void check_expansion (void)
     for (i = 0; i < 100; i++) {
         snprintf (keybuf, sizeof (keybuf), "key%032d", i);
         snprintf (valbuf, sizeof (valbuf), "%032d", i);
-        if (kv_put_string (kv, keybuf, valbuf) < 0)
+        if (kv_put (kv, keybuf, KV_STRING, valbuf) < 0)
             break;
     }
     ok (i == 100,
-        "kv_put_string added 100 69-byte entries");
+        "kv_put added 100 69-byte entries");
 
     for (i = 0; i < 100; i++) {
         snprintf (keybuf, sizeof (keybuf), "key%032d", i);
@@ -224,8 +224,8 @@ static void bad_parameters (void)
         BAIL_OUT ("kv_create failed");
     if (!(kv2 = kv_create ()))
         BAIL_OUT ("kv_create failed");
-    if (kv_put_string (kv2, "foo", "bar") < 0)
-        BAIL_OUT ("kv_put_string failed");
+    if (kv_put (kv2, "foo", KV_STRING, "bar") < 0)
+        BAIL_OUT ("kv_put failed");
     if (!(entry = kv_next (kv2, NULL)))
         BAIL_OUT ("kv_next kv=(one entry) key=NULL returned NULL");
 
@@ -244,24 +244,23 @@ static void bad_parameters (void)
     ok (kv_equal (NULL, NULL) == false,
         "kv_equal kv1=NULL kv2=NULL returns false");
 
-    /* kv_put_*
-     * bad params caught with type independent common code
+    /* kv_put
      */
     errno = 0;
-    ok (kv_put_string (NULL, "foo", "bar") < 0 && errno == EINVAL,
-        "kv_put_string kv=NULL fails with EINVAL");
+    ok (kv_put (NULL, "foo", KV_STRING, "bar") < 0 && errno == EINVAL,
+        "kv_put kv=NULL fails with EINVAL");
     errno = 0;
-    ok (kv_put_string (kv, NULL, "bar") < 0 && errno == EINVAL,
-        "kv_put_string key=NULL fails with EINVAL");
+    ok (kv_put (kv, NULL, KV_STRING, "bar") < 0 && errno == EINVAL,
+        "kv_put key=NULL fails with EINVAL");
     errno = 0;
-    ok (kv_put_string (kv, "", NULL) < 0 && errno == EINVAL,
-        "kv_put_string key="" fails with EINVAL");
+    ok (kv_put (kv, "", KV_STRING, NULL) < 0 && errno == EINVAL,
+        "kv_put key="" fails with EINVAL");
     errno = 0;
-    ok (kv_put_string (kv, "foo", NULL) < 0 && errno == EINVAL,
+    ok (kv_put (kv, "foo", KV_STRING, NULL) < 0 && errno == EINVAL,
         "kv_put_string val=NULL fails with EINVAL");
 
     errno = 0;
-    ok (kv_put_timestamp (kv, "foo", -1) < 0 && errno == EINVAL,
+    ok (kv_put (kv, "foo", KV_TIMESTAMP, (time_t)-1) < 0 && errno == EINVAL,
         "kv_put_timestamp val=-1 fails with EINVAL");
 
     /* kv_get
@@ -341,15 +340,15 @@ void key_deletion (void)
 
     if (!(kv = kv_create ()))
         BAIL_OUT ("kv_create failed");
-    ok (kv_put_string (kv, "foo", "bar") == 0,
-        "kv_put_string foo=bar works");
+    ok (kv_put (kv, "foo", KV_STRING, "bar") == 0,
+        "kv_put foo=bar works");
     ok (kv_delete (kv, "foo") == 0,
         "kv_delete foo works");
     errno = 0;
     ok (kv_delete (kv, "foo") < 0,
         "kv_delete foo a second time fails with ENOENT");
-    ok (kv_put_string (kv, "foo", "baz") == 0,
-        "kv_put_string foo=baz works");
+    ok (kv_put (kv, "foo", KV_STRING, "baz") == 0,
+        "kv_put foo=baz works");
 
     kv_destroy (kv);
 }
@@ -362,39 +361,39 @@ void key_update (void)
     if (!(kv = kv_create ()))
         BAIL_OUT ("kv_create failed");
 
-    ok (kv_put_string (kv, "foo", "bar") == 0,
-        "kv_put_string foo=bar works");
+    ok (kv_put (kv, "foo", KV_STRING, "bar") == 0,
+        "kv_put foo=bar works");
 
     /* Update first (only) entry
      */
-    ok (kv_put_string (kv, "foo", "baz") == 0,
-        "kv_put_string foo=baz works");
+    ok (kv_put (kv, "foo", KV_STRING, "baz") == 0,
+        "kv_put foo=baz works");
     ok (kv_get (kv, "foo", KV_STRING, &val) == 0 && !strcmp (val, "baz"),
         "kv_get foo returns baz");
 
-    ok (kv_put_string (kv, "bar", "xxx") == 0,
-        "kv_put_string bar=xxx works");
+    ok (kv_put (kv, "bar", KV_STRING, "xxx") == 0,
+        "kv_put bar=xxx works");
 
     /* Update first (of two) entry
      */
-    ok (kv_put_string (kv, "foo", "yyy") == 0,
-        "kv_put_string foo=yyy works");
+    ok (kv_put (kv, "foo", KV_STRING, "yyy") == 0,
+        "kv_put foo=yyy works");
     ok (kv_get (kv, "foo", KV_STRING, &val) == 0 && !strcmp (val, "yyy"),
         "kv_get foo returns yyy");
 
     /* Update second (of two) entry
      */
-    ok (kv_put_string (kv, "bar", "zzz") == 0,
-        "kv_put_string bar=zzz works");
+    ok (kv_put (kv, "bar", KV_STRING, "zzz") == 0,
+        "kv_put bar=zzz works");
     ok (kv_get (kv, "bar", KV_STRING, &val) == 0 && !strcmp (val, "zzz"),
         "kv_get bar returns zzz");
 
-    ok (kv_put_string (kv, "baz", "qqq") == 0,
-        "kv_put_string baz=qqq works");
+    ok (kv_put (kv, "baz", KV_STRING, "qqq") == 0,
+        "kv_put baz=qqq works");
 
     /* Update second (of three) entry
      */
-    ok (kv_put_string (kv, "bar", "111") == 0,
+    ok (kv_put (kv, "bar", KV_STRING, "111") == 0,
         "kv_put_string bar=111 works");
     ok (kv_get (kv, "bar", KV_STRING, &val) == 0 && !strcmp (val, "111"),
         "kv_get bar returns 111");
@@ -407,10 +406,10 @@ static struct kv *create_test_kv (void)
     struct kv *kv;
     if (!(kv = kv_create ()))
         BAIL_OUT ("kv_create failed");
-    if (kv_put_string (kv, "a", "foo") < 0
-        || kv_put_int64 (kv, "b", 42) < 0
-        || kv_put_double (kv, "c", 3.14) < 0
-        || kv_put_bool (kv, "d", true) < 0)
+    if (kv_put (kv, "a", KV_STRING, "foo") < 0
+        || kv_put (kv, "b", KV_INT64, 42LL) < 0
+        || kv_put (kv, "c", KV_DOUBLE, 3.14) < 0
+        || kv_put (kv, "d", KV_BOOL, true) < 0)
         BAIL_OUT ("kv_put failed");
     return kv;
 }


### PR DESCRIPTION
@grondo - what do you think about this change to the kv api which replaces the typed kv_get_TYPE, kv_put_TYPE functions with single varargs functions?

This seemed like a good idea until I recalled the fact that one can get into trouble with the lack of type promotion through varargs interfaces, specifically
```c
kv_put (kv, key, KV_INT64, 42);
```
causes an out of bounds memory access. You need
```c
kv_put (kv, key, KV_INT64, 42LL);
```

Maybe not such a good idea in a security sensitive situation?

OTOH, the reduction in API footprint is nice, especially given that this class may end up partially wrapped in several places.

Hope you don't mind me posting this half baked idea just to get your feedback. 