### PR TITLE
libutil/cf: add interface to update a cf table with multiple files

### DIFF
--- a/src/libutil/cf.c
+++ b/src/libutil/cf.c
@@ -27,6 +27,7 @@
 #endif /* HAVE_CONFIG_H */
 #include <errno.h>
 #include <string.h>
+#include <glob.h>
 #include <jansson.h>
 
 #include "src/libtomlc99/toml.h"
@@ -262,6 +263,58 @@ int cf_update (cf_t *cf, const char *buf, int len, struct cf_error *error)
 int cf_update_file (cf_t *cf, const char *filename, struct cf_error *error)
 {
     return update_object (cf, filename, NULL, 0, error);
+}
+
+int cf_update_glob (cf_t *cf, const char *pattern, struct cf_error *error)
+{
+    cf_t *tmp;
+    glob_t gl;
+    size_t i;
+    int count = -1;
+    int errnum = 0;
+    int rc = glob (pattern, GLOB_ERR, NULL, &gl);
+
+    tmp = cf_create ();
+
+    switch (rc) {
+        case 0:
+            count = 0;
+            for (i = 0; i < gl.gl_pathc; i++) {
+                if (cf_update_file (tmp, gl.gl_pathv[i], error) < 0) {
+                    errnum = errno;
+                    count = -1;
+                    break;
+                }
+                count++;
+            }
+            break;
+        case GLOB_NOMATCH:
+            count = 0;
+            errprintf (error, pattern, -1, "No match");
+            break;
+        case GLOB_NOSPACE:
+            errprintf (error, pattern, -1, "Out of memory");
+            errnum = ENOMEM;
+            break;
+        case GLOB_ABORTED:
+            errprintf (error, pattern, -1, "Read error");
+            errnum = EINVAL;
+            break;
+    }
+    globfree (&gl);
+
+    /*
+     *  If glob sucessfully processed at least one file, update
+     *   caller's cf object with all new date in tmp object:
+     */
+    if ((count > 0) &&  json_object_update (cf, tmp) < 0) {
+        errprintf (error, pattern, -1, "updating JSON object: out of memory");
+        errno = ENOMEM;
+        count = -1;
+    }
+    cf_destroy (tmp);
+    errno = errnum;
+    return (count);
 }
 
 static bool is_end_marker (struct cf_option opt)

--- a/src/libutil/cf.c
+++ b/src/libutil/cf.c
@@ -238,8 +238,7 @@ static int update_object (cf_t *cf,
         goto error;
     }
     if (json_object_update (cf, obj) < 0) {
-        errprintf (error, filename, -1, "updating JSON object: out of memory",
-                   strerror (errno));
+        errprintf (error, filename, -1, "updating JSON object: out of memory");
         errno = ENOMEM;
         goto error;
     }

--- a/src/libutil/cf.c
+++ b/src/libutil/cf.c
@@ -68,9 +68,10 @@ cf_t *cf_copy (cf_t *cf)
     return cpy;
 }
 
-static void errprintf (struct cf_error *error,
-                       const char *filename, int lineno,
-                       const char *fmt, ...)
+static void __attribute__ ((format (printf, 4, 5)))
+errprintf (struct cf_error *error,
+           const char *filename, int lineno,
+            const char *fmt, ...)
 {
     va_list ap;
     int saved_errno = errno;

--- a/src/libutil/cf.h
+++ b/src/libutil/cf.h
@@ -89,6 +89,19 @@ int cf_array_size (cf_t *cf);
 int cf_update (cf_t *cf, const char *buf, int len, struct cf_error *error);
 int cf_update_file (cf_t *cf, const char *filename, struct cf_error *error);
 
+/* Update table 'cf' with info parsed from all filenames matching the
+ * wildcard 'pattern', following the rules for the glob(3) function call.
+ * On success returns the number of individual files successfully parsed,
+ * or 0 when there are no files that match 'pattern'.
+ *
+ * If any one file has a non-zero return code from cf_update_file(), then
+ * the entire operation is aborted (no updates are written to 'cf'), and
+ * -1 is returned with errno from cf_update_file() set.
+ *
+ * If error is non-NULL the description of the error is written there.
+ */
+int cf_update_glob (cf_t *cf, const char *pattern, struct cf_error *error);
+
 /* Apply 'opts' to table 'cf' according to flags.
  * On success return 0.  On failure, return -1 with errno set.
  * If error is non-NULL, write error description there.


### PR DESCRIPTION
This PR adds a `cf_update_glob()` call to iteratively call `cf_update_file()` on all files matching a pattern. It is meant to be used for loading TOML files from a `conf.d` style directory, e.g. `cf_update_glob (cf, "/etc/conf.d/*.toml")`.

Some decisions here were made that probably need to be vetted. The call only updates the `cf` table if *all* files matching the pattern parse and are loaded successfully. That seemed the most sane way to do it.

The return value from the function is the number of files successfully parsed, or -1 on an unrecoverable error (ENOMEM or if `glob(3)` can't open a directory). A return value of zero therefore means there was no error, but no files matched the pattern. I figured this was not necessarily an error condition, but the caller may want to test for it.
