### PR TITLE
libutil/cf:  make some cf_t parameters const

### DIFF
--- a/src/libutil/cf.h
+++ b/src/libutil/cf.h
@@ -54,33 +54,33 @@ void cf_destroy (cf_t *cf);
 
 /* Copy a cf_t object.  Destroy with cf_destroy().
  */
-cf_t *cf_copy (cf_t *cf);
+cf_t *cf_copy (const cf_t *cf);
 
 /* Get type of cf_t object.
  */
-enum cf_type cf_typeof (cf_t *cf);
+enum cf_type cf_typeof (const cf_t *cf);
 
 /* Get cf_t object from table.  Do not free.
  */
-cf_t *cf_get_in (cf_t *cf, const char *key);
+const cf_t *cf_get_in (const cf_t *cf, const char *key);
 
 /* Get cf_t object from array.  Do not free.
  */
-cf_t *cf_get_at (cf_t *cf, int index);
+const cf_t *cf_get_at (const cf_t *cf, int index);
 
 /* Access object as a particular type.
  * If wrong type or NULL cf, default value is returned.
  */
-int64_t cf_int64 (cf_t *cf);        // default: 0
-double cf_double (cf_t *cf);        // default: 0.
-const char *cf_string (cf_t *cf);   // default: ""
-bool cf_bool (cf_t *cf);            // default: false
-time_t cf_timestamp (cf_t *cf);     // default: 0
+int64_t cf_int64 (const cf_t *cf);        // default: 0
+double cf_double (const cf_t *cf);        // default: 0.
+const char *cf_string (const cf_t *cf);   // default: ""
+bool cf_bool (const cf_t *cf);            // default: false
+time_t cf_timestamp (const cf_t *cf);     // default: 0
 
 /* Get array size.
  * If object is not an array, return 0.
  */
-int cf_array_size (cf_t *cf);
+int cf_array_size (const cf_t *cf);
 
 /* Update table 'cf' with info parsed from TOML 'buf' or 'filename'.
  * On success return 0.  On failure, return -1 with errno set.
@@ -106,7 +106,7 @@ int cf_update_glob (cf_t *cf, const char *pattern, struct cf_error *error);
  * On success return 0.  On failure, return -1 with errno set.
  * If error is non-NULL, write error description there.
  */
-int cf_check (cf_t *cf, const struct cf_option opts[], int flags,
+int cf_check (const cf_t *cf, const struct cf_option opts[], int flags,
               struct cf_error *error);
 
 #endif /* !_UTIL_CF_H */

--- a/src/libutil/test/cf.c
+++ b/src/libutil/test/cf.c
@@ -84,7 +84,8 @@ void cfdiag (int rc, const char *prefix, struct cf_error *error)
 
 void test_basic (void)
 {
-    cf_t *cf, *cf2;
+    cf_t *cf, *cf_cpy;
+    const cf_t *cf2;
     struct cf_error error;
     int rc;
     const char *s;
@@ -100,12 +101,12 @@ void test_basic (void)
 
     /* Copy a cf object.
      */
-    cf2 = cf_copy (cf);
-    ok (cf2 != NULL,
+    cf_cpy = cf_copy (cf);
+    ok (cf_cpy != NULL,
         "cf_copy works");
     ok (cf_typeof (cf) == CF_TABLE,
         "cf_typeof says copy is CF_TABLE");
-    cf_destroy (cf2);
+    cf_destroy (cf_cpy);
 
     /* Read some TOML into the cf top level table
      */
@@ -162,7 +163,8 @@ void test_basic (void)
 
 void test_multi (void)
 {
-    cf_t *cf, *cf2;
+    cf_t *cf;
+    const cf_t *cf2;
     int rc;
     struct cf_error error;
 
@@ -237,7 +239,7 @@ void test_multi (void)
 void test_corner (void)
 {
     cf_t *cf;
-    cf_t *cf_array;
+    const cf_t *cf_array;
     struct cf_error error;
 
     if (!(cf = cf_create ()))
@@ -263,8 +265,6 @@ void test_corner (void)
     ok (cf_update (NULL, NULL, 0, &error) < 0 && errno == EINVAL,
         "cf_update cf=NULL fails with EINVAL");
     errno = 0;
-    ok (cf_update (cf_array, NULL, 0, &error) < 0 && errno == EINVAL,
-        "cf_update cf=(not table) fails with EINVAL");
     ok (cf_update (cf, NULL, 0, &error) == 0,
         "cf_update buf=NULL works (no-op)");
     errno = 0;
@@ -432,7 +432,8 @@ void test_update_glob (void)
     char invalid[PATH_MAX + 1];
     char p [1024];
 
-    cf_t *cf, *cf2, *cf3;
+    cf_t *cf;
+    const cf_t *cf2, *cf3;
     struct cf_error error;
 
 

--- a/src/libutil/tomltk.c
+++ b/src/libutil/tomltk.c
@@ -110,11 +110,14 @@ int tomltk_ts_to_epoch (toml_timestamp_t *ts, time_t *tp)
     return 0;
 }
 
-int tomltk_json_to_epoch (json_t *obj, time_t *tp)
+int tomltk_json_to_epoch (const json_t *obj, time_t *tp)
 {
     const char *s;
 
-    if (!obj || json_unpack (obj, "{s:s}", "iso-8601-ts", &s) < 0) {
+    /* N.B. 'O' specifier not used, hence obj is not in danger
+     * of being modified by json_unpack.
+     */
+    if (!obj || json_unpack ((json_t *)obj, "{s:s}", "iso-8601-ts", &s) < 0) {
         errno = EINVAL;
         return -1;
     }

--- a/src/libutil/tomltk.h
+++ b/src/libutil/tomltk.h
@@ -25,7 +25,7 @@ json_t *tomltk_table_to_json (toml_table_t *tab);
 /* Convert timestamp JSON object to a time_t (UTC).
  * Return 0 on success, or -1 on failure with errno set.
  */
-int tomltk_json_to_epoch (json_t *obj, time_t *t);
+int tomltk_json_to_epoch (const json_t *obj, time_t *t);
 
 /* Convert time_t (UTC) to a timestamp JSON object.
  * Return new object on success, NULL on failure with errno set.


### PR DESCRIPTION
A number of `cf_t *` parameters in the cf class should have been tagged `const` for better clarity.