### PR TITLE
libutil/sigcert: use kv serialization not JSON

### DIFF
--- a/src/libutil/Makefile.am
+++ b/src/libutil/Makefile.am
@@ -27,7 +27,9 @@ libutil_la_SOURCES = \
 	kv.c \
 	kv.h \
 	sigcert.c \
-	sigcert.h
+	sigcert.h \
+	timestamp.c \
+	timestamp.h
 
 TESTS = \
 	test_base64.t \

--- a/src/libutil/kv.c
+++ b/src/libutil/kv.c
@@ -36,6 +36,7 @@
 #include <stdarg.h>
 #include <assert.h>
 
+#include "timestamp.h"
 #include "kv.h"
 
 #define KV_CHUNK 4096
@@ -241,11 +242,8 @@ int kv_vput (struct kv *kv, const char *key, enum kv_type type, va_list ap)
             break;
         }
         case KV_TIMESTAMP: {
-            struct tm tm;
             time_t t = va_arg (ap, time_t);
-            if (t < 0 || !gmtime_r (&t, &tm))
-                goto inval;
-             if (strftime (s, sizeof (s), "%FT%TZ", &tm) == 0)
+            if (timestamp_tostr (t, s, sizeof (s)) < 0)
                 goto inval;
             val = s;
             break;
@@ -318,10 +316,9 @@ bool kv_val_bool (const char *key)
 
 time_t kv_val_timestamp (const char *key)
 {
-    struct tm tm;
     time_t t;
     const char *s = kv_val_string (key);
-    if (!strptime (s, "%FT%TZ", &tm) || (t = timegm (&tm)) < 0)
+    if (timestamp_fromstr (s, &t) < 0)
         return 0;
     return t;
 }

--- a/src/libutil/kv.c
+++ b/src/libutil/kv.c
@@ -434,7 +434,7 @@ inval:
     return -1;
 }
 
-int kv_raw_encode (const struct kv *kv, const char **buf, int *len)
+int kv_encode (const struct kv *kv, const char **buf, int *len)
 {
     if (!kv || !buf || !len) {
         errno = EINVAL;
@@ -445,7 +445,7 @@ int kv_raw_encode (const struct kv *kv, const char **buf, int *len)
     return 0;
 }
 
-struct kv *kv_raw_decode (const char *buf, int len)
+struct kv *kv_decode (const char *buf, int len)
 {
     struct kv *kv;
 

--- a/src/libutil/kv.h
+++ b/src/libutil/kv.h
@@ -72,12 +72,12 @@ int kv_get (const struct kv *kv, const char *key, enum kv_type type, ...);
 /* Access internal binary encoding.
  * Return 0 on success, -1 on failure with errno set.
  */
-int kv_raw_encode (const struct kv *kv, const char **buf, int *len);
+int kv_encode (const struct kv *kv, const char **buf, int *len);
 
 /* Create kv object from binary encoding.
  * Return kv object on success, NULL on failure with errno set.
  */
-struct kv *kv_raw_decode (const char *buf, int len);
+struct kv *kv_decode (const char *buf, int len);
 
 /* Iteration example:
  *

--- a/src/libutil/kv.h
+++ b/src/libutil/kv.h
@@ -29,6 +29,7 @@ struct kv *kv_copy (const struct kv *kv);
 
 /* Add kv2 entries to kv1, prepending 'prefix' to its keys (if non-NULL).
  * When there are key conflicts, values from kv2 override kv1.
+ * Return 0 on success, -1 on failure with errno set.
  */
 int kv_join (struct kv *kv1, const struct kv *kv2, const char *prefix);
 
@@ -50,6 +51,8 @@ bool kv_equal (const struct kv *kv1, const struct kv *kv2);
 int kv_delete (struct kv *kv, const char *key);
 
 /* Add key=val to kv object.
+ * N.B. take care that KV_INT64 and KV_TIMESTAMP arguments are the expected
+ * size, remembering that default integer argument promotion is to "int".
  * Return 0 on success, -1 on failure with errno set:
  *   EINVAL - invalid argument
  *   ENOMEM - out of memory

--- a/src/libutil/test/keygen.c
+++ b/src/libutil/test/keygen.c
@@ -43,10 +43,10 @@ void generate_cert (const char *target_path)
         die ("sigcert_create");
     if (time (&t) == (time_t)-1)
         die ("time");
-    if (sigcert_meta_setts (cert, "create-time", t) < 0)
-        die ("sigcert_meta_setts");
-    if (sigcert_meta_seti (cert, "userid", getuid ()) < 0)
-        die ("sigcert_meta_seti");
+    if (sigcert_meta_set (cert, "create-time", SM_TIMESTAMP, t) < 0)
+        die ("sigcert_meta_set create-time");
+    if (sigcert_meta_set (cert, "userid", SM_INT64, (int64_t)getuid ()) < 0)
+        die ("sigcert_meta_set userid");
     fprintf (stderr, "keygen: updating %s\n", target_path);
     if (sigcert_store (cert, target_path) < 0)
         die ("sigcert_store");
@@ -68,14 +68,14 @@ void sign_cert (const char *signer_path, const char *target_path)
     if (!(cert2 = sigcert_load (target_path, false)))
         die ("load %s", target_path);
 
-    if (sigcert_meta_geti (cert1, "userid", &userid) < 0)
-        die ("sigcert_meta_setts");
-    if (sigcert_meta_seti (cert2, "ca-userid", userid) < 0)
-        die ("sigcert_meta_setts");
+    if (sigcert_meta_get (cert1, "userid", SM_INT64, &userid) < 0)
+        die ("sigcert_meta_get userid");
+    if (sigcert_meta_set (cert2, "ca-userid", SM_INT64, userid) < 0)
+        die ("sigcert_meta_set ca-userid");
     if (time (&t) == (time_t)-1)
         die ("time");
-    if (sigcert_meta_setts (cert2, "ca-signed-time", t) < 0)
-        die ("sigcert_meta_setts");
+    if (sigcert_meta_set (cert2, "ca-signed-time", SM_TIMESTAMP, t) < 0)
+        die ("sigcert_meta_set ca-signed-time");
 
     if (sigcert_sign_cert (cert1, cert2) < 0)
         die ("sigcert_sign_cert");

--- a/src/libutil/test/kv.c
+++ b/src/libutil/test/kv.c
@@ -17,7 +17,7 @@ static void diag_kv (struct kv *kv)
     int len;
     int i;
 
-    if (kv_raw_encode (kv, &buf, &len) < 0)
+    if (kv_encode (kv, &buf, &len) < 0)
         BAIL_OUT ("diag_kv: %s", strerror (errno));
     printf ("# ");
     for (i = 0; i < len; i++) {
@@ -135,11 +135,11 @@ static void simple_test (void)
 
     /* Create a new copy through raw "codec" and check for equality.
      */
-    ok (kv_raw_encode (kv, &s, &len) == 0,
-        "kv_raw_encode works");
-    kv3 = kv_raw_decode (s, len);
+    ok (kv_encode (kv, &s, &len) == 0,
+        "kv_encode works");
+    kv3 = kv_decode (s, len);
     ok (kv3 != NULL,
-        "kv_raw_decode works");
+        "kv_decode works");
     ok (kv_equal (kv, kv3),
         "kv_equal says new copy is identical");
 
@@ -159,12 +159,12 @@ static void empty_object (void)
         "kv_create works");
     ok (kv_next (kv, NULL) == NULL,
         "kv_next key=NULL returns NULL");
-    ok (kv_raw_encode (kv, &buf, &len) == 0,
-        "kv_raw_encode works");
+    ok (kv_encode (kv, &buf, &len) == 0,
+        "kv_encode works");
 
-    kv2 = kv_raw_decode (buf, len);
+    kv2 = kv_decode (buf, len);
     ok (kv2 != NULL,
-        "kv_raw_decode works");
+        "kv_decode works");
     ok (kv_equal (kv, kv2),
         "kv_equal says they are identical");
 
@@ -300,35 +300,35 @@ static void bad_parameters (void)
     ok (kv_val_timestamp (NULL) == 0.,
         "kv_val_timestamp key=NULL returns 0");
 
-    /* kv_raw_encode
+    /* kv_encode
      */
     errno = 0;
-    ok (kv_raw_encode (NULL, &s, &len) < 0 && errno == EINVAL,
-        "kv_raw_encode kv=NULL fails with EINVAL");
+    ok (kv_encode (NULL, &s, &len) < 0 && errno == EINVAL,
+        "kv_encode kv=NULL fails with EINVAL");
     errno = 0;
-    ok (kv_raw_encode (kv, NULL, &len) < 0 && errno == EINVAL,
-        "kv_raw_encode buf=NULL fails with EINVAL");
+    ok (kv_encode (kv, NULL, &len) < 0 && errno == EINVAL,
+        "kv_encode buf=NULL fails with EINVAL");
     errno = 0;
-    ok (kv_raw_encode (kv, &s, NULL) < 0 && errno == EINVAL,
-        "kv_raw_encode len=NULL fails with EINVAL");
+    ok (kv_encode (kv, &s, NULL) < 0 && errno == EINVAL,
+        "kv_encode len=NULL fails with EINVAL");
 
-    /* kv_raw_decode
+    /* kv_decode
      */
     errno = 0;
-    ok (kv_raw_decode ("foo\0sbar\0", -1) == NULL && errno == EINVAL,
-        "kv_raw_decode len=-1 fails with EINVAL");
+    ok (kv_decode ("foo\0sbar\0", -1) == NULL && errno == EINVAL,
+        "kv_decode len=-1 fails with EINVAL");
     errno = 0;
-    ok (kv_raw_decode (NULL, 1) == NULL && errno == EINVAL,
-        "kv_raw_decode buf=NULL len=1 fails with EINVAL");
+    ok (kv_decode (NULL, 1) == NULL && errno == EINVAL,
+        "kv_decode buf=NULL len=1 fails with EINVAL");
     errno = 0;
-    ok (kv_raw_decode ("foo\0sbar", 8) == NULL && errno == EINVAL,
-        "kv_raw_decode buf=(unterm) fails with EINVAL");
+    ok (kv_decode ("foo\0sbar", 8) == NULL && errno == EINVAL,
+        "kv_decode buf=(unterm) fails with EINVAL");
     errno = 0;
-    ok (kv_raw_decode ("foo\0sbar\0foobar\0", 16) == NULL && errno == EINVAL,
-        "kv_raw_decode buf=(no delim entry) fails with EINVAL");
+    ok (kv_decode ("foo\0sbar\0foobar\0", 16) == NULL && errno == EINVAL,
+        "kv_decode buf=(no delim entry) fails with EINVAL");
     errno = 0;
-    ok (kv_raw_decode ("foo\0sbar\0\0sfoobar\0", 18) == NULL && errno == EINVAL,
-        "kv_raw_decode buf=(empty key entry) fails with EINVAL");
+    ok (kv_decode ("foo\0sbar\0\0sfoobar\0", 18) == NULL && errno == EINVAL,
+        "kv_decode buf=(empty key entry) fails with EINVAL");
 
     kv_destroy (kv);
     kv_destroy (kv2);

--- a/src/libutil/timestamp.c
+++ b/src/libutil/timestamp.c
@@ -1,0 +1,58 @@
+/*****************************************************************************\
+ *  Copyright (c) 2017 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
+
+#include <time.h>
+
+#include "timestamp.h"
+
+int timestamp_tostr (time_t t, char *buf, int size)
+{
+    struct tm tm;
+    if (t < 0 || !gmtime_r (&t, &tm))
+        return -1;
+    if (strftime (buf, size, "%FT%TZ", &tm) == 0)
+        return -1;
+    return 0;
+}
+
+int timestamp_fromstr (const char *s, time_t *tp)
+{
+    struct tm tm;
+    time_t t;
+    if (!strptime (s, "%FT%TZ", &tm))
+        return -1;
+    if ((t = timegm (&tm)) < 0)
+        return -1;
+    if (tp)
+        *tp = t;
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/libutil/timestamp.h
+++ b/src/libutil/timestamp.h
@@ -1,0 +1,20 @@
+#ifndef _UTIL_TIMESTAMP_H
+#define _UTIL_TIMESTAMP_H
+
+#include <time.h>
+
+/* Convert time_t (GMT) to ISO 8601 timestamp string,
+ * e.g. "2003-08-24T05:14:50Z"
+ */
+int timestamp_tostr (time_t t, char *buf, int size);
+
+/* Convert from ISO 8601 string to time_t.
+ */
+int timestamp_fromstr (const char *s, time_t *tp);
+
+
+#endif /* !_UTIL_TIMESTAMP_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */


### PR DESCRIPTION
This PR makes a few minor changes to the kv class
* restore header comment that was somehow dropped before merge of pr #32 
* factor out time_t/string conversion functions to timestamp.[ch]
* rename kv_raw_encode() to kv_encode(), kv_raw_decode() to kv_decode()

Then it reworks the sigcert class to use kv internally instead of JSON, and to replace JSON serialization with kv serialization.