### PR TITLE
Add basic skeleton for the IMP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ before_install:
   - export PKG_CONFIG_PATH=$HOME/local/lib/pkgconfig:$HOME/local/share/pkgconfig
 
 script:
+  - export FLUX_TESTS_LOGFILE=t
   # Force update to allow version m4 to work
   - ( git fetch --unshallow --tags || true )
   - ./autogen.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ before_install:
   - export PKG_CONFIG_PATH=$HOME/local/lib/pkgconfig:$HOME/local/share/pkgconfig
 
 script:
+  # Force update to allow version m4 to work
+  - ( git fetch --unshallow --tags || true )
   - ./autogen.sh
   - ./configure ${ARGS}
   - eval ${MAKECMDS:-make && make check}

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,3 +38,6 @@ script:
 
 after_success:
   - if test "$COVERAGE" = "t"; then bash <(curl -s https://codecov.io/bash); fi
+
+after_failure:
+  - find . -name t[0-9]*.output | xargs -i sh -c 'printf "\033[31mFound {}\033[39m\n";cat {}'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
-sudo: false
+sudo: true
 
 matrix:
   include:

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS =         src
+SUBDIRS =         src t
 ACLOCAL_AMFLAGS = -I config
 EXTRA_DIST = \
 	config/tap-driver.sh \

--- a/configure.ac
+++ b/configure.ac
@@ -80,6 +80,7 @@ AX_CODE_COVERAGE
 #
 AC_CONFIG_FILES( \
   Makefile \
+  t/Makefile \
   src/Makefile \
   src/lib/Makefile \
   src/libtap/Makefile \

--- a/src/imp/Makefile.am
+++ b/src/imp/Makefile.am
@@ -22,7 +22,9 @@ flux_imp_SOURCES = \
 	imp_log.c
 
 TESTS = \
-	test_imp_log.t
+	test_imp_log.t \
+	test_privsep.t
+
 check_PROGRAMS = \
 	$(TESTS)
 
@@ -40,3 +42,12 @@ test_imp_log_t_SOURCES =  \
 	imp_log.h
 
 test_imp_log_t_LDADD = $(test_ldadd)
+
+test_privsep_t_SOURCES = \
+	test/privsep.c \
+	privsep.c \
+	privsep.h \
+	imp_log.h \
+	imp_log.c
+
+test_privsep_t_LDADD = $(test_ldadd)

--- a/src/imp/Makefile.am
+++ b/src/imp/Makefile.am
@@ -47,6 +47,8 @@ test_privsep_t_SOURCES = \
 	test/privsep.c \
 	privsep.c \
 	privsep.h \
+	sudosim.h \
+	sudosim.c \
 	imp_log.h \
 	imp_log.c
 

--- a/src/imp/Makefile.am
+++ b/src/imp/Makefile.am
@@ -22,6 +22,9 @@ flux_imp_SOURCES = \
 	imp_log.h \
 	imp_log.c
 
+EXTRA_DIST = \
+	imp.conf.d
+
 TESTS = \
 	test_imp_log.t \
 	test_privsep.t \

--- a/src/imp/Makefile.am
+++ b/src/imp/Makefile.am
@@ -23,7 +23,8 @@ flux_imp_SOURCES = \
 
 TESTS = \
 	test_imp_log.t \
-	test_privsep.t
+	test_privsep.t \
+	test_impcmd.t
 
 check_PROGRAMS = \
 	$(TESTS)
@@ -53,3 +54,10 @@ test_privsep_t_SOURCES = \
 	imp_log.c
 
 test_privsep_t_LDADD = $(test_ldadd)
+
+test_impcmd_t_SOURCES =  \
+	test/impcmd.c \
+	impcmd.c \
+	impcmd.h
+
+test_impcmd_t_LDADD = $(test_ldadd)

--- a/src/imp/Makefile.am
+++ b/src/imp/Makefile.am
@@ -22,6 +22,12 @@ flux_imp_SOURCES = \
 	imp_state.h \
 	imp_log.h \
 	imp_log.c \
+	privsep.c \
+	privsep.h \
+	impcmd-list.c \
+	impcmd.c \
+	impcmd.h \
+	version.c \
 	testconfig.c
 
 testconfig.c: $(top_builddir)/config/config.h

--- a/src/imp/Makefile.am
+++ b/src/imp/Makefile.am
@@ -18,6 +18,7 @@ flux_imp_LDADD = \
 
 flux_imp_SOURCES = \
 	imp.c \
+	imp_state.h \
 	imp_log.h \
 	imp_log.c
 

--- a/src/imp/Makefile.am
+++ b/src/imp/Makefile.am
@@ -14,13 +14,23 @@ libexec_PROGRAMS = \
 	flux-imp
 
 flux_imp_LDADD = \
-	$(top_builddir)/src/libutil/libutil.la
+	$(top_builddir)/src/libutil/libutil.la \
+	$(top_builddir)/src/libtomlc99/libtomlc99.la
 
 flux_imp_SOURCES = \
 	imp.c \
 	imp_state.h \
 	imp_log.h \
-	imp_log.c
+	imp_log.c \
+	testconfig.c
+
+testconfig.c: $(top_builddir)/config/config.h
+	@(confdir=`cd $(srcdir) && pwd`/imp.conf.d; \
+	  echo "const char *imp_config_pattern = \"$$confdir/*.toml\";" \
+	 )> testconfig.c
+
+MOSTLYCLEANFILES = \
+	testconfig.c
 
 EXTRA_DIST = \
 	imp.conf.d

--- a/src/imp/Makefile.am
+++ b/src/imp/Makefile.am
@@ -27,6 +27,8 @@ flux_imp_SOURCES = \
 	impcmd-list.c \
 	impcmd.c \
 	impcmd.h \
+	sudosim.c \
+	sudosim.h \
 	version.c \
 	testconfig.c
 

--- a/src/imp/Makefile.am
+++ b/src/imp/Makefile.am
@@ -30,6 +30,7 @@ flux_imp_SOURCES = \
 	sudosim.c \
 	sudosim.h \
 	version.c \
+	whoami.c \
 	testconfig.c
 
 testconfig.c: $(top_builddir)/config/config.h

--- a/src/imp/imp.c
+++ b/src/imp/imp.c
@@ -34,17 +34,12 @@
 
 /*  Static prototypes:
  */
+static void initialize_logging ();
 static void print_version (void);
-static int  log_stderr (int level, const char *str, void *arg);
 
 int main (int argc, char *argv[])
 {
-    imp_openlog ();
-
-    if (imp_log_add ("stderr", IMP_LOG_INFO, log_stderr, NULL) < 0) {
-        fprintf (stderr, "flux-imp: Failed to initialize logging. Aborting.\n");
-        exit (1);
-    }
+    initialize_logging ();
 
     if (argc < 2)
         imp_die (1, "IMP requires a command, master!");
@@ -85,6 +80,15 @@ static int log_stderr (int level, const char *str,
     else
         fprintf (stderr, "flux-imp: %s: %s\n", imp_log_strlevel (level), str);
     return (0);
+}
+
+static void initialize_logging (void)
+{
+    imp_openlog ();
+    if (imp_log_add ("stderr", IMP_LOG_INFO, log_stderr, NULL) < 0) {
+        fprintf (stderr, "flux-imp: Fatal: Failed to initialize logging.\n");
+        exit (1);
+    }
 }
 
 

--- a/src/imp/imp.c
+++ b/src/imp/imp.c
@@ -37,7 +37,6 @@
 /*  Static prototypes:
  */
 static void initialize_logging ();
-static void print_version (void);
 static int  imp_state_init (struct imp_state *imp, int argc, char **argv);
 
 int main (int argc, char *argv[])
@@ -48,12 +47,6 @@ int main (int argc, char *argv[])
 
     if (imp_state_init (&imp, argc, argv) < 0)
         imp_die (1, "Initialization error");
-
-    if (argc < 2)
-        imp_die (1, "IMP requires a command, master!");
-
-    if (argc == 2 && strncmp (argv[1], "version", 7) == 0)
-        print_version ();
 
     /*  Configuration:
      */
@@ -73,11 +66,6 @@ int main (int argc, char *argv[])
 
     imp_closelog ();
     exit (0);
-}
-
-static void print_version ()
-{
-    printf ("flux-imp v%s\n", PACKAGE_VERSION);
 }
 
 static int log_stderr (int level, const char *str,

--- a/src/imp/imp.c
+++ b/src/imp/imp.c
@@ -29,17 +29,25 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
+#include "imp_state.h"
 #include "imp_log.h"
 
 /*  Static prototypes:
  */
 static void initialize_logging ();
 static void print_version (void);
+static int  imp_state_init (struct imp_state *imp, int argc, char **argv);
 
 int main (int argc, char *argv[])
 {
+    struct imp_state imp;
+
     initialize_logging ();
+
+    if (imp_state_init (&imp, argc, argv) < 0)
+        imp_die (1, "Initialization error");
 
     if (argc < 2)
         imp_die (1, "IMP requires a command, master!");
@@ -91,6 +99,13 @@ static void initialize_logging (void)
     }
 }
 
+static int imp_state_init (struct imp_state *imp, int argc, char *argv[])
+{
+    memset (imp, 0, sizeof (*imp));
+    imp->argc = argc;
+    imp->argv = argv;
+    return (0);
+}
 
 /*
  * vi: ts=4 sw=4 expandtab

--- a/src/imp/imp.conf.d/imp.toml
+++ b/src/imp/imp.conf.d/imp.toml
@@ -1,0 +1,1 @@
+allow-sudo = true

--- a/src/imp/imp_state.h
+++ b/src/imp/imp_state.h
@@ -22,27 +22,12 @@
  *  See also:  http://www.gnu.org/licenses/
 \*****************************************************************************/
 
-#ifndef HAVE_IMPCMD_H
-#define HAVE_IMPCMD_H 1
+#ifndef HAVE_IMP_STATE_H
+#define HAVE_IMP_STATE_H 1
 
-#include "imp_state.h"
-
-typedef int (*imp_cmd_f) (struct imp_state *imp);
-
-struct impcmd {
-    const char *name;
-    imp_cmd_f child_fn;
-    imp_cmd_f parent_fn;
+struct imp_state {
+    int        argc;
+    char     **argv;        /* cmdline arguments from main() */
 };
 
-/*  Return unprivileged child version of IMP command with `name`, or NULL
- *   if no such command found.
- */
-imp_cmd_f imp_cmd_find_child (const char *name);
-
-/*  Return privileged parent version of IMP command with `name`, or NULL
- *   if no such command found.
- */
-imp_cmd_f imp_cmd_find_parent (const char *name);
-
-#endif /* !HAVE_IMPCMD_H */
+#endif /* !HAVE_IMP_STATE_H */

--- a/src/imp/imp_state.h
+++ b/src/imp/imp_state.h
@@ -26,11 +26,13 @@
 #define HAVE_IMP_STATE_H 1
 
 #include "src/libutil/cf.h"
+#include "privsep.h"
 
 struct imp_state {
     int        argc;
     char     **argv;        /* cmdline arguments from main() */
     cf_t      *conf;        /* IMP configuration */
+    privsep_t *ps;          /* Privilege separation handle */
 };
 
 #endif /* !HAVE_IMP_STATE_H */

--- a/src/imp/imp_state.h
+++ b/src/imp/imp_state.h
@@ -25,9 +25,12 @@
 #ifndef HAVE_IMP_STATE_H
 #define HAVE_IMP_STATE_H 1
 
+#include "src/libutil/cf.h"
+
 struct imp_state {
     int        argc;
     char     **argv;        /* cmdline arguments from main() */
+    cf_t      *conf;        /* IMP configuration */
 };
 
 #endif /* !HAVE_IMP_STATE_H */

--- a/src/imp/impcmd-list.c
+++ b/src/imp/impcmd-list.c
@@ -26,6 +26,8 @@
 #include "impcmd.h"
 
 extern int imp_cmd_version (struct imp_state *imp, struct kv *);
+extern int imp_whoami_unprivileged (struct imp_state *imp, struct kv *);
+extern int imp_whoami_privileged (struct imp_state *imp, struct kv *);
 
 /*  List of supported imp commands, curated by hand for now.
  *   For each named command, the `child_fn` runs unprivileged and the
@@ -36,6 +38,9 @@ extern int imp_cmd_version (struct imp_state *imp, struct kv *);
 struct impcmd impcmd_list[] = {
 	{ "version",
 	  imp_cmd_version, NULL },
+	{ "whoami",
+	  imp_whoami_unprivileged,
+      imp_whoami_privileged },
 	{ NULL, NULL, NULL}
 };
 

--- a/src/imp/impcmd-list.c
+++ b/src/imp/impcmd-list.c
@@ -34,6 +34,8 @@ extern int imp_cmd_version (struct imp_state *imp, struct kv *);
  *
  */
 struct impcmd impcmd_list[] = {
+	{ "version",
+	  imp_cmd_version, NULL },
 	{ NULL, NULL, NULL}
 };
 

--- a/src/imp/impcmd-list.c
+++ b/src/imp/impcmd-list.c
@@ -1,0 +1,41 @@
+/*****************************************************************************\
+ *  Copyright (c) 2017 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#include "src/libutil/kv.h"
+#include "impcmd.h"
+
+extern int imp_cmd_version (struct imp_state *imp, struct kv *);
+
+/*  List of supported imp commands, curated by hand for now.
+ *   For each named command, the `child_fn` runs unprivileged and the
+ *   `parent_fn` runs privileged. The child function communicates to
+ *   the parent using privsep_write/read.
+ *
+ */
+struct impcmd impcmd_list[] = {
+	{ NULL, NULL, NULL}
+};
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/imp/impcmd.c
+++ b/src/imp/impcmd.c
@@ -1,0 +1,60 @@
+/*****************************************************************************\
+ *  Copyright (c) 2017 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#include <stdio.h>
+#include <string.h>
+
+#include "impcmd.h"
+
+extern struct impcmd impcmd_list[];
+
+static struct impcmd * imp_cmd_lookup (const char *name)
+{
+    struct impcmd *cmd = &impcmd_list[0];
+    while (cmd->name != NULL) {
+        if (strcmp (name, cmd->name) == 0)
+            return (cmd);
+        cmd++;
+    }
+    return (NULL);
+}
+
+imp_cmd_f imp_cmd_find_child (const char *name)
+{
+    struct impcmd *cmd = imp_cmd_lookup (name);
+    if (cmd)
+        return (cmd->child_fn);
+    return (NULL);
+}
+
+imp_cmd_f imp_cmd_find_parent (const char *name)
+{
+    struct impcmd *cmd = imp_cmd_lookup (name);
+    if (cmd)
+        return (cmd->parent_fn);
+    return (NULL);
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/imp/impcmd.h
+++ b/src/imp/impcmd.h
@@ -25,9 +25,10 @@
 #ifndef HAVE_IMPCMD_H
 #define HAVE_IMPCMD_H 1
 
+#include "src/libutil/kv.h"
 #include "imp_state.h"
 
-typedef int (*imp_cmd_f) (struct imp_state *imp);
+typedef int (*imp_cmd_f) (struct imp_state *imp, struct kv *kv);
 
 struct impcmd {
     const char *name;

--- a/src/imp/impcmd.h
+++ b/src/imp/impcmd.h
@@ -1,0 +1,48 @@
+/*****************************************************************************\
+ *  Copyright (c) 2017 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef HAVE_IMPCMD_H
+#define HAVE_IMPCMD_H 1
+
+struct imp_state;
+
+typedef int (*imp_cmd_f) (struct imp_state *imp);
+
+struct impcmd {
+    const char *name;
+    imp_cmd_f child_fn;
+    imp_cmd_f parent_fn;
+};
+
+/*  Return unprivileged child version of IMP command with `name`, or NULL
+ *   if no such command found.
+ */
+imp_cmd_f imp_cmd_find_child (const char *name);
+
+/*  Return privileged parent version of IMP command with `name`, or NULL
+ *   if no such command found.
+ */
+imp_cmd_f imp_cmd_find_parent (const char *name);
+
+#endif /* !HAVE_IMPCMD_H */

--- a/src/imp/privsep.c
+++ b/src/imp/privsep.c
@@ -1,0 +1,332 @@
+/*****************************************************************************\
+ *  Copyright (c) 2017 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <assert.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/wait.h>
+#include <signal.h>
+#include <string.h>
+#include <errno.h>
+
+/*  Max size of KV array allowed to be sent over privsep pipe */
+#define PRIVSEP_MAX_KVLEN 1024*1024*4
+
+#include "privsep.h"
+#include "imp_log.h"
+
+struct privsep {
+    bool enabled;
+
+    pid_t cpid;    /* unprivileged child pid */
+    pid_t ppid;    /* privileged parent pid  */
+
+    int upfds[2];  /* unpriv child pipefds (cpfd[0] is child read fd)      */
+    int ppfds[2];  /* priv parent pipefds (ppfd[0] is priv parent read fd) */
+
+    int wfd;       /* Copy of current process' write fd */
+    int rfd;       /* Copy of current process' read fd  */
+};
+
+static int wakeup_child (privsep_t *ps)
+{
+    char c = 0;
+    assert (privsep_is_parent (ps));
+    if (write (ps->wfd, &c, sizeof (c)) != sizeof (c))
+        return (-1);
+    return (0);
+}
+
+static int wait_for_parent (privsep_t *ps)
+{
+    char c;
+    assert (privsep_is_child (ps));
+    if (read (ps->rfd, &c, sizeof (c)) != sizeof (c))
+        return (-1);
+    return (0);
+}
+
+void drop_privileges ()
+{
+    uid_t ruid = -1, euid, suid;
+    gid_t rgid = -1, egid, sgid;
+
+    if (  (getresuid (&ruid, &euid, &suid) < 0)
+       || (getresgid (&rgid, &egid, &sgid) < 0))
+        imp_die (1, "getresuid/getresgid");
+
+    if (setresgid (rgid, rgid, rgid) < 0)
+        imp_die (1, "setresgid");
+    if (setresuid (ruid, ruid, ruid) < 0)
+        imp_die (1, "setresuid");
+
+     /*  Verify privilege cannot be restored */
+    if (setreuid (-1, 0) == 0)
+        imp_die (1, "irreversible switch to uid %ld failed");
+}
+
+static void child_pfds_setup (privsep_t *ps)
+{
+    /* Set child read and write fds to read end of upfds and
+     *  write end of ppfds respectively. Then close fds we don't want
+     *  to bother passing to the unprivilged child.
+     */
+    ps->rfd = ps->upfds[0];
+    ps->wfd = ps->ppfds[1];
+
+    close (ps->upfds[1]);
+    ps->upfds[1] = -1;
+    close (ps->ppfds[0]);
+    ps->ppfds[0] = -1;
+}
+
+static void parent_pfds_setup (privsep_t *ps)
+{
+    /* Set parent read and write fds to read end of ppfds and
+     *  write end of ppfds respectively. Close fds we no longer need
+     *  in parent, since they are only used in the child.
+     */
+    ps->rfd = ps->ppfds[0];
+    ps->wfd = ps->upfds[1];
+    close (ps->ppfds[1]);
+    ps->ppfds[1] = -1;
+    close (ps->upfds[0]);
+    ps->upfds[0] = -1;
+}
+
+static int
+run_unprivileged_child (privsep_t *ps, privsep_child_f fn, void *arg)
+{
+    if ((ps->cpid = fork ()) < 0) {
+        imp_warn ("fork: %s\n", strerror (errno));
+        return (-1);
+    }
+
+    if (ps->cpid == 0) {
+        /* Now drop privileges. This is fatal on error */
+        drop_privileges ();
+        child_pfds_setup (ps);
+        if (wait_for_parent (ps) < 0)
+            imp_die (1, "wait_for_parent: %s", strerror (errno));
+        fn (ps, arg);
+        exit (0);
+    }
+    /*  Only parent returns from this function */
+
+    parent_pfds_setup (ps);
+    return (0);
+}
+
+privsep_t * privsep_init (privsep_child_f fn, void *arg)
+{
+    privsep_t *ps;
+
+    if (geteuid () == getuid () || geteuid() != 0) {
+        imp_warn ("privsep_init: called when not setuid");
+        errno = EINVAL;
+        return (NULL);
+    }
+    if (!(ps = calloc (1, sizeof (*ps)))) {
+        imp_warn ("privsep_init: Out of memory");
+        return (NULL);
+    }
+    ps->ppid = getpid ();
+
+    if (pipe (ps->upfds) < 0 || pipe (ps->ppfds) < 0) {
+        imp_warn ("privsep_init: pipe: %s\n", strerror (errno));
+        privsep_destroy (ps);
+        return (NULL);
+    }
+
+    if (run_unprivileged_child (ps, fn, arg) < 0) {
+        privsep_destroy (ps);
+        return (NULL);
+    }
+
+    if (wakeup_child (ps) < 0) {
+        imp_warn ("wakeup_child: %s", strerror (errno));
+        privsep_destroy (ps);
+        return (NULL);
+    }
+    return (ps);
+}
+
+int privsep_destroy (privsep_t *ps)
+{
+    int status = 0;
+
+    if (ps->wfd > 0)
+        close (ps->wfd);
+    if (ps->rfd > 0)
+        close (ps->rfd);
+
+    if (privsep_is_parent (ps)) {
+        if (ps->cpid > (pid_t) 0) {
+            int status;
+            kill (SIGTERM, ps->cpid);
+            if (waitpid (ps->cpid, &status, 0) < 0)
+                status = -1;
+        }
+    }
+
+    free (ps);
+    return (status == 0 ? 0 : -1);
+}
+
+bool privsep_is_parent (privsep_t *ps)
+{
+    return (getpid () == ps->ppid);
+}
+bool privsep_is_child (privsep_t *ps)
+{
+    return (getpid () != ps->ppid && ps->cpid == 0);
+}
+
+ssize_t privsep_write (privsep_t *ps, const void *buf, size_t count)
+{
+    const char *p;
+    size_t nleft;
+
+    if (!ps || !buf || ps->wfd < 0) {
+        errno = EINVAL;
+        return (-1);
+    }
+
+    p = buf;
+    nleft = count;
+    while (nleft > 0) {
+        ssize_t n = write (ps->wfd, p, nleft);
+        if (n < 0) {
+            if (errno == EINTR)
+                continue;
+            else
+                return (-1);
+        }
+        nleft -= n;
+        p += n;
+    }
+    return (count);
+}
+
+ssize_t privsep_read (privsep_t *ps, void *buf, size_t count)
+{
+    char *p;
+    size_t nleft;
+
+    if (!ps || !buf || ps->rfd < 0) {
+        errno = EINVAL;
+        return (-1);
+    }
+
+    p = buf;
+    nleft = count;
+    while (nleft > 0) {
+        ssize_t n = read (ps->rfd, p, nleft);
+        if (n < 0) {
+            if (errno == EINTR)
+                continue;
+            else
+                return (-1);
+        }
+        else if (n == 0)
+            break;
+
+        nleft -= n;
+        p += n;
+    }
+    return (count - nleft);
+}
+
+struct kv * privsep_read_kv (privsep_t *ps)
+{
+    struct kv *kv = NULL;
+    char *buf;
+    int len;
+
+    /*
+     *  First read length of kv that is being sent
+     */
+    if (privsep_read (ps, &len, sizeof (len)) != sizeof (len))
+        return (NULL);
+
+    if (len <= 0 || len > PRIVSEP_MAX_KVLEN) {
+        errno = E2BIG;
+        return (NULL);
+    }
+
+    /*
+     *  Allocate buffer big enough to fit incoming kv structure:
+     */
+    if ((buf = calloc (1, len)) == NULL)
+        return (NULL);
+
+    /*
+     *  Read all of the new struct kv in raw form
+     */
+    if (privsep_read (ps, buf, len) < len) {
+        int saved_errno = errno;
+        free (buf);
+        errno = saved_errno;
+        return (NULL);
+    }
+
+    kv = kv_decode (buf, len);
+    free (buf);
+    return (kv);
+}
+
+ssize_t privsep_write_kv (privsep_t *ps, struct kv *kv)
+{
+    int n;
+    int len;
+    const char *buf;
+
+    if (kv_encode (kv, &buf, &len) < 0)
+        return (-1);
+
+    if (len <= 0 || len > PRIVSEP_MAX_KVLEN) {
+        errno = E2BIG;
+        return (-1);
+    }
+
+    /*  Write length first */
+    if (privsep_write (ps, &len, sizeof (len)) != sizeof (len))
+        return (-1);
+
+    /*  Then write encoded kv structure */
+    if ((n = privsep_write (ps, buf, len)) != len)
+        return (-1);
+
+    return (n);
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/imp/privsep.h
+++ b/src/imp/privsep.h
@@ -1,0 +1,91 @@
+/*****************************************************************************\
+ *  Copyright (c) 2017 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+#ifndef HAVE_PRIVSEP_H
+#define HAVE_PRIVSEP_H 1
+
+#include <stdbool.h>
+#include <unistd.h>
+
+#include "src/libutil/kv.h"
+
+typedef struct privsep privsep_t;
+
+typedef void (*privsep_child_f) (privsep_t *ps, void *arg);
+
+/*  Spawn an unprivliged child running child_fn from a setuid program,
+ *   connected to the current process with pipes for IPC.
+ *
+ *  Parent returns valid privsep_t on success, child calls function fn
+ *   and does not return.
+ */
+privsep_t * privsep_init (privsep_child_f fn, void *arg);
+
+/*  Free memory associated with privsep handle and close associated
+ *   file descriptors to parent/child. If this is the parent process,
+ *   it will wait for the child to exit.
+ */  
+int privsep_destroy (privsep_t *ps);
+
+/*  Return true if running in child.
+ */
+bool privsep_is_child (privsep_t *ps);
+
+/*  Return true if running in parent
+ */
+bool privsep_is_parent (privsep_t *ps);
+
+/*
+ *  Read up to count bytes from privsep connection into buffer buf.
+ *  Returns number of bytes read into buf or -1 on error.
+ */
+ssize_t privsep_read (privsep_t *ps, void *buf, size_t count);
+
+/*
+ *  Write count bytes from buf over privsep channel in `ps`.
+ *  Returns number of bytes written (always == count) or -1 on failure
+ */
+ssize_t privsep_write (privsep_t *ps, const void *buf, size_t count);
+
+/*
+ *  Write a struct kv over privsep pipe, returning size of the kv
+ *   written on success, -1 on failure.
+ *
+ *  Specific errno values include:
+ *    EINVAL  - Invalid argument (bad privsep handle or struct kv)
+ *    E2BIG   - Encoded size of kv too large for privsep_write_kv()
+ */
+ssize_t privsep_write_kv (privsep_t *ps, struct kv *kv);
+
+/*
+ *  Read a struct kv from privsep pipe. Returns kv on success or NULL
+ *   on failure with errno set.
+ *
+ *  Specific errno values include:
+ *    EINVAL  - Invalide privsep handle
+ *    E2BIG   - Remote tried to send kv that was too large
+ */
+struct kv * privsep_read_kv (privsep_t *ps);
+
+#endif /* !HAVE_PRIVSEP_H */
+

--- a/src/imp/sudosim.c
+++ b/src/imp/sudosim.c
@@ -1,0 +1,84 @@
+/*****************************************************************************\
+ *  Copyright (c) 2017 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <pwd.h>
+#include <string.h>
+#include <errno.h>
+
+#include "imp_log.h"
+#include "sudosim.h"
+
+const char * sudo_user_name (void)
+{
+    if (getuid() == 0)
+        return (getenv ("SUDO_USER"));
+    return (NULL);
+}
+
+bool sudo_is_active (void)
+{
+    return (sudo_user_name() != NULL);
+}
+
+int sudo_simulate_setuid (void)
+{
+    const char *user = NULL;
+
+    /*  Ignore SUDO_USER unless real UID is 0. We're then fairly sure this
+     *   process was run under sudo, or someone with privileges wants to
+     *   simulate running under sudo.
+     */
+    if ((user = sudo_user_name ())) {
+        struct passwd *pwd = getpwnam (user);
+
+        /*  Fail in the abnormal condition that SUDO_USER is not found.
+         */
+        if (pwd == NULL)
+            return (-1);
+
+        /*  O/w, set real UID/GID to the SUDO_USER credentials so it
+         *   appears that this process is setuid.
+         */
+        if (setresgid (pwd->pw_gid, -1, -1) < 0) {
+            imp_warn ("sudosim: setresgid: %s", strerror (errno));
+            return (-1);
+        }
+        if (setresuid (pwd->pw_uid, -1, -1) < 0) {
+            imp_warn ("sudosim: setresuid: %s", strerror (errno));
+            return (-1);
+        }
+    }
+    return (0);
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/imp/sudosim.h
+++ b/src/imp/sudosim.h
@@ -1,0 +1,50 @@
+/*****************************************************************************\
+ *  Copyright (c) 2017 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef HAVE_SUDOSIM_H
+#define HAVE_SUDOSIM_H 1
+
+#include <stdbool.h>
+
+/*  If current process was run under sudo, return the user name as recorded
+ *   in the SUDO_USER environment variable. Return NULL otherwise.
+ */
+const char * sudo_user_name (void);
+
+/*  Return true if it appears the current process is running under sudo, i.e.
+ *   real UID is 0, and SUDO_USER environment variable is set.
+ */
+bool sudo_is_active (void);
+
+/*  If running under sudo by evidence of real UID == 0 and SUDO_USER set,
+ *   adapt process credentials to simulate a setuid program. That is,
+ *   set the real UID/GID to that of SUDO_USER and leave effective/saved
+ *   UIDs as root.
+ *
+ *  Returns 0 on success or if SUDO not active (in which case nothing was
+ *   done), or < 0 if some failure occurred (should be fatal).
+ */
+int sudo_simulate_setuid (void);
+
+#endif /* !HAVE_SUDOSIM_H */

--- a/src/imp/test/impcmd.c
+++ b/src/imp/test/impcmd.c
@@ -1,0 +1,81 @@
+/*****************************************************************************\
+ *  Copyright (c) 2017 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+#include "impcmd.h"
+
+#include "src/libtap/tap.h"
+
+static int test_cmd (struct imp_state *imp __attribute__ ((unused)),
+                     struct kv *kv __attribute__ ((unused)))
+{
+    return 0;
+}
+
+static int test_cmd_privileged (struct imp_state *imp __attribute__ ((unused)),
+                     struct kv *kv __attribute__ ((unused)))
+{
+    return 0;
+}
+
+struct impcmd impcmd_list[] =
+{
+    { "test",
+      test_cmd, test_cmd_privileged },
+    { "test2",
+      test_cmd, NULL },
+    { NULL, NULL, NULL }
+};
+
+int main (void)
+{
+    imp_cmd_f cmd;
+    plan (NO_PLAN);
+
+    ok ((cmd = imp_cmd_find_child ("noexist")) == NULL,
+        "imp_cmd_find_child returns NULL on nonexistent function");
+    ok ((cmd = imp_cmd_find_parent ("noexist")) == NULL,
+        "imp_cmd_find_parent returns NULL on nonexistent function");
+    ok ((cmd = imp_cmd_find_child ("test")) != NULL,
+        "imp_cmd_find_child finds 'test' cmd");
+    ok (cmd == test_cmd, "imp_cmd_find_child returned correct function");
+    ok ((cmd = imp_cmd_find_parent ("test")) != NULL,
+        "imp_cmd_find_parent finds 'test' subcommand");
+    ok (cmd == test_cmd_privileged,
+        "imp_cmd_find_parent returned correct function");
+    ok ((cmd = imp_cmd_find_child ("test2")) != NULL,
+        "imp_cmd_find_child finds 'test2' cmd");
+    ok ((cmd = imp_cmd_find_parent ("test2")) == NULL,
+        "imp_cmd_find_parent returns NULL for 'test2' cmd");
+
+    done_testing ();
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/imp/test/privsep.c
+++ b/src/imp/test/privsep.c
@@ -30,6 +30,7 @@
 #include <sys/types.h>
 
 #include "imp_log.h"
+#include "sudosim.h"
 #include "privsep.h"
 
 #include "src/libtap/tap.h"
@@ -253,6 +254,9 @@ int main (void)
      */
     imp_openlog ();
     imp_log_add ("diag", IMP_LOG_DEBUG, log_diag, NULL);
+
+    if (sudo_simulate_setuid () < 0)
+        BAIL_OUT ("Failed to simulate setuid under sudo");
 
     if (geteuid () == getuid ()) {
         plan (SKIP_ALL, "Privsep test needs to be run setuid");

--- a/src/imp/test/privsep.c
+++ b/src/imp/test/privsep.c
@@ -1,0 +1,274 @@
+/*****************************************************************************\
+ *  Copyright (c) 2017 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+#include <sys/types.h>
+
+#include "imp_log.h"
+#include "privsep.h"
+
+#include "src/libtap/tap.h"
+
+static void child (privsep_t *ps, void *arg __attribute__ ((unused)))
+{
+    bool rv;
+    uid_t euid = geteuid ();
+    uid_t uid = getuid ();
+    int len = sizeof (uid_t);
+
+    int n = privsep_write (ps, &euid, len);
+    if (n != len) {
+        diag ("privsep_write: euid: %s", strerror (errno));
+        exit (1);
+    }
+    n = privsep_write (ps, &uid, len);
+    if (n != len) {
+        diag ("privsep_write: uid: %s", strerror (errno));
+        exit (1);
+    }
+
+    /*  Can't use TAP output here (numbering would be incorrect),
+     *   instead send result directly to parent over the privsep connection.
+     */
+    rv = privsep_is_child (ps);
+    n = privsep_write (ps, &rv, sizeof (rv));
+    if (n != sizeof (rv)) {
+        diag ("privsep write: bool: %s", strerror (errno));
+        exit (1);
+    }
+
+    rv = privsep_is_parent (ps);
+    n = privsep_write (ps, &rv, sizeof (rv));
+    if (n != sizeof (rv)) {
+        diag ("privsep write: bool: %s", strerror (errno));
+        exit (1);
+    }
+    /*  Child exits on return */
+}
+
+
+static void test_privsep_basic (void)
+{
+    uid_t uid, euid;
+    bool result;
+    ssize_t len = sizeof (uid_t);
+    privsep_t *ps = NULL;
+
+    ok ((ps = privsep_init (child, NULL)) != NULL, "privsep_init");
+    if (ps == NULL)
+        BAIL_OUT ("privsep_init failed");
+
+    ok (privsep_is_parent (ps), "privsep_is_parent returns true in parent");
+
+    ok (privsep_read (ps, &euid, len) == len,
+        "privsep_read: euid from child");
+    ok (privsep_read (ps, &uid, len) == len,
+        "privsep_read: uid from child");
+
+    ok (euid == getuid (),
+        "child has effective uid of parent real uid (euid=%ld)", (long) euid);
+    ok (uid == getuid (),
+        "child has real uid of parent (uid=%ld)", (long) uid);
+
+
+    ok (privsep_read (ps, &result, sizeof (result)) == sizeof (result),
+        "privsep read: result of privsep_is_child");
+    ok (result == true, "privsep_is_child in child returns true");
+    ok (privsep_read (ps, &result, sizeof (result)) == sizeof (result),
+        "privsep read: result of privsep_is_parent");
+    ok (result == false, "privsep_is_parent in child returns false");
+
+    ok (!privsep_is_child (ps), "privsep_is_child in parent returns false");
+
+
+    ok (geteuid() == 0,
+        "parent retains effective uid == 0");
+
+    ok (privsep_destroy (ps) == 0, "privsep child exited normally");
+}
+
+static void child_kv_test (privsep_t *ps, void *arg __attribute__ ((unused)))
+{
+    bool v;
+    struct kv *kv = kv_create ();
+
+    /* Send a kv to parent, get same kv back with addition of "parent = true"
+     */
+    if (!kv)
+        imp_die (1, "kv_create");
+    if (kv_put (kv, "child", KV_BOOL, true) < 0)
+        imp_die (1, "kv_put: %s", strerror (errno));
+    if (kv_put (kv, "foo", KV_STRING, "bar") < 0)
+        imp_die (1, "kv_put: %s", strerror (errno));
+
+    if (privsep_write_kv (ps, kv) <= 0)
+        imp_die (1, "privsep_write_kv: %s", strerror (errno));
+
+    imp_say ("privsep_write_kv complete");
+
+    kv_destroy (kv);
+
+    if (!(kv = privsep_read_kv (ps)))
+        imp_die (1, "privsep_read_kv: %s", strerror (errno));
+
+    if (kv_get (kv, "parent", KV_BOOL, &v) < 0)
+        imp_die (1, "kv_get ('parent'): %s", strerror (errno));
+
+    if (!v)
+        imp_die (1, "parent = 'true' not set in returned kv object");
+}
+
+static void test_privsep_kv (void)
+{
+    privsep_t *ps;
+    struct kv *kv;
+    bool v;
+    const char *s;
+
+    ok ((ps = privsep_init (child_kv_test, NULL)) != NULL,
+        "privsep_init");
+
+    if (ps == NULL)
+        BAIL_OUT ("privsep_init failed");
+
+    /*  Read kv from child, set parent = 'true' and write back to child */
+    ok ((kv = privsep_read_kv (ps)) != NULL, "privsep_read_kv");
+
+    ok ((kv_get (kv, "child", KV_BOOL, &v) >= 0),
+        "key 'child' set in obtained kv");
+    ok (v, "key 'child' is true");
+    ok ((kv_get (kv, "foo", KV_STRING, &s) >= 0),
+        "key 'foo' set in obtained kv");
+    is (s, "bar", "key 'foo' has correct value");
+
+    ok (kv_put (kv, "parent", KV_BOOL, true) >= 0,
+        "set parent = true in kv");
+
+    ok (privsep_write_kv (ps, kv) >= 0,
+        "privsep_write_kv");
+
+    ok (privsep_destroy (ps) == 0, "privsep child exited normally");
+}
+
+static void child_write_ints (privsep_t *ps, void *arg)
+{
+    int *z = ((int *) arg);
+    privsep_write (ps, &z[0], sizeof (int));
+    privsep_write (ps, &z[1], sizeof (int));
+    privsep_write (ps, &z[2], sizeof (int));
+}
+
+static struct kv *create_yuuuuuge_kv (void)
+{
+    int i;
+    char largeval [4096];
+    struct kv *kv = kv_create ();
+
+    memset (largeval, 'x', sizeof (largeval) - 1);
+    largeval [4095] = '\0';
+
+    ok (strlen (largeval) == 4095, "Create huge value for oversized kv");
+
+    for (i = 0; i < 1024; i++) {
+        char key [5];
+        if (sprintf (key, "%04d", i) != 4) {
+            imp_warn ("huge_kv: Failed to create key %04d", i);
+            goto fail;
+        }
+        if (kv_put (kv, key, KV_STRING, largeval) < 0) {
+            imp_warn ("huge_kv: kv_put: %s", strerror (errno));
+            goto fail;
+        }
+    }
+    return (kv);
+fail:
+    kv_destroy (kv);
+    return (NULL);
+}
+
+static void test_privsep_kv_bad_input (void)
+{
+    struct kv *kv;
+    int invalid_size[3] = { 1024*1024*4 + 1, 0, -1234 };
+
+    privsep_t *ps = privsep_init (child_write_ints, &invalid_size);
+
+    ok (ps != NULL, "privsep_init");
+
+    /*  Child writes value too large, then too small (0) then much too
+     *   small (< 0), Each read should return E2BIG
+     */
+    ok ((kv = privsep_read_kv (ps)) == NULL && errno == E2BIG,
+        "privsep_read fails with invalid size (too large)");
+    ok ((kv = privsep_read_kv (ps)) == NULL && errno == E2BIG,
+        "privsep_read fails with invalid size (0)");
+    ok ((kv = privsep_read_kv (ps)) == NULL && errno == E2BIG,
+        "privsep_read fails with invalid size (< 0)");
+
+    ok ((kv = create_yuuuuuge_kv ()) != NULL,
+        "created kv of unusual size");
+    ok ((privsep_write_kv (ps, kv) < 0) && errno == E2BIG,
+        "privsep_write_kv returns E2BIG on very large kv");
+
+    kv_destroy (kv);
+
+    privsep_destroy (ps);
+}
+
+static int log_diag (int level, const char *str,
+                     void *arg __attribute__ ((unused)))
+{
+    diag ("privsep: %s: %s\n", imp_log_strlevel (level), str);
+    return (0);
+}
+
+int main (void)
+{
+    /*  Privsep code uses imp log for errors, so need to initialize here
+     */
+    imp_openlog ();
+    imp_log_add ("diag", IMP_LOG_DEBUG, log_diag, NULL);
+
+    if (geteuid () == getuid ()) {
+        plan (SKIP_ALL, "Privsep test needs to be run setuid");
+        return (0);
+    }
+
+    plan (NO_PLAN);
+
+    test_privsep_basic ();
+    test_privsep_kv ();
+    test_privsep_kv_bad_input ();
+
+    imp_closelog ();
+    done_testing ();
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/imp/version.c
+++ b/src/imp/version.c
@@ -1,0 +1,39 @@
+/*****************************************************************************\
+ *  Copyright (c) 2017 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdio.h>
+#include "impcmd.h"
+
+int imp_cmd_version (struct imp_state *imp __attribute__ ((unused)))
+{
+    printf ("flux-imp v%s\n", PACKAGE_VERSION);
+    return (0);
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/imp/version.c
+++ b/src/imp/version.c
@@ -29,7 +29,8 @@
 #include <stdio.h>
 #include "impcmd.h"
 
-int imp_cmd_version (struct imp_state *imp __attribute__ ((unused)))
+int imp_cmd_version (struct imp_state *imp __attribute__ ((unused)),
+                     struct kv *kv __attribute__ ((unused)))
 {
     printf ("flux-imp v%s\n", PACKAGE_VERSION);
     return (0);

--- a/src/imp/whoami.c
+++ b/src/imp/whoami.c
@@ -1,0 +1,66 @@
+/*****************************************************************************\
+ *  Copyright (c) 2017 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <string.h>
+#include <errno.h>
+
+#include "src/libutil/kv.h"
+
+#include "imp_log.h"
+#include "imp_state.h"
+#include "impcmd.h"
+#include "privsep.h"
+
+static void print_ids (const char *prefix)
+{
+    printf ("%s: uid=%ju euid=%ju gid=%ju egid=%ju\n",
+            prefix, (uintmax_t) getuid(), (uintmax_t) geteuid(),
+            (uintmax_t) getgid(), (uintmax_t) getegid());
+}
+
+int imp_whoami_privileged (struct imp_state *imp __attribute__ ((unused)),
+                           struct kv *kv __attribute__ ((unused)))
+{
+    print_ids ("flux-imp: privileged");
+    return (0);
+}
+
+int imp_whoami_unprivileged (struct imp_state *imp, struct kv *kv)
+{
+    /* Send kv with `cmd="whoami"` to parent */
+    if (imp->ps && privsep_write_kv (imp->ps, kv) < 0)
+        imp_die (1, "whoami: failed to communicate with privsep parent");
+    print_ids ("flux-imp: unprivileged");
+    return (0);
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/libutil/kv.h
+++ b/src/libutil/kv.h
@@ -10,6 +10,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdarg.h>
 #include <time.h> // time_t
 
 enum kv_type {

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -3,9 +3,12 @@ T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
 	$(top_srcdir)/config/tap-driver.sh
 
 TESTS = \
-	t0000-sharness.t
+	t0000-sharness.t \
+	t0100-sudo-unit-tests.t
+
 check_SCRIPTS = \
-	t0000-sharness.t
+	t0000-sharness.t \
+	t0100-sudo-unit-tests.t
 
 EXTRA_DIST= \
 	sharness.sh \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -1,0 +1,16 @@
+TEST_EXTENSIONS = .t
+T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
+	$(top_srcdir)/config/tap-driver.sh
+
+TESTS = \
+	t0000-sharness.t
+check_SCRIPTS = \
+	t0000-sharness.t
+
+EXTRA_DIST= \
+	sharness.sh \
+	sharness.d \
+	$(check_SCRIPTS)
+
+clean-local:
+	rm -fr trash-directory.* test-results .prove

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -4,11 +4,13 @@ T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
 
 TESTS = \
 	t0000-sharness.t \
-	t0100-sudo-unit-tests.t
+	t0100-sudo-unit-tests.t \
+	t1000-imp-basic.t
 
 check_SCRIPTS = \
 	t0000-sharness.t \
-	t0100-sudo-unit-tests.t
+	t0100-sudo-unit-tests.t \
+	t1000-imp-basic.t
 
 EXTRA_DIST= \
 	sharness.sh \

--- a/t/sharness.d/10-sudo.sh
+++ b/t/sharness.d/10-sudo.sh
@@ -1,0 +1,6 @@
+##
+# Is non-interactive sudo available?
+##
+if sudo --non-interactive true >/dev/null 2>&1; then
+    test_set_prereq SUDO
+fi

--- a/t/sharness.sh
+++ b/t/sharness.sh
@@ -1,0 +1,873 @@
+#!/bin/sh
+#
+# Copyright (c) 2011-2012 Mathias Lafeldt
+# Copyright (c) 2005-2012 Git project
+# Copyright (c) 2005-2012 Junio C Hamano
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see http://www.gnu.org/licenses/ .
+
+# Public: Current version of Sharness.
+SHARNESS_VERSION="1.0.0"
+export SHARNESS_VERSION
+
+# Public: The file extension for tests.  By default, it is set to "t".
+: ${SHARNESS_TEST_EXTENSION:=t}
+export SHARNESS_TEST_EXTENSION
+
+#  Reset TERM to original terminal if found, otherwise save orignal TERM
+[ "x" = "x$SHARNESS_ORIG_TERM" ] &&
+		SHARNESS_ORIG_TERM="$TERM" ||
+		TERM="$SHARNESS_ORIG_TERM"
+# Public: The unsanitized TERM under which sharness is originally run
+export SHARNESS_ORIG_TERM
+
+# Export SHELL_PATH
+: ${SHELL_PATH:=$SHELL}
+export SHELL_PATH
+
+# For repeatability, reset the environment to a known state.
+# TERM is sanitized below, after saving color control sequences.
+LANG=C
+LC_ALL=C
+PAGER=cat
+TZ=UTC
+EDITOR=:
+export LANG LC_ALL PAGER TZ EDITOR
+unset VISUAL CDPATH GREP_OPTIONS
+
+# Line feed
+LF='
+'
+
+[ "x$TERM" != "xdumb" ] && (
+		[ -t 1 ] &&
+		tput bold >/dev/null 2>&1 &&
+		tput setaf 1 >/dev/null 2>&1 &&
+		tput sgr0 >/dev/null 2>&1
+	) &&
+	color=t
+
+while test "$#" -ne 0; do
+	case "$1" in
+	--logfile)
+		logfile=t; shift;;
+	-d|--d|--de|--deb|--debu|--debug)
+		debug=t; shift ;;
+	-i|--i|--im|--imm|--imme|--immed|--immedi|--immedia|--immediat|--immediate)
+		immediate=t; shift ;;
+	-l|--l|--lo|--lon|--long|--long-|--long-t|--long-te|--long-tes|--long-test|--long-tests)
+		TEST_LONG=t; export TEST_LONG; shift ;;
+	--in|--int|--inte|--inter|--intera|--interac|--interact|--interacti|--interactiv|--interactive|--interactive-|--interactive-t|--interactive-te|--interactive-tes|--interactive-test|--interactive-tests):
+		TEST_INTERACTIVE=t; export TEST_INTERACTIVE; verbose=t; shift ;;
+	-h|--h|--he|--hel|--help)
+		help=t; shift ;;
+	-v|--v|--ve|--ver|--verb|--verbo|--verbos|--verbose)
+		verbose=t; shift ;;
+	-q|--q|--qu|--qui|--quie|--quiet)
+		# Ignore --quiet under a TAP::Harness. Saying how many tests
+		# passed without the ok/not ok details is always an error.
+		test -z "$HARNESS_ACTIVE" && quiet=t; shift ;;
+	--chain-lint)
+		chain_lint=t; shift ;;
+	--no-chain-lint)
+		chain_lint=; shift ;;
+	--no-color)
+		color=; shift ;;
+	--root=*)
+		root=$(expr "z$1" : 'z[^=]*=\(.*\)')
+		shift ;;
+	*)
+		echo "error: unknown test option '$1'" >&2; exit 1 ;;
+	esac
+done
+
+if test -n "$color"; then
+	# Save the color control sequences now rather than run tput
+	# each time say_color() is called.  This is done for two
+	# reasons:
+	#   * TERM will be changed to dumb
+	#   * HOME will be changed to a temporary directory and tput
+	#     might need to read ~/.terminfo from the original HOME
+	#     directory to get the control sequences
+	# Note:  This approach assumes the control sequences don't end
+	# in a newline for any terminal of interest (command
+	# substitutions strip trailing newlines).  Given that most
+	# (all?) terminals in common use are related to ECMA-48, this
+	# shouldn't be a problem.
+	say_color_error=$(tput bold; tput setaf 1) # bold red
+	say_color_skip=$(tput setaf 4) # blue
+	say_color_warn=$(tput setaf 3) # brown/yellow
+	say_color_pass=$(tput setaf 2) # green
+	say_color_info=$(tput setaf 6) # cyan
+	say_color_reset=$(tput sgr0)
+	say_color_="" # no formatting for normal text
+	say_color() {
+		test -z "$1" && test -n "$quiet" && return
+		eval "say_color_color=\$say_color_$1"
+		shift
+		printf "%s\\n" "$say_color_color$*$say_color_reset"
+	}
+else
+	say_color() {
+		test -z "$1" && test -n "$quiet" && return
+		shift
+		printf "%s\n" "$*"
+	}
+fi
+
+TERM=dumb
+export TERM
+
+error() {
+	say_color error "error: $*"
+	EXIT_OK=t
+	exit 1
+}
+
+say() {
+	say_color info "$*"
+}
+
+test -n "$test_description" || error "Test script did not set test_description."
+
+if test "$help" = "t"; then
+	echo "$test_description"
+	exit 0
+fi
+
+exec 5>&1
+exec 6<&0
+if test "$verbose" = "t"; then
+	exec 4>&2 3>&1
+elif test "$logfile" = "t"; then
+	logfile=$(basename $0 .t).output
+	exec 4>${logfile} 3>&4
+else
+	exec 4>/dev/null 3>/dev/null
+fi
+
+test_failure=0
+test_count=0
+test_fixed=0
+test_broken=0
+test_success=0
+
+die() {
+	code=$?
+	if test -n "$EXIT_OK"; then
+		exit $code
+	else
+		echo >&5 "FATAL: Unexpected exit with code $code"
+		exit 1
+	fi
+}
+
+EXIT_OK=
+trap 'die' EXIT
+
+# Public: Define that a test prerequisite is available.
+#
+# The prerequisite can later be checked explicitly using test_have_prereq or
+# implicitly by specifying the prerequisite name in calls to test_expect_success
+# or test_expect_failure.
+#
+# $1 - Name of prerequiste (a simple word, in all capital letters by convention)
+#
+# Examples
+#
+#   # Set PYTHON prerequisite if interpreter is available.
+#   command -v python >/dev/null && test_set_prereq PYTHON
+#
+#   # Set prerequisite depending on some variable.
+#   test -z "$NO_GETTEXT" && test_set_prereq GETTEXT
+#
+# Returns nothing.
+test_set_prereq() {
+	satisfied_prereq="$satisfied_prereq$1 "
+}
+satisfied_prereq=" "
+
+# Public: Check if one or more test prerequisites are defined.
+#
+# The prerequisites must have previously been set with test_set_prereq.
+# The most common use of this is to skip all the tests if some essential
+# prerequisite is missing.
+#
+# $1 - Comma-separated list of test prerequisites.
+#
+# Examples
+#
+#   # Skip all remaining tests if prerequisite is not set.
+#   if ! test_have_prereq PERL; then
+#       skip_all='skipping perl interface tests, perl not available'
+#       test_done
+#   fi
+#
+# Returns 0 if all prerequisites are defined or 1 otherwise.
+test_have_prereq() {
+	# prerequisites can be concatenated with ','
+	save_IFS=$IFS
+	IFS=,
+	set -- $*
+	IFS=$save_IFS
+
+	total_prereq=0
+	ok_prereq=0
+	missing_prereq=
+
+	for prerequisite; do
+		case "$prerequisite" in
+		!*)
+			negative_prereq=t
+			prerequisite=${prerequisite#!}
+			;;
+		*)
+			negative_prereq=
+		esac
+
+		total_prereq=$(($total_prereq + 1))
+		case "$satisfied_prereq" in
+		*" $prerequisite "*)
+			satisfied_this_prereq=t
+			;;
+		*)
+			satisfied_this_prereq=
+		esac
+
+		case "$satisfied_this_prereq,$negative_prereq" in
+		t,|,t)
+			ok_prereq=$(($ok_prereq + 1))
+			;;
+		*)
+			# Keep a list of missing prerequisites; restore
+			# the negative marker if necessary.
+			prerequisite=${negative_prereq:+!}$prerequisite
+			if test -z "$missing_prereq"; then
+				missing_prereq=$prerequisite
+			else
+				missing_prereq="$prerequisite,$missing_prereq"
+			fi
+		esac
+	done
+
+	test $total_prereq = $ok_prereq
+}
+
+# You are not expected to call test_ok_ and test_failure_ directly, use
+# the text_expect_* functions instead.
+
+test_ok_() {
+	test_success=$(($test_success + 1))
+	say_color "pass" "ok $test_count - $@"
+	test -n "$logfile" && say >&3 "ok $test_count - $@"
+	test -n "$logfile" && printf "%s\n" "$*" >&3
+}
+
+test_failure_() {
+	test_failure=$(($test_failure + 1))
+	say_color error "not ok $test_count - $1"
+	test -n "$logfile" && say >&3 "not ok $test_count - $1"
+	shift
+	echo "$@" | sed -e 's/^/#	/'
+	test "$immediate" = "" || { EXIT_OK=t; exit 1; }
+}
+
+test_known_broken_ok_() {
+	test_fixed=$(($test_fixed + 1))
+	say_color error "ok $test_count - $@ # TODO known breakage vanished"
+	test -n "$logfile" && say >&3 "ok $test_count - $@ # TODO known breakage vanished"
+}
+
+test_known_broken_failure_() {
+	test_broken=$(($test_broken + 1))
+	say_color warn "not ok $test_count - $@ # TODO known breakage"
+	test -n "$logfile" && say >&3 "not ok $test_count - $@ # TODO known breakage"
+}
+
+# Public: Execute commands in debug mode.
+#
+# Takes a single argument and evaluates it only when the test script is started
+# with --debug. This is primarily meant for use during the development of test
+# scripts.
+#
+# $1 - Commands to be executed.
+#
+# Examples
+#
+#   test_debug "cat some_log_file"
+#
+# Returns the exit code of the last command executed in debug mode or 0
+#   otherwise.
+test_debug() {
+	test "$debug" = "" || eval "$1"
+}
+
+# Public: Stop execution and start a shell.
+#
+# This is useful for debugging tests and only makes sense together with "-v".
+# Be sure to remove all invocations of this command before submitting.
+test_pause() {
+	if test "$verbose" = t; then
+		"$SHELL_PATH" <&6 >&3 2>&4
+	else
+		error >&5 "test_pause requires --verbose"
+	fi
+}
+
+test_eval_() {
+	# This is a separate function because some tests use
+	# "return" to end a test_expect_success block early.
+	case ",$test_prereq," in
+	*,INTERACTIVE,*)
+		eval "$*"
+		;;
+	*)
+		eval </dev/null >&3 2>&4 "$*"
+		;;
+	esac
+}
+
+test_run_() {
+	test_cleanup=:
+	expecting_failure=$2
+	test_eval_ "$1"
+	eval_ret=$?
+
+	if test "$chain_lint" = "t"; then
+		test_eval_ "(exit 117) && $1"
+		if test "$?" != 117; then
+			error "bug in the test script: broken &&-chain: $1"
+		fi
+	fi
+
+	if test -z "$immediate" || test $eval_ret = 0 || test -n "$expecting_failure"; then
+		test_eval_ "$test_cleanup"
+	fi
+	if test "$verbose" = "t" && test -n "$HARNESS_ACTIVE"; then
+		echo ""
+	fi
+	return "$eval_ret"
+}
+
+test_skip_() {
+	test_count=$(($test_count + 1))
+	to_skip=
+	for skp in $SKIP_TESTS; do
+		case $this_test.$test_count in
+		$skp)
+			to_skip=t
+			break
+		esac
+	done
+	if test -z "$to_skip" && test -n "$test_prereq" && ! test_have_prereq "$test_prereq"; then
+		to_skip=t
+	fi
+	case "$to_skip" in
+	t)
+		of_prereq=
+		if test "$missing_prereq" != "$test_prereq"; then
+			of_prereq=" of $test_prereq"
+		fi
+
+		say_color skip >&3 "skipping test: $@"
+		say_color skip "ok $test_count # skip $1 (missing $missing_prereq${of_prereq})"
+		: true
+		;;
+	*)
+		false
+		;;
+	esac
+}
+
+# Public: Run test commands and expect them to succeed.
+#
+# When the test passed, an "ok" message is printed and the number of successful
+# tests is incremented. When it failed, a "not ok" message is printed and the
+# number of failed tests is incremented.
+#
+# With --immediate, exit test immediately upon the first failed test.
+#
+# Usually takes two arguments:
+# $1 - Test description
+# $2 - Commands to be executed.
+#
+# With three arguments, the first will be taken to be a prerequisite:
+# $1 - Comma-separated list of test prerequisites. The test will be skipped if
+#      not all of the given prerequisites are set. To negate a prerequisite,
+#      put a "!" in front of it.
+# $2 - Test description
+# $3 - Commands to be executed.
+#
+# Examples
+#
+#   test_expect_success \
+#       'git-write-tree should be able to write an empty tree.' \
+#       'tree=$(git-write-tree)'
+#
+#   # Test depending on one prerequisite.
+#   test_expect_success TTY 'git --paginate rev-list uses a pager' \
+#       ' ... '
+#
+#   # Multiple prerequisites are separated by a comma.
+#   test_expect_success PERL,PYTHON 'yo dawg' \
+#       ' test $(perl -E 'print eval "1 +" . qx[python -c "print 2"]') == "4" '
+#
+# Returns nothing.
+test_expect_success() {
+	test "$#" = 3 && { test_prereq=$1; shift; } || test_prereq=
+	test "$#" = 2 || error "bug in the test script: not 2 or 3 parameters to test_expect_success"
+	export test_prereq
+	if ! test_skip_ "$@"; then
+		say >&3 "expecting success: $2"
+		if test_run_ "$2"; then
+			test_ok_ "$1"
+		else
+			test_failure_ "$@"
+		fi
+	fi
+	echo >&3 ""
+}
+
+# Public: Run test commands and expect them to fail. Used to demonstrate a known
+# breakage.
+#
+# This is NOT the opposite of test_expect_success, but rather used to mark a
+# test that demonstrates a known breakage.
+#
+# When the test passed, an "ok" message is printed and the number of fixed tests
+# is incremented. When it failed, a "not ok" message is printed and the number
+# of tests still broken is incremented.
+#
+# Failures from these tests won't cause --immediate to stop.
+#
+# Usually takes two arguments:
+# $1 - Test description
+# $2 - Commands to be executed.
+#
+# With three arguments, the first will be taken to be a prerequisite:
+# $1 - Comma-separated list of test prerequisites. The test will be skipped if
+#      not all of the given prerequisites are set. To negate a prerequisite,
+#      put a "!" in front of it.
+# $2 - Test description
+# $3 - Commands to be executed.
+#
+# Returns nothing.
+test_expect_failure() {
+	test "$#" = 3 && { test_prereq=$1; shift; } || test_prereq=
+	test "$#" = 2 || error "bug in the test script: not 2 or 3 parameters to test_expect_failure"
+	export test_prereq
+	if ! test_skip_ "$@"; then
+		say >&3 "checking known breakage: $2"
+		if test_run_ "$2" expecting_failure; then
+			test_known_broken_ok_ "$1"
+		else
+			test_known_broken_failure_ "$1"
+		fi
+	fi
+	echo >&3 ""
+}
+
+# Public: Run command and ensure that it fails in a controlled way.
+#
+# Use it instead of "! <command>". For example, when <command> dies due to a
+# segfault, test_must_fail diagnoses it as an error, while "! <command>" would
+# mistakenly be treated as just another expected failure.
+#
+# This is one of the prefix functions to be used inside test_expect_success or
+# test_expect_failure.
+#
+# $1.. - Command to be executed.
+#
+# Examples
+#
+#   test_expect_success 'complain and die' '
+#       do something &&
+#       do something else &&
+#       test_must_fail git checkout ../outerspace
+#   '
+#
+# Returns 1 if the command succeeded (exit code 0).
+# Returns 1 if the command died by signal (exit codes 130-192)
+# Returns 1 if the command could not be found (exit code 127).
+# Returns 0 otherwise.
+test_must_fail() {
+	"$@"
+	exit_code=$?
+	if test $exit_code = 0; then
+		echo >&2 "test_must_fail: command succeeded: $*"
+		return 1
+	elif test $exit_code -gt 129 -a $exit_code -le 192; then
+		echo >&2 "test_must_fail: died by signal: $*"
+		return 1
+	elif test $exit_code = 127; then
+		echo >&2 "test_must_fail: command not found: $*"
+		return 1
+	fi
+	return 0
+}
+
+# Public: Run command and ensure that it succeeds or fails in a controlled way.
+#
+# Similar to test_must_fail, but tolerates success too. Use it instead of
+# "<command> || :" to catch failures caused by a segfault, for instance.
+#
+# This is one of the prefix functions to be used inside test_expect_success or
+# test_expect_failure.
+#
+# $1.. - Command to be executed.
+#
+# Examples
+#
+#   test_expect_success 'some command works without configuration' '
+#       test_might_fail git config --unset all.configuration &&
+#       do something
+#   '
+#
+# Returns 1 if the command died by signal (exit codes 130-192)
+# Returns 1 if the command could not be found (exit code 127).
+# Returns 0 otherwise.
+test_might_fail() {
+	"$@"
+	exit_code=$?
+	if test $exit_code -gt 129 -a $exit_code -le 192; then
+		echo >&2 "test_might_fail: died by signal: $*"
+		return 1
+	elif test $exit_code = 127; then
+		echo >&2 "test_might_fail: command not found: $*"
+		return 1
+	fi
+	return 0
+}
+
+# Public: Run command and ensure it exits with a given exit code.
+#
+# This is one of the prefix functions to be used inside test_expect_success or
+# test_expect_failure.
+#
+# $1   - Expected exit code.
+# $2.. - Command to be executed.
+#
+# Examples
+#
+#   test_expect_success 'Merge with d/f conflicts' '
+#       test_expect_code 1 git merge "merge msg" B master
+#   '
+#
+# Returns 0 if the expected exit code is returned or 1 otherwise.
+test_expect_code() {
+	want_code=$1
+	shift
+	"$@"
+	exit_code=$?
+	if test $exit_code = $want_code; then
+		return 0
+	fi
+
+	echo >&2 "test_expect_code: command exited with $exit_code, we wanted $want_code $*"
+	return 1
+}
+
+# Public: Compare two files to see if expected output matches actual output.
+#
+# The TEST_CMP variable defines the command used for the comparision; it
+# defaults to "diff -u". Only when the test script was started with --verbose,
+# will the command's output, the diff, be printed to the standard output.
+#
+# This is one of the prefix functions to be used inside test_expect_success or
+# test_expect_failure.
+#
+# $1 - Path to file with expected output.
+# $2 - Path to file with actual output.
+#
+# Examples
+#
+#   test_expect_success 'foo works' '
+#       echo expected >expected &&
+#       foo >actual &&
+#       test_cmp expected actual
+#   '
+#
+# Returns the exit code of the command set by TEST_CMP.
+test_cmp() {
+	${TEST_CMP:-diff -u} "$@"
+}
+
+# Public: portably print a sequence of numbers.
+#
+# seq is not in POSIX and GNU seq might not be available everywhere,
+# so it is nice to have a seq implementation, even a very simple one.
+#
+# $1 - Starting number.
+# $2 - Ending number.
+#
+# Examples
+#
+#   test_expect_success 'foo works 10 times' '
+#       for i in $(test_seq 1 10)
+#       do
+#           foo || return
+#       done
+#   '
+#
+# Returns 0 if all the specified numbers can be displayed.
+test_seq() {
+	i="$1"
+	j="$2"
+	while test "$i" -le "$j"
+	do
+		echo "$i" || return
+		i=$(expr "$i" + 1)
+	done
+}
+
+# Public: Check if the file expected to be empty is indeed empty, and barfs
+# otherwise.
+#
+# $1 - File to check for emptyness.
+#
+# Returns 0 if file is empty, 1 otherwise.
+test_must_be_empty() {
+	if test -s "$1"
+	then
+		echo "'$1' is not empty, it contains:"
+		cat "$1"
+		return 1
+	fi
+}
+
+# Public: Schedule cleanup commands to be run unconditionally at the end of a
+# test.
+#
+# If some cleanup command fails, the test will not pass. With --immediate, no
+# cleanup is done to help diagnose what went wrong.
+#
+# This is one of the prefix functions to be used inside test_expect_success or
+# test_expect_failure.
+#
+# $1.. - Commands to prepend to the list of cleanup commands.
+#
+# Examples
+#
+#   test_expect_success 'test core.capslock' '
+#       git config core.capslock true &&
+#       test_when_finished "git config --unset core.capslock" &&
+#       do_something
+#   '
+#
+# Returns the exit code of the last cleanup command executed.
+test_when_finished() {
+	test_cleanup="{ $*
+		} && (exit \"\$eval_ret\"); eval_ret=\$?; $test_cleanup"
+}
+
+# Public: Schedule cleanup commands to be run unconditionally when all tests
+# have run.
+#
+# This can be used to clean up things like test databases. It is not needed to
+# clean up temporary files, as test_done already does that.
+#
+# Examples:
+#
+#   cleanup mysql -e "DROP DATABASE mytest"
+#
+# Returns the exit code of the last cleanup command executed.
+final_cleanup=
+cleanup() {
+	final_cleanup="{ $*
+		} && (exit \"\$eval_ret\"); eval_ret=\$?; $final_cleanup"
+}
+
+# Public: Summarize test results and exit with an appropriate error code.
+#
+# Must be called at the end of each test script.
+#
+# Can also be used to stop tests early and skip all remaining tests. For this,
+# set skip_all to a string explaining why the tests were skipped before calling
+# test_done.
+#
+# Examples
+#
+#   # Each test script must call test_done at the end.
+#   test_done
+#
+#   # Skip all remaining tests if prerequisite is not set.
+#   if ! test_have_prereq PERL; then
+#       skip_all='skipping perl interface tests, perl not available'
+#       test_done
+#   fi
+#
+# Returns 0 if all tests passed or 1 if there was a failure.
+test_done() {
+	EXIT_OK=t
+
+	if test -z "$HARNESS_ACTIVE"; then
+		test_results_dir="$SHARNESS_TEST_DIRECTORY/test-results"
+		mkdir -p "$test_results_dir"
+		test_results_path="$test_results_dir/${SHARNESS_TEST_NAME}.$$.counts"
+
+		cat >>"$test_results_path" <<-EOF
+		total $test_count
+		success $test_success
+		fixed $test_fixed
+		broken $test_broken
+		failed $test_failure
+
+		EOF
+	fi
+
+	if test "$test_fixed" != 0; then
+		say_color error "# $test_fixed known breakage(s) vanished; please update test(s)"
+		test -n "$logfile" && say >&3 "# $test_fixed known breakage(s) vanished"
+	fi
+	if test "$test_broken" != 0; then
+		say_color warn "# still have $test_broken known breakage(s)"
+		test -n "$logfile" && say >&3 "# still have $test_broken known breakage(s)"
+	fi
+	if test "$test_broken" != 0 || test "$test_fixed" != 0; then
+		test_remaining=$(( $test_count - $test_broken - $test_fixed ))
+		msg="remaining $test_remaining test(s)"
+	else
+		test_remaining=$test_count
+		msg="$test_count test(s)"
+	fi
+
+	case "$test_failure" in
+	0)
+		# Maybe print SKIP message
+		if test -n "$skip_all" && test $test_count -gt 0; then
+			error "Can't use skip_all after running some tests"
+		fi
+		[ -z "$skip_all" ] || skip_all=" # SKIP $skip_all"
+
+		if test $test_remaining -gt 0; then
+			say_color pass "# passed all $msg"
+			test -n "$logfile" && say >&3 "# passed all $msg"
+		fi
+		say "1..$test_count$skip_all"
+		test -n "$logfile" && say >&3 "1..$test_count$skip_all"
+
+		test_eval_ "$final_cleanup"
+
+		test -d "$remove_trash" &&
+		cd "$(dirname "$remove_trash")" &&
+		rm -rf "$(basename "$remove_trash")"
+		test -n "$logfile" &&
+		  test -f "$logfile" &&
+		  rm -f "${logfile}"
+
+		exit 0 ;;
+
+	*)
+		say_color error "# failed $test_failure among $msg"
+		say "1..$test_count"
+		if test -n "$logfile"; then
+			say >&3 "# failed $test_failure among $msg"
+			say >&3 "1..$test_count"
+		fi
+
+		exit 1 ;;
+
+	esac
+}
+
+# Public: Root directory containing tests. Tests can override this variable,
+# e.g. for testing Sharness itself.
+: ${SHARNESS_TEST_DIRECTORY:=$(pwd)}
+export SHARNESS_TEST_DIRECTORY
+
+# Public: Source directory of test code and sharness library.
+# This directory may be different from the directory in which tests are
+# being run.
+: ${SHARNESS_TEST_SRCDIR:=$(cd $(dirname $0) && pwd)}
+export SHARNESS_TEST_SRCDIR
+
+# Public: Build directory that will be added to PATH. By default, it is set to
+# the parent directory of SHARNESS_TEST_DIRECTORY.
+: ${SHARNESS_BUILD_DIRECTORY:="$SHARNESS_TEST_DIRECTORY/.."}
+PATH="$SHARNESS_BUILD_DIRECTORY:$PATH"
+export PATH SHARNESS_BUILD_DIRECTORY
+
+# Public: Path to test script currently executed.
+SHARNESS_TEST_FILE="$0"
+export SHARNESS_TEST_FILE
+
+SHARNESS_TEST_NAME=${SHARNESS_TEST_FILE##*/}
+SHARNESS_TEST_NAME=${SHARNESS_TEST_NAME%.${SHARNESS_TEST_EXTENSION}}
+
+# Prepare test area.
+SHARNESS_TRASH_DIRECTORY="trash-directory.$SHARNESS_TEST_NAME"
+test -n "$root" && SHARNESS_TRASH_DIRECTORY="$root/$SHARNESS_TRASH_DIRECTORY"
+case "$SHARNESS_TRASH_DIRECTORY" in
+/*) ;; # absolute path is good
+ *) SHARNESS_TRASH_DIRECTORY="$SHARNESS_TEST_DIRECTORY/$SHARNESS_TRASH_DIRECTORY" ;;
+esac
+test "$debug" = "t" || remove_trash="$SHARNESS_TRASH_DIRECTORY"
+rm -rf "$SHARNESS_TRASH_DIRECTORY" || {
+	EXIT_OK=t
+	echo >&5 "FATAL: Cannot prepare test area"
+	exit 1
+}
+
+
+#
+#  Load any extensions in $srcdir/sharness.d/*.sh
+#
+if test -d "${SHARNESS_TEST_SRCDIR}/sharness.d"
+then
+	for file in "${SHARNESS_TEST_SRCDIR}"/sharness.d/*.sh
+	do
+		# Ensure glob was not an empty match:
+		test -e "${file}" || break
+
+		if test -n "$debug"
+		then
+			echo >&5 "sharness: loading extensions from ${file}"
+		fi
+		. "${file}"
+		if test $? != 0
+		then
+			echo >&5 "sharness: Error loading ${file}. Aborting."
+			exit 1
+		fi
+	done
+fi
+
+# Public: Empty trash directory, the test area, provided for each test. The HOME
+# variable is set to that directory too.
+export SHARNESS_TRASH_DIRECTORY
+
+HOME="$SHARNESS_TRASH_DIRECTORY"
+export HOME
+
+mkdir -p "$SHARNESS_TRASH_DIRECTORY" || exit 1
+# Use -P to resolve symlinks in our working directory so that the cwd
+# in subprocesses like git equals our $PWD (for pathname comparisons).
+cd -P "$SHARNESS_TRASH_DIRECTORY" || exit 1
+
+for skp in $SKIP_TESTS; do
+	case "$SHARNESS_TEST_NAME" in
+	$skp)
+		say_color info >&3 "skipping test $this_test altogether"
+		skip_all="skip all tests in $this_test"
+		test_done
+	esac
+done
+
+test -n "$TEST_LONG" && test_set_prereq EXPENSIVE
+test -n "$TEST_INTERACTIVE" && test_set_prereq INTERACTIVE
+
+# Make sure this script ends with code 0
+:
+
+# vi: set ts=4 sw=4 noet :

--- a/t/t0000-sharness.t
+++ b/t/t0000-sharness.t
@@ -1,0 +1,473 @@
+#!/bin/sh
+#
+# Copyright (c) 2011-2013 Mathias Lafeldt
+# Copyright (c) 2005-2013 Git project
+# Copyright (c) 2005-2013 Junio C Hamano
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see http://www.gnu.org/licenses/ .
+
+test_description='Test Sharness itself'
+
+. `dirname $0`/sharness.sh
+
+ret="$?"
+
+test_expect_success 'sourcing sharness succeeds' '
+	test "$ret" = 0
+'
+
+test_expect_success 'success is reported like this' '
+	:
+'
+test_expect_failure 'pretend we have a known breakage' '
+	false
+'
+
+test_terminal () {
+	perl "$SHARNESS_TEST_DIRECTORY"/test-terminal.perl "$@"
+}
+
+# If test_terminal works, then set a PERL_AND_TTY prereq for future tests:
+# (PERL and TTY prereqs may later be split if needed separately)
+test_terminal sh -c "test -t 1 && test -t 2" && test_set_prereq PERL_AND_TTY
+
+run_sub_test_lib_test () {
+	name="$1" descr="$2" # stdin is the body of the test code
+	prefix="$3"          # optionally run sub-test under command
+	opt="$4"             # optionally call the script with extra option(s)
+	mkdir "$name" &&
+	(
+		cd "$name" &&
+		cat >".$name.t" <<-EOF &&
+		#!/bin/sh
+
+		test_description='$descr (run in sub sharness)
+
+		This is run in a sub sharness so that we do not get incorrect
+		passing metrics
+		'
+
+		# Point to the test/sharness.sh, which isn't in ../ as usual
+		. "\$SHARNESS_TEST_SRCDIR"/sharness.sh
+		EOF
+		cat >>".$name.t" &&
+		chmod +x ".$name.t" &&
+		export SHARNESS_TEST_SRCDIR &&
+		$prefix ./".$name.t" $opt --chain-lint >out 2>err
+	)
+}
+
+check_sub_test_lib_test () {
+	name="$1" # stdin is the expected output from the test
+	(
+		cd "$name" &&
+		! test -s err &&
+		sed -e 's/^> //' -e 's/Z$//' >expect &&
+		test_cmp expect out
+	)
+}
+
+test_expect_success 'pretend we have a fully passing test suite' "
+	run_sub_test_lib_test full-pass '3 passing tests' <<-\\EOF &&
+	for i in 1 2 3
+	do
+		test_expect_success \"passing test #\$i\" 'true'
+	done
+	test_done
+	EOF
+	check_sub_test_lib_test full-pass <<-\\EOF
+	> ok 1 - passing test #1
+	> ok 2 - passing test #2
+	> ok 3 - passing test #3
+	> # passed all 3 test(s)
+	> 1..3
+	EOF
+"
+
+test_expect_success 'pretend we have a partially passing test suite' "
+	test_must_fail run_sub_test_lib_test \
+		partial-pass '2/3 tests passing' <<-\\EOF &&
+	test_expect_success 'passing test #1' 'true'
+	test_expect_success 'failing test #2' 'false'
+	test_expect_success 'passing test #3' 'true'
+	test_done
+	EOF
+	check_sub_test_lib_test partial-pass <<-\\EOF
+	> ok 1 - passing test #1
+	> not ok 2 - failing test #2
+	#	false
+	> ok 3 - passing test #3
+	> # failed 1 among 3 test(s)
+	> 1..3
+	EOF
+"
+
+test_expect_success 'pretend we have a known breakage' "
+	run_sub_test_lib_test failing-todo 'A failing TODO test' <<-\\EOF &&
+	test_expect_success 'passing test' 'true'
+	test_expect_failure 'pretend we have a known breakage' 'false'
+	test_done
+	EOF
+	check_sub_test_lib_test failing-todo <<-\\EOF
+	> ok 1 - passing test
+	> not ok 2 - pretend we have a known breakage # TODO known breakage
+	> # still have 1 known breakage(s)
+	> # passed all remaining 1 test(s)
+	> 1..2
+	EOF
+"
+
+test_expect_success 'pretend we have fixed a known breakage' "
+	run_sub_test_lib_test passing-todo 'A passing TODO test' <<-\\EOF &&
+	test_expect_failure 'pretend we have fixed a known breakage' 'true'
+	test_done
+	EOF
+	check_sub_test_lib_test passing-todo <<-\\EOF
+	> ok 1 - pretend we have fixed a known breakage # TODO known breakage vanished
+	> # 1 known breakage(s) vanished; please update test(s)
+	> 1..1
+	EOF
+"
+
+test_expect_success 'pretend we have fixed one of two known breakages (run in sub sharness)' "
+	run_sub_test_lib_test partially-passing-todos \
+		'2 TODO tests, one passing' <<-\\EOF &&
+	test_expect_failure 'pretend we have a known breakage' 'false'
+	test_expect_success 'pretend we have a passing test' 'true'
+	test_expect_failure 'pretend we have fixed another known breakage' 'true'
+	test_done
+	EOF
+	check_sub_test_lib_test partially-passing-todos <<-\\EOF
+	> not ok 1 - pretend we have a known breakage # TODO known breakage
+	> ok 2 - pretend we have a passing test
+	> ok 3 - pretend we have fixed another known breakage # TODO known breakage vanished
+	> # 1 known breakage(s) vanished; please update test(s)
+	> # still have 1 known breakage(s)
+	> # passed all remaining 1 test(s)
+	> 1..3
+	EOF
+"
+
+test_expect_success 'pretend we have a pass, fail, and known breakage' "
+	test_must_fail run_sub_test_lib_test \
+		mixed-results1 'mixed results #1' <<-\\EOF &&
+	test_expect_success 'passing test' 'true'
+	test_expect_success 'failing test' 'false'
+	test_expect_failure 'pretend we have a known breakage' 'false'
+	test_done
+	EOF
+	check_sub_test_lib_test mixed-results1 <<-\\EOF
+	> ok 1 - passing test
+	> not ok 2 - failing test
+	> #	false
+	> not ok 3 - pretend we have a known breakage # TODO known breakage
+	> # still have 1 known breakage(s)
+	> # failed 1 among remaining 2 test(s)
+	> 1..3
+	EOF
+"
+
+test_expect_success 'pretend we have a mix of all possible results' "
+	test_must_fail run_sub_test_lib_test \
+		mixed-results2 'mixed results #2' <<-\\EOF &&
+	test_expect_success 'passing test' 'true'
+	test_expect_success 'passing test' 'true'
+	test_expect_success 'passing test' 'true'
+	test_expect_success 'passing test' 'true'
+	test_expect_success 'failing test' 'false'
+	test_expect_success 'failing test' 'false'
+	test_expect_success 'failing test' 'false'
+	test_expect_failure 'pretend we have a known breakage' 'false'
+	test_expect_failure 'pretend we have a known breakage' 'false'
+	test_expect_failure 'pretend we have fixed a known breakage' 'true'
+	test_done
+	EOF
+	check_sub_test_lib_test mixed-results2 <<-\\EOF
+	> ok 1 - passing test
+	> ok 2 - passing test
+	> ok 3 - passing test
+	> ok 4 - passing test
+	> not ok 5 - failing test
+	> #	false
+	> not ok 6 - failing test
+	> #	false
+	> not ok 7 - failing test
+	> #	false
+	> not ok 8 - pretend we have a known breakage # TODO known breakage
+	> not ok 9 - pretend we have a known breakage # TODO known breakage
+	> ok 10 - pretend we have fixed a known breakage # TODO known breakage vanished
+	> # 1 known breakage(s) vanished; please update test(s)
+	> # still have 2 known breakage(s)
+	> # failed 3 among remaining 7 test(s)
+	> 1..10
+	EOF
+"
+
+test_set_prereq HAVEIT
+haveit=no
+test_expect_success HAVEIT 'test runs if prerequisite is satisfied' '
+	test_have_prereq HAVEIT &&
+	haveit=yes
+'
+donthaveit=yes
+test_expect_success DONTHAVEIT 'unmet prerequisite causes test to be skipped' '
+	donthaveit=no
+'
+if test $haveit$donthaveit != yesyes
+then
+	say "bug in test framework: prerequisite tags do not work reliably"
+	exit 1
+fi
+
+test_set_prereq HAVETHIS
+haveit=no
+test_expect_success HAVETHIS,HAVEIT 'test runs if prerequisites are satisfied' '
+	test_have_prereq HAVEIT &&
+	test_have_prereq HAVETHIS &&
+	haveit=yes
+'
+donthaveit=yes
+test_expect_success HAVEIT,DONTHAVEIT 'unmet prerequisites causes test to be skipped' '
+	donthaveit=no
+'
+donthaveiteither=yes
+test_expect_success DONTHAVEIT,HAVEIT 'unmet prerequisites causes test to be skipped' '
+	donthaveiteither=no
+'
+if test $haveit$donthaveit$donthaveiteither != yesyesyes
+then
+	say "bug in test framework: multiple prerequisite tags do not work reliably"
+	exit 1
+fi
+
+clean=no
+test_expect_success 'tests clean up after themselves' '
+	test_when_finished clean=yes
+'
+
+if test $clean != yes
+then
+	say "bug in test framework: basic cleanup command does not work reliably"
+	exit 1
+fi
+
+test_expect_success 'tests clean up even on failures' "
+	test_must_fail run_sub_test_lib_test \
+		failing-cleanup 'Failing tests with cleanup commands' <<-\\EOF &&
+	test_expect_success 'tests clean up even after a failure' '
+		touch clean-after-failure &&
+		test_when_finished rm clean-after-failure &&
+		(exit 1)
+	'
+	test_expect_success 'failure to clean up causes the test to fail' '
+		test_when_finished \"(exit 2)\"
+	'
+	test_done
+	EOF
+	check_sub_test_lib_test failing-cleanup <<-\\EOF
+	> not ok 1 - tests clean up even after a failure
+	> #	Z
+	> #	touch clean-after-failure &&
+	> #	test_when_finished rm clean-after-failure &&
+	> #	(exit 1)
+	> #	Z
+	> not ok 2 - failure to clean up causes the test to fail
+	> #	Z
+	> #	test_when_finished \"(exit 2)\"
+	> #	Z
+	> # failed 2 among 2 test(s)
+	> 1..2
+	EOF
+"
+
+test_expect_success 'cleanup functions tun at the end of the test' "
+	run_sub_test_lib_test cleanup-function 'Empty test with cleanup function' <<-\\EOF &&
+	cleanup 'echo cleanup-function-called >&5'
+	test_done
+	EOF
+	check_sub_test_lib_test cleanup-function <<-\\EOF
+	1..0
+	cleanup-function-called
+	EOF
+"
+
+test_expect_success 'We detect broken && chains' "
+	test_must_fail run_sub_test_lib_test \
+		broken-chain 'Broken && chain' <<-\\EOF
+	test_expect_success 'Cannot fail' '
+		true
+		true
+	'
+	test_done
+	EOF
+"
+
+test_expect_success 'tests can be run from an alternate directory' '
+	# Act as if we have an installation of sharness in current dir:
+	ln -sf $SHARNESS_TEST_SRCDIR/sharness.sh . &&
+	export working_path="$(pwd)" &&
+	cat >test.t <<-EOF &&
+	test_description="test run of script from alternate dir"
+	. \$(dirname \$0)/sharness.sh
+	test_expect_success "success" "
+		true
+	"
+	test_expect_success "trash dir is subdir of working path" "
+		test \"\$(cd .. && pwd)\" = \"\$working_path/test-rundir\"
+	"
+	test_done
+	EOF
+        (
+          # unset SHARNESS variables before sub-test
+	  unset SHARNESS_TEST_DIRECTORY SHARNESS_TEST_SRCDIR &&
+	  # unset HARNESS_ACTIVE so we get a test-results dir
+	  unset HARNESS_ACTIVE &&
+	  chmod +x test.t &&
+	  mkdir test-rundir &&
+	  cd test-rundir &&
+	  ../test.t >output 2>err &&
+	  cat >expected <<-EOF &&
+	ok 1 - success
+	ok 2 - trash dir is subdir of working path
+	# passed all 2 test(s)
+	1..2
+	EOF
+	  test_cmp expected output &&
+	  test -d test-results
+	)
+'
+
+test_expect_success 'SHARNESS_ORIG_TERM propagated to sub-sharness' "
+	(
+	  export TERM=foo &&
+	  unset SHARNESS_ORIG_TERM &&
+	  run_sub_test_lib_test orig-term 'check original term' <<-\\EOF
+	test_expect_success 'SHARNESS_ORIG_TERM is foo' '
+		test \"x\$SHARNESS_ORIG_TERM\" = \"xfoo\" '
+	test_done
+	EOF
+	)
+"
+
+[ -z "$color" ] || test_set_prereq COLOR
+test_expect_success COLOR,PERL_AND_TTY 'sub-sharness still has color' "
+	run_sub_test_lib_test \
+	  test-color \
+	  'sub-sharness color check' \
+	  test_terminal <<-\\EOF
+	test_expect_success 'color is enabled' '[ -n \"\$color\" ]'
+	test_done
+	EOF
+"
+
+test_expect_success 'EXPENSIVE prereq not activated by default' "
+	run_sub_test_lib_test no-long 'long test' <<-\\EOF &&
+	test_expect_success 'passing test' 'true'
+	test_expect_success EXPENSIVE 'passing suposedly long test' 'true'
+	test_done
+	EOF
+	check_sub_test_lib_test no-long <<-\\EOF
+	> ok 1 - passing test
+	> ok 2 # skip passing suposedly long test (missing EXPENSIVE)
+	> # passed all 2 test(s)
+	> 1..2
+	EOF
+"
+
+test_expect_success 'EXPENSIVE prereq is activated by --long' "
+	run_sub_test_lib_test long 'long test' '' '--long' <<-\\EOF &&
+	test_expect_success 'passing test' 'true'
+	test_expect_success EXPENSIVE 'passing suposedly long test' 'true'
+	test_done
+	EOF
+	check_sub_test_lib_test long <<-\\EOF
+	> ok 1 - passing test
+	> ok 2 - passing suposedly long test
+	> # passed all 2 test(s)
+	> 1..2
+	EOF
+"
+
+test_expect_success 'loading sharness extensions works' '
+	# Act as if we have a new installation of sharness
+	# under `extensions` directory. Then create
+	# a sharness.d/ directory with a test extension function:
+	mkdir extensions &&
+	(
+		cd extensions &&
+		mkdir sharness.d &&
+		cat >sharness.d/test.sh <<-EOF &&
+		this_is_a_test() {
+			return 0
+		}
+		EOF
+		ln -sf $SHARNESS_TEST_SRCDIR/sharness.sh . &&
+		cat >test-extension.t <<-\EOF &&
+		test_description="test sharness extensions"
+		. ./sharness.sh
+		test_expect_success "extension function is present" "
+			this_is_a_test
+		"
+		test_done
+		EOF
+		unset SHARNESS_TEST_DIRECTORY SHARNESS_TEST_SRCDIR &&
+		chmod +x ./test-extension.t &&
+		./test-extension.t >out 2>err &&
+		cat >expected <<-\EOF &&
+		ok 1 - extension function is present
+		# passed all 1 test(s)
+		1..1
+		EOF
+		test_cmp expected out
+	)
+'
+
+test_expect_success 'empty sharness.d directory does not cause failure' '
+	# Act as if we have a new installation of sharness
+	# under `extensions` directory. Then create
+	# an empty sharness.d/ directory
+	mkdir nil-extensions &&
+	(
+		cd nil-extensions &&
+		mkdir sharness.d  &&
+		ln -sf $SHARNESS_TEST_SRCDIR/sharness.sh . &&
+		cat >test.t <<-\EOF &&
+		test_description="sharness works"
+		. ./sharness.sh
+		test_expect_success "test success" "
+			/bin/true
+		"
+		test_done
+		EOF
+		unset SHARNESS_TEST_DIRECTORY SHARNESS_TEST_SRCDIR &&
+		chmod +x ./test.t &&
+		./test.t >out 2>err &&
+		cat >expected <<-\EOF &&
+		ok 1 - test success
+		# passed all 1 test(s)
+		1..1
+		EOF
+		test_cmp expected out
+	)
+'
+
+test_expect_success INTERACTIVE 'Interactive tests work' '
+    echo -n "Please type yes and hit enter " &&
+    read -r var &&
+    test "$var" = "yes"
+'
+
+test_done
+
+# vi: set ft=sh :

--- a/t/t0100-sudo-unit-tests.t
+++ b/t/t0100-sudo-unit-tests.t
@@ -8,6 +8,9 @@ to work properly. During an automated test run, their execution is deferred
 until this script, since it is not possible to run them directly under
 `make check` in their srcdir.
 '
+
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 . `dirname $0`/sharness.sh
 
 basedir=${SHARNESS_BUILD_DIRECTORY}/src

--- a/t/t0100-sudo-unit-tests.t
+++ b/t/t0100-sudo-unit-tests.t
@@ -1,0 +1,18 @@
+#!/bin/sh
+#
+
+test_description='Run unit tests that require sudo
+
+Some unit tests in the flux-security project may require sudo support
+to work properly. During an automated test run, their execution is deferred
+until this script, since it is not possible to run them directly under
+`make check` in their srcdir.
+'
+. `dirname $0`/sharness.sh
+
+basedir=${SHARNESS_BUILD_DIRECTORY}/src
+
+test_expect_success SUDO 'privsep unit tests' '
+	sudo $basedir/imp/test_privsep.t
+'
+test_done

--- a/t/t1000-imp-basic.t
+++ b/t/t1000-imp-basic.t
@@ -27,4 +27,21 @@ test_expect_success 'flux-imp version works' '
 test_expect_success SUDO 'flux-imp version works under sudo' '
 	sudo $flux_imp version | grep "flux-imp v"
 '
+test_expect_success 'flux-imp whoami works' '
+	$flux_imp whoami | sort -k2,2 > output.whoami &&
+	test_debug cat output.whoami &&
+	cat <<-EOF > expected.whoami &&
+	flux-imp: unprivileged: uid=$(id -ru) euid=$(id -u) gid=$(id -rg) egid=$(id -g)
+EOF
+	test_cmp expected.whoami output.whoami
+'
+test_expect_success SUDO 'flux-imp whoami works under sudo' '
+	sudo $flux_imp whoami | sort -k2,2 > output.whoami.sudo &&
+	test_debug cat output.whoami.sudo &&
+	cat <<-EOF > expected.whoami.sudo &&
+	flux-imp: privileged: uid=$(id -ru) euid=0 gid=$(id -rg) egid=0
+	flux-imp: unprivileged: uid=$(id -ru) euid=$(id -u) gid=$(id -rg) egid=$(id -g)
+EOF
+	test_cmp expected.whoami.sudo output.whoami.sudo
+'
 test_done

--- a/t/t1000-imp-basic.t
+++ b/t/t1000-imp-basic.t
@@ -6,6 +6,9 @@ test_description='IMP basic functionality test
 Ensure IMP runs and runs under sudo when SUDO is available.
 Also test basic subcommands like "version".
 '
+
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 . `dirname $0`/sharness.sh
 
 flux_imp=${SHARNESS_BUILD_DIRECTORY}/src/imp/flux-imp

--- a/t/t1000-imp-basic.t
+++ b/t/t1000-imp-basic.t
@@ -1,0 +1,27 @@
+#!/bin/sh
+#
+
+test_description='IMP basic functionality test
+
+Ensure IMP runs and runs under sudo when SUDO is available.
+Also test basic subcommands like "version".
+'
+. `dirname $0`/sharness.sh
+
+flux_imp=${SHARNESS_BUILD_DIRECTORY}/src/imp/flux-imp
+
+echo "# Using ${flux_imp}"
+
+test_expect_success 'flux-imp is built and is executable' '
+	test -x $flux_imp
+'
+test_expect_success 'flux-imp returns error when run with no args' '
+	test_must_fail $flux_imp 
+'
+test_expect_success 'flux-imp version works' '
+	$flux_imp version | grep "flux-imp v"
+'
+test_expect_success SUDO 'flux-imp version works under sudo' '
+	sudo $flux_imp version | grep "flux-imp v"
+'
+test_done

--- a/t/t1000-imp-basic.t
+++ b/t/t1000-imp-basic.t
@@ -27,6 +27,9 @@ test_expect_success 'flux-imp version works' '
 test_expect_success SUDO 'flux-imp version works under sudo' '
 	sudo $flux_imp version | grep "flux-imp v"
 '
+test_expect_success SUDO 'flux-imp generates error if SUDO_USER is invalid' '
+	test_expect_code 1 sudo SUDO_USER=invalid $flux_imp version
+'
 test_expect_success 'flux-imp whoami works' '
 	$flux_imp whoami | sort -k2,2 > output.whoami &&
 	test_debug cat output.whoami &&
@@ -43,5 +46,27 @@ test_expect_success SUDO 'flux-imp whoami works under sudo' '
 	flux-imp: unprivileged: uid=$(id -ru) euid=$(id -u) gid=$(id -rg) egid=$(id -g)
 EOF
 	test_cmp expected.whoami.sudo output.whoami.sudo
+'
+test_expect_success SUDO 'create setuid copy of flux-imp for testing' '
+	sudo cp $flux_imp . &&
+	sudo chmod 4755 ./flux-imp
+'
+test_expect_success SUDO 'setuid copy of flux-imp works' '
+	./flux-imp whoami | sort -k2,2 > output.whoami.setuid &&
+	test_debug cat output.whoami.setuid &&
+	cat <<-EOF >expected.whoami.setuid &&
+	flux-imp: privileged: uid=$(id -ru) euid=0 gid=$(id -rg) egid=$(id -g)
+	flux-imp: unprivileged: uid=$(id -ru) euid=$(id -u) gid=$(id -rg) egid=$(id -g)
+	EOF
+	test_cmp expected.whoami.setuid output.whoami.setuid
+'
+test_expect_success SUDO 'flux-imp setuid ignores SUDO_USER' '
+	SUDO_USER=nobody ./flux-imp whoami | sort -k2,2 > output.whoami.no &&
+	test_debug cat output.whoami.no &&
+	cat <<-EOF >expected.whoami.no &&
+	flux-imp: privileged: uid=$(id -ru) euid=0 gid=$(id -rg) egid=$(id -g)
+	flux-imp: unprivileged: uid=$(id -ru) euid=$(id -u) gid=$(id -rg) egid=$(id -g)
+	EOF
+	test_cmp expected.whoami.no output.whoami.no
 '
 test_done


### PR DESCRIPTION
This PR adds basic functional skeleton for the IMP including:
 
 * Support for directory of TOML config files under a directory like `imp.conf.d/*.toml`. For now config is only loaded from build directory, but support is there to load from hard-coded system configuration directory by building a separate binary (e.g. flux-imp.installed or something).
 * Implementation of privilege separation when IMP is running setuid. The IMP process will fork off a child that drops privileges to the real UID. The "privliged parent" and "unprivileged child" are connected with a pair of pipes. The child is meant to process all input from the untrusted source, and push data back to the parent over the pipe in a more restricted format. Nothing uses this yet.
 * Support for running under sudo by simulating a setuid installation with sudo (set real UID to SUDO_USER)
 * Very basic subcommand support. Subcommands are split into an "unprivileged" child half and "privileged" parent half. Only a child subcommand may be registered if the command does not require privileged.
 * Addition of a simple "version" subcommand which does not require privilege to run.

Additionally, a `t` directory is added with a sharness support. The sharness suite here uses a hook from MUNGE to detect non-interactive sudo support, and uses that to run unit tests and modes of `flux-imp` that require privilege. Not sure if this is the best approach.