### PR TITLE
imp/casign: add casign subcommand

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,6 +2,7 @@ coverage:
  round: down
  range: "50...100"
  ignore:
+ - "t/.*"
  - ".*/test/.*"
  - ".*/libtap/.*"
 

--- a/src/imp/Makefile.am
+++ b/src/imp/Makefile.am
@@ -32,7 +32,8 @@ flux_imp_SOURCES = \
 	version.c \
 	whoami.c \
 	testconfig.h \
-	testconfig.c
+	testconfig.c \
+	casign.c
 
 testconfig.o: testconfig.h
 testconfig.h: $(top_builddir)/config/config.h

--- a/src/imp/casign.c
+++ b/src/imp/casign.c
@@ -1,0 +1,152 @@
+/*****************************************************************************\
+ *  Copyright (c) 2017 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#include "src/libutil/kv.h"
+#include "src/libutil/sigcert.h"
+#include "src/libutil/cf.h"
+#include "src/libutil/ca.h"
+
+#include "imp_log.h"
+#include "imp_state.h"
+#include "impcmd.h"
+#include "privsep.h"
+
+/* Create a cert from 'cert' prefix in 'kv'.
+ * On success, return cert.  On failure, return NULL with errno set.
+ */
+static struct sigcert *get_cert_from_kv (const struct kv *kv)
+{
+    struct kv *cert_kv;
+    const char *buf;
+    int len;
+    struct sigcert *cert = NULL;
+
+    if (!(cert_kv = kv_split (kv, "cert")))
+        goto done;
+    if (kv_encode (cert_kv, &buf, &len) < 0)
+        goto done;
+    cert = sigcert_decode (buf, len);
+done:
+    kv_destroy (cert_kv);
+    return cert;
+}
+
+/* Add cert to kv under 'cert' prefix.
+ * On success, return 0. On failure, return -1 with errno set.
+ */
+static int add_cert_to_kv (struct kv *kv, const struct sigcert *cert)
+{
+    struct kv *cert_kv = NULL;
+    const char *buf;
+    int len;
+    int rc = -1;
+
+    if (sigcert_encode (cert, &buf, &len) < 0)
+        goto done;
+    if (!(cert_kv = kv_decode (buf, len)))
+        goto done;
+    rc = kv_join (kv, cert_kv, "cert");
+done:
+    kv_destroy (cert_kv);
+    return rc;
+}
+
+/* Sign 'cert' with the CA cert, and emit to stdout.
+ * The cert userid is set to the real uid used to execute the imp.
+ * The TTL is set to the configured maximum.
+ * The location of the CA cert is obtained from the [ca] configuration.
+ */
+static void sign_cert (cf_t *conf, struct sigcert *cert)
+{
+    struct ca *ca;
+    const cf_t *cf;
+    ca_error_t error;
+    int64_t ttl = 0;            // use configured maximum
+    int64_t userid = getuid (); // sign as real userid
+
+    if (!conf)
+        imp_die (1, "casign: no configuration");
+    if (!(cf = cf_get_in (conf, "ca")))
+        imp_die (1, "casign: no [ca] configuration");
+    if (!(ca = ca_create (cf, error)))
+        imp_die (1, "casign: ca_create: %s", error);
+    if (ca_load (ca, true, error) < 0)
+        imp_die (1, "casign: ca_load: %s", error);
+    if (ca_sign (ca, cert, ttl, userid, error) < 0)
+        imp_die (1, "casign: ca_sign: %s", error);
+    if (sigcert_fwrite_public (cert, stdout) < 0)
+        imp_die (1, "casign: write stdout: %s", strerror (errno));
+    ca_destroy (ca);
+}
+
+int imp_casign_privileged (struct imp_state *imp, const struct kv *kv)
+{
+    struct sigcert *cert;
+
+    if (!(cert = get_cert_from_kv (kv)))
+        imp_die (1, "casign: decode cert: %s", strerror (errno));
+    sign_cert (imp->conf, cert);
+    sigcert_destroy (cert);
+    return (0);
+}
+
+int imp_casign_unprivileged (struct imp_state *imp, struct kv *kv)
+{
+    struct sigcert *cert;
+
+    if (!(cert = sigcert_fread_public (stdin)))
+        imp_die (1, "casign: decode cert: %s", strerror (errno));
+
+    if (imp->ps) {
+        if (add_cert_to_kv (kv, cert) < 0)
+            imp_die (1, "casign: encode cert: %s", strerror (errno));
+        if (privsep_write_kv (imp->ps, kv) < 0)
+            imp_die (1, "casign: failed to communicate with privsep parent");
+    }
+    /* N.B. for testing, if the IMP isn't installed setuid, try the signing
+     * operation without privilege.  It will fail if the CA cert cannot be
+     * accessed, as would normally be the case in a real installation.
+     */
+    else {
+        imp_warn ("casign: imp is not installed setuid, proceeding anyway...");
+        sign_cert (imp->conf, cert);
+    }
+
+    sigcert_destroy (cert);
+    return (0);
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/imp/impcmd-list.c
+++ b/src/imp/impcmd-list.c
@@ -28,6 +28,8 @@
 extern int imp_cmd_version (struct imp_state *imp, struct kv *);
 extern int imp_whoami_unprivileged (struct imp_state *imp, struct kv *);
 extern int imp_whoami_privileged (struct imp_state *imp, struct kv *);
+extern int imp_casign_unprivileged (struct imp_state *imp, struct kv *);
+extern int imp_casign_privileged (struct imp_state *imp, struct kv *);
 
 /*  List of supported imp commands, curated by hand for now.
  *   For each named command, the `child_fn` runs unprivileged and the
@@ -41,6 +43,9 @@ struct impcmd impcmd_list[] = {
 	{ "whoami",
 	  imp_whoami_unprivileged,
       imp_whoami_privileged },
+	{ "casign",
+	  imp_casign_unprivileged,
+      imp_casign_privileged },
 	{ NULL, NULL, NULL}
 };
 

--- a/src/libutil/sigcert.c
+++ b/src/libutil/sigcert.c
@@ -46,6 +46,12 @@
 
 #include "sigcert.h"
 
+/* Place an upper limit on size of a cert that can be read in.
+ * If libtomlc99 integer byte offsets wrap, there will be segfaults.
+ * If that ever gets fixed, we would OOM.
+ */
+static const size_t cert_read_limit = (1024*1024*10); // 10mb
+
 /* Define some handy types for fixed length keys and their base64 encodings.
  * N.B. macro versions of base64_encode_length() and base64_decode_length()
  * were defined so these types can be declared in a struct or on the stack.
@@ -555,6 +561,47 @@ done:
     return rc;
 }
 
+/* Read NULL-terminated buffer, up to 'limit' bytes in length, including NULL.
+ */
+static char *freads_limited (FILE *fp, size_t limit)
+{
+    const size_t chunksz = 1024;
+    char *buf = NULL;
+    size_t bufsz = 0;
+    size_t count = 0;
+    int saved_errno;
+
+    if (!fp)
+        goto inval;
+    if (!(buf = malloc (chunksz)))
+        return NULL;
+    bufsz += chunksz;
+    while (!feof (fp)) {
+        if (bufsz - count <= 1) { // need a min of NULL + 1 char to continue
+            char *newbuf;
+            if (!(newbuf = realloc (buf, bufsz + chunksz)))
+                goto error;
+            buf = newbuf;
+            bufsz += chunksz;
+        }
+        count += fread (buf + count, 1, bufsz - count - 1, fp); // reserve NULL
+        if (ferror (fp))
+            goto error;
+        if (count > limit)
+            goto inval;
+    }
+    assert (count < bufsz);
+    buf[count] = '\0';
+    return buf;
+inval:
+    errno = EINVAL;
+error:
+    saved_errno = errno;
+    free (buf);
+    errno = saved_errno;
+    return NULL;
+}
+
 /* Read in secret-key.
  */
 static int sigcert_fread_secret (struct sigcert *cert, FILE *fp)
@@ -563,8 +610,11 @@ static int sigcert_fread_secret (struct sigcert *cert, FILE *fp)
     toml_table_t *curve_table;
     const char *raw;
     char errbuf[200];
+    char *conf;
 
-    if (!(cert_table = toml_parse_file (fp, errbuf, sizeof (errbuf))))
+    if (!(conf = freads_limited (fp, cert_read_limit)))
+        return -1;
+    if (!(cert_table = toml_parse (conf, errbuf, sizeof (errbuf))))
         goto inval;
     if (!(curve_table = toml_table_in (cert_table, "curve")))
         goto inval;
@@ -573,9 +623,11 @@ static int sigcert_fread_secret (struct sigcert *cert, FILE *fp)
     if (parse_toml_secret_key (raw, cert->secret_key) < 0)
         goto inval;
     cert->secret_valid = true;
+    free (conf);
     toml_free (cert_table);
     return 0;
 inval:
+    free (conf);
     toml_free (cert_table);
     errno = EINVAL;
     return -1;
@@ -593,10 +645,15 @@ struct sigcert *sigcert_fread_public (FILE *fp)
     const char *raw;
     int i;
     char errbuf[200];
+    char *conf;
 
     if (!(cert = sigcert_alloc ()))
         return NULL;
-    if (!(cert_table = toml_parse_file (fp, errbuf, sizeof (errbuf))))
+    if (!(conf = freads_limited (fp, cert_read_limit))) {
+        sigcert_destroy (cert);
+        return NULL;
+    }
+    if (!(cert_table = toml_parse (conf, errbuf, sizeof (errbuf))))
         goto inval;
 
     // [metadata]
@@ -621,9 +678,11 @@ struct sigcert *sigcert_fread_public (FILE *fp)
             goto inval;
         cert->signature_valid = true;
     }
+    free (conf);
     toml_free (cert_table);
     return cert;
 inval:
+    free (conf);
     toml_free (cert_table);
     sigcert_destroy (cert);
     errno = EINVAL;

--- a/src/libutil/sigcert.c
+++ b/src/libutil/sigcert.c
@@ -376,7 +376,7 @@ static int sigcert_fwrite_secret (const struct sigcert *cert, FILE *fp)
 
 /* Write public cert contents (not secret-key) to 'fp' in TOML format.
  */
-static int sigcert_fwrite_public (const struct sigcert *cert, FILE *fp)
+int sigcert_fwrite_public (const struct sigcert *cert, FILE *fp)
 {
     const char *key = NULL;
 

--- a/src/libutil/sigcert.h
+++ b/src/libutil/sigcert.h
@@ -49,9 +49,13 @@ struct sigcert *sigcert_load (const char *name, bool secret);
  */
 int sigcert_store (const struct sigcert *cert, const char *name);
 
-/* Write cert to 'fp'.
+/* Write public portion of cert to 'fp'.
  */
 int sigcert_fwrite_public (const struct sigcert *cert, FILE *fp);
+
+/* Read public portion of cert from 'fp'.
+ */
+struct sigcert *sigcert_fread_public (FILE *fp);
 
 /* Decode kv buffer to cert.
  */

--- a/src/libutil/sigcert.h
+++ b/src/libutil/sigcert.h
@@ -4,6 +4,7 @@
 #include <time.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
 
 /* Certificate class for signing/verification.
  *
@@ -47,6 +48,10 @@ struct sigcert *sigcert_load (const char *name, bool secret);
 /* Store cert to 'name' and 'name.pub'.
  */
 int sigcert_store (const struct sigcert *cert, const char *name);
+
+/* Write cert to 'fp'.
+ */
+int sigcert_fwrite_public (const struct sigcert *cert, FILE *fp);
 
 /* Decode kv buffer to cert.
  */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -12,6 +12,20 @@ check_SCRIPTS = \
 	t0100-sudo-unit-tests.t \
 	t1000-imp-basic.t
 
+check_PROGRAMS = \
+	src/keygen
+
+test_cppflags = \
+	-I$(top_srcdir)
+
+test_ldadd = \
+	$(top_builddir)/src/libutil/libutil.la \
+	$(top_builddir)/src/libtomlc99/libtomlc99.la
+
+src_keygen_SOURCES = src/keygen.c
+src_keygen_CPPFLAGS = $(test_cppflags)
+src_keygen_LDADD = $(test_ldadd)
+
 EXTRA_DIST= \
 	sharness.sh \
 	sharness.d \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -15,7 +15,8 @@ check_SCRIPTS = \
 check_PROGRAMS = \
 	src/keygen \
 	src/certutil \
-	src/ca
+	src/ca \
+	src/cf
 
 test_cppflags = \
 	-I$(top_srcdir)
@@ -36,6 +37,10 @@ src_certutil_LDADD = $(test_ldadd)
 src_ca_SOURCES = src/ca.c
 src_ca_CPPFLAGS = $(test_cppflags)
 src_ca_LDADD = $(test_ldadd)
+
+src_cf_SOURCES = src/cf.c
+src_cf_CPPFLAGS = $(test_cppflags)
+src_cf_LDADD = $(test_ldadd)
 
 EXTRA_DIST= \
 	sharness.sh \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -14,14 +14,16 @@ check_SCRIPTS = \
 
 check_PROGRAMS = \
 	src/keygen \
-	src/certutil
+	src/certutil \
+	src/ca
 
 test_cppflags = \
 	-I$(top_srcdir)
 
 test_ldadd = \
 	$(top_builddir)/src/libutil/libutil.la \
-	$(top_builddir)/src/libtomlc99/libtomlc99.la
+	$(top_builddir)/src/libtomlc99/libtomlc99.la \
+	$(top_builddir)/src/imp/testconfig.o
 
 src_keygen_SOURCES = src/keygen.c
 src_keygen_CPPFLAGS = $(test_cppflags)
@@ -30,6 +32,10 @@ src_keygen_LDADD = $(test_ldadd)
 src_certutil_SOURCES = src/certutil.c
 src_certutil_CPPFLAGS = $(test_cppflags)
 src_certutil_LDADD = $(test_ldadd)
+
+src_ca_SOURCES = src/ca.c
+src_ca_CPPFLAGS = $(test_cppflags)
+src_ca_LDADD = $(test_ldadd)
 
 EXTRA_DIST= \
 	sharness.sh \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -1,3 +1,12 @@
+AM_CFLAGS = \
+	$(WARNING_CFLAGS) \
+	$(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+	$(CODE_COVERAGE_LIBS)
+
+AM_CPPFLAGS =
+
 TEST_EXTENSIONS = .t
 T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
 	$(top_srcdir)/config/tap-driver.sh
@@ -21,7 +30,8 @@ check_PROGRAMS = \
 	src/cf
 
 test_cppflags = \
-	-I$(top_srcdir)
+	-I$(top_srcdir) \
+	$(AM_CPPFLAGS)
 
 test_ldadd = \
 	$(top_builddir)/src/libutil/libutil.la \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -13,7 +13,8 @@ check_SCRIPTS = \
 	t1000-imp-basic.t
 
 check_PROGRAMS = \
-	src/keygen
+	src/keygen \
+	src/certutil
 
 test_cppflags = \
 	-I$(top_srcdir)
@@ -25,6 +26,10 @@ test_ldadd = \
 src_keygen_SOURCES = src/keygen.c
 src_keygen_CPPFLAGS = $(test_cppflags)
 src_keygen_LDADD = $(test_ldadd)
+
+src_certutil_SOURCES = src/certutil.c
+src_certutil_CPPFLAGS = $(test_cppflags)
+src_certutil_LDADD = $(test_ldadd)
 
 EXTRA_DIST= \
 	sharness.sh \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -5,12 +5,14 @@ T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
 TESTS = \
 	t0000-sharness.t \
 	t0100-sudo-unit-tests.t \
-	t1000-imp-basic.t
+	t1000-imp-basic.t \
+	t1001-imp-casign.t
 
 check_SCRIPTS = \
 	t0000-sharness.t \
 	t0100-sudo-unit-tests.t \
-	t1000-imp-basic.t
+	t1000-imp-basic.t \
+	t1001-imp-casign.t
 
 check_PROGRAMS = \
 	src/keygen \

--- a/t/src/ca.c
+++ b/t/src/ca.c
@@ -1,0 +1,130 @@
+/* ca.c - CA utility
+ */
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <assert.h>
+
+#include "src/libutil/sigcert.h"
+#include "src/libutil/cf.h"
+#include "src/libutil/ca.h"
+
+extern const char *imp_get_config_pattern (void);
+
+const char *prog = "ca";
+
+static void die (const char *fmt, ...)
+{
+    va_list ap;
+    char buf[256];
+
+    va_start (ap, fmt);
+    (void)vsnprintf (buf, sizeof (buf), fmt, ap);
+    va_end (ap);
+    fprintf (stderr, "%s: %s\n", prog, buf);
+    exit (1);
+}
+
+static void usage (void)
+{
+    fprintf (stderr,
+"Usage: ca keygen\n"
+"   or: ca revoke uuid\n"
+"   or: ca verify path\n");
+}
+
+static struct ca *init_ca (void)
+{
+    const char *pattern = imp_get_config_pattern ();
+    cf_t *conf;
+    const cf_t *conf_ca;
+    struct cf_error e;
+    struct ca *ca;
+    ca_error_t error;
+
+    assert (pattern != NULL);
+    if (!(conf = cf_create ()))
+        die ("cf_create: %s", strerror (errno));
+    if (cf_update_glob (conf, pattern, &e) < 0)
+        die ("%s::%d: %s", e.filename, e.lineno, e.errbuf);
+    if (!(conf_ca = cf_get_in (conf, "ca")))
+        die ("no [ca] configuration");
+    if (!(ca = ca_create (conf_ca, error)))
+        die ("ca_create: %s", error);
+
+    cf_destroy (conf);
+
+    return ca;
+}
+
+/* Add 'uuid' to the CA revocation directory.
+ */
+static void revoke (const char *uuid)
+{
+    struct ca *ca = init_ca ();
+    ca_error_t error;
+
+    if (ca_revoke (ca, uuid, error) < 0)
+        die ("ca_revoke: %s", error);
+
+    ca_destroy (ca);
+}
+
+/* Generate new CA cert, writing to the configured path.
+ */
+static void keygen (void)
+{
+    struct ca *ca = init_ca ();
+    ca_error_t error;
+
+    if (ca_keygen (ca, error) < 0)
+        die ("ca_keygen: %s", error);
+    if (ca_store (ca, error) < 0)
+        die ("ca_store: %s", error);
+
+    ca_destroy (ca);
+}
+
+/* Verify that a cert was signed by the CA and has not been revoked.
+ */
+static void verify (const char *path)
+{
+    struct ca *ca = init_ca ();
+    ca_error_t error;
+    struct sigcert *cert;
+    int64_t userid;
+
+    if (ca_load (ca, false, error) < 0)
+        die ("ca_load: %s", error);
+    if (!(cert = sigcert_load (path, false)))
+        die ("sigcert_load: %s", strerror (errno));
+    if (ca_verify (ca, cert, &userid, NULL, error) < 0)
+        die ("ca_verify: %s", error);
+    printf ("%lld\n", (long long)userid);
+    sigcert_destroy (cert);
+
+    ca_destroy (ca);
+}
+
+
+int main (int argc, char **argv)
+{
+    if (argc == 2 && !strcmp (argv[1], "keygen"))
+        keygen ();
+    else if (argc == 3 && !strcmp (argv[1], "revoke"))
+        revoke (argv[2]);
+    else if (argc == 3 && !strcmp (argv[1], "verify"))
+        verify (argv[2]);
+    else
+        usage ();
+
+    return 0;
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/t/src/certutil.c
+++ b/t/src/certutil.c
@@ -1,0 +1,167 @@
+/* certutil.c - get/put cert metadata
+ *
+ * Usage: certutil certname get key
+ *        certutil certname put key [type:]value
+ *
+ * Possible type indicators are
+ *   s = string (default)
+ *   i = int64
+ *   d = double
+ *   b = boolean
+ *   t = timestamp
+ *
+ * N.B. timestamps are input/output in seconds-since-epoch localtime form,
+ * for easy manipulation in sharness tests, comparisons with TTL's, etc..
+ */
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+#include "src/libutil/sigcert.h"
+
+const char *prog = "certutil";
+
+static void die (const char *fmt, ...)
+{
+    va_list ap;
+    char buf[256];
+
+    va_start (ap, fmt);
+    (void)vsnprintf (buf, sizeof (buf), fmt, ap);
+    va_end (ap);
+    fprintf (stderr, "%s: %s\n", prog, buf);
+    exit (1);
+}
+
+static void usage (void)
+{
+    fprintf (stderr, "Usage: certutil certname get key [type]\n"
+                     "   or: certutil certname put key [type:]value\n");
+    exit (1);
+}
+
+/* Get key from cert metadata and display.
+ */
+void get_meta (const char *certname, const char *key, const char *type)
+{
+    struct sigcert *cert;
+
+    if (!type)
+        type = "s";
+    if (!(cert = sigcert_load (certname, false)))
+        die ("load %s: %s", certname, strerror (errno));
+    switch (type[0]) {
+        case 's': {
+            const char *s;
+            if (sigcert_meta_get (cert, key, SM_STRING, &s) < 0)
+                die ("sigcert_meta_get: %s", strerror (errno));
+            printf ("%s\n", s);
+            break;
+        }
+        case 'i': {
+            int64_t i;
+            if (sigcert_meta_get (cert, key, SM_INT64, &i) < 0)
+                die ("sigcert_meta_get: %s", strerror (errno));
+            printf ("%lld\n", (long long int)i);
+            break;
+        }
+        case 'd': {
+            double d;
+            if (sigcert_meta_get (cert, key, SM_DOUBLE, &d) < 0)
+                die ("sigcert_meta_get: %s", strerror (errno));
+            printf ("%lf\n", d);
+            break;
+        }
+        case 'b': {
+            bool b;
+            if (sigcert_meta_get (cert, key, SM_BOOL, &b) < 0)
+                die ("sigcert_meta_get: %s", strerror (errno));
+            printf ("%s\n", b ? "true" : "false");
+            break;
+        }
+        case 't': {
+            time_t t;
+            if (sigcert_meta_get (cert, key, SM_TIMESTAMP, &t) < 0)
+                die ("sigcert_meta_get: %s", strerror (errno));
+            printf ("%d\n", (int)t);
+            break;
+        }
+        default:
+            die ("unknown type indicator '%c'", type[0]);
+            break;
+    }
+    sigcert_destroy (cert);
+}
+
+/* Put key=value to cert.
+ * The type: prefix determines the type of the value.
+ */
+void put_meta (const char *certname, const char *key, const char *value)
+{
+    struct sigcert *cert;
+    char type[2] = "s";
+
+    if (strlen (value) >= 2 && value[1] == ':') {
+        type[0] = value[0];
+        value += 2;
+    }
+    if (!(cert = sigcert_load (certname, false)))
+        die ("load %s: %s", certname, strerror (errno));
+    switch (type[0]) {
+        case 's': {
+            if (sigcert_meta_set (cert, key, SM_STRING, value) < 0)
+                die ("sigcert_meta_set: %s", strerror (errno));
+            break;
+        }
+        case 'i': {
+            int64_t i = strtoll (value, NULL, 10);
+            if (sigcert_meta_set (cert, key, SM_INT64, i) < 0)
+                die ("sigcert_meta_set: %s", strerror (errno));
+            break;
+        }
+        case 'd': {
+            double d = strtod (value, NULL);
+            if (sigcert_meta_set (cert, key, SM_DOUBLE, d) < 0)
+                die ("sigcert_meta_set: %s", strerror (errno));
+            break;
+        }
+        case 'b': {
+            bool b = !strcmp (value, "false") ? false : true;
+            if (sigcert_meta_set (cert, key, SM_BOOL, b) < 0)
+                die ("sigcert_meta_set: %s", strerror (errno));
+            break;
+        }
+        case 't': {
+            time_t t = strtol (value, NULL, 10);
+            if (sigcert_meta_set (cert, key, SM_TIMESTAMP, t) < 0)
+                die ("sigcert_meta_set: %s", strerror (errno));
+            break;
+        }
+        default:
+            die ("unknown type indicator '%c'", type[0]);
+            break;
+    }
+
+    if (sigcert_store (cert, certname) < 0)
+        die ("store %s: %s", certname, strerror (errno));
+    sigcert_destroy (cert);
+}
+
+int main (int argc, char **argv)
+{
+    if ((argc == 4 || argc == 5) && !strcmp (argv[2], "get"))
+        get_meta (argv[1], argv[3], argc == 5 ? argv[4] : NULL);
+    else if ((argc == 5 && !strcmp (argv[2], "put")))
+        put_meta (argv[1], argv[3], argv[4]);
+    else
+        usage ();
+    return 0;
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/t/src/cf.c
+++ b/t/src/cf.c
@@ -1,0 +1,105 @@
+/* cf.c - read imp config
+ *
+ * Usage: keygen path
+ */
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <assert.h>
+
+#include "src/libutil/cf.h"
+
+extern const char *imp_get_config_pattern (void);
+
+const char *prog = "cf";
+
+static void die (const char *fmt, ...)
+{
+    va_list ap;
+    char buf[256];
+
+    va_start (ap, fmt);
+    (void)vsnprintf (buf, sizeof (buf), fmt, ap);
+    va_end (ap);
+    fprintf (stderr, "%s: %s\n", prog, buf);
+    exit (1);
+}
+
+void lookup (const cf_t *cf, char *key)
+{
+    char *nextkey = strchr (key, '.');
+    const cf_t *val;
+
+    if (nextkey) {
+        *nextkey++ = '\0';
+        if (!(val = cf_get_in (cf, key)))
+            die ("%s: not found", key);
+        if (cf_typeof (val) != CF_TABLE)
+            die ("%s: not a table object", key);
+        lookup (val, nextkey);
+    }
+    else {
+        if (!(val = cf_get_in (cf, key)))
+            die ("%s: not found", key);
+
+        switch (cf_typeof (val)) {
+            case CF_INT64:
+                printf ("%lld\n", (long long)cf_int64 (val));
+                break;
+            case CF_DOUBLE:
+                printf ("%lf\n", cf_double (val));
+                break;
+            case CF_BOOL:
+                printf ("%s\n", cf_bool (val) ? "true" : "false");
+                break;
+            case CF_STRING:
+                printf ("%s\n", cf_string (val));
+                break;
+            case CF_TIMESTAMP:
+                printf ("%d\n", (int)cf_timestamp (val));
+                break;
+            case CF_TABLE:
+                printf ("[table]\n");
+                break;
+            case CF_ARRAY:
+                printf ("[array]\n");
+                break;
+            case CF_UNKNOWN:
+                die ("unknwon type");
+                break;
+        }
+    }
+}
+
+int main (int argc, char **argv)
+{
+    const char *pattern = imp_get_config_pattern ();
+    cf_t *cf;
+    struct cf_error e;
+
+    if (argc != 2) {
+        fprintf (stderr, "Usage: cf key\n");
+        exit (1);
+    }
+
+    if (!(cf = cf_create ()))
+        die ("cf_create: %s", strerror (errno));
+    assert (pattern != NULL);
+    if (cf_update_glob (cf, pattern, &e) < 0)
+        die ("%s::%d: %s", e.filename, e.lineno, e.errbuf);
+
+    lookup (cf, argv[1]);
+
+    cf_destroy (cf);
+
+    return 0;
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/t/src/keygen.c
+++ b/t/src/keygen.c
@@ -1,0 +1,49 @@
+/* keygen.c - generate signing keys
+ *
+ * Usage: keygen path
+ */
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+#include "src/libutil/sigcert.h"
+
+const char *prog = "keygen";
+
+static void die (const char *fmt, ...)
+{
+    va_list ap;
+    char buf[256];
+
+    va_start (ap, fmt);
+    (void)vsnprintf (buf, sizeof (buf), fmt, ap);
+    va_end (ap);
+    fprintf (stderr, "%s: %s\n", prog, buf);
+    exit (1);
+}
+
+int main (int argc, char **argv)
+{
+    struct sigcert *cert;
+    const char *certname;
+
+    if (argc != 2)
+        die ("Usage: keygen path");
+    certname = argv[1];
+
+    if (!(cert = sigcert_create ()))
+        die ("sigcert_create: %s", strerror (errno));
+    if (sigcert_store (cert, certname) < 0)
+        die ("sigcert_store: %s", strerror (errno));
+    sigcert_destroy (cert);
+
+    return 0;
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/t/t1001-imp-casign.t
+++ b/t/t1001-imp-casign.t
@@ -1,0 +1,112 @@
+#!/bin/sh
+#
+
+test_description='IMP casign functionality test
+
+Ensure IMP casign works as designed.
+'
+
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+. `dirname $0`/sharness.sh
+
+flux_imp=${SHARNESS_BUILD_DIRECTORY}/src/imp/flux-imp
+keygen=${SHARNESS_BUILD_DIRECTORY}/t/src/keygen
+certutil=${SHARNESS_BUILD_DIRECTORY}/t/src/certutil
+ca=${SHARNESS_BUILD_DIRECTORY}/t/src/ca
+cf=${SHARNESS_BUILD_DIRECTORY}/t/src/cf
+
+# used by 'ca' utility as well as imp
+export FLUX_IMP_CONFIG_PATTERN=${SHARNESS_TRASH_DIRECTORY}/conf.d/*.toml
+mkdir -p conf.d
+echo 'allow-sudo = true' >${SHARNESS_TRASH_DIRECTORY}/conf.d/imp.toml
+
+new_ca_config() {
+	local max_cert_ttl=$1
+	local max_sign_ttl=$2
+
+	cat >conf.d/ca.toml <<-EOT
+	[ca]
+	max-cert-ttl = ${max_cert_ttl}
+	max-sign-ttl = ${max_sign_ttl}
+
+	cert-path = "${SHARNESS_TRASH_DIRECTORY}/ca"
+	revoke-dir = "${SHARNESS_TRASH_DIRECTORY}/revoke.d"
+	revoke-allow = true
+	EOT
+}
+
+test_expect_success 'create new CA config' '
+	new_ca_config 60 30 &&
+	$cf ca.max-cert-ttl &&
+	$cf ca.max-sign-ttl &&
+	$cf ca.cert-path &&
+	$cf ca.revoke-dir &&
+	$cf ca.revoke-allow
+'
+
+test_expect_success 'create new CA cert' '
+	$ca keygen &&
+	test -f ca &&
+	test -f ca.pub
+'
+
+test_expect_success 'create new user signing cert' '
+	$keygen u &&
+	test -f u &&
+	test -f u.pub
+'
+
+test_expect_success SUDO 'imp casign works under sudo' '
+	sudo FLUX_IMP_CONFIG_PATTERN=${SHARNESS_TRASH_DIRECTORY}/conf.d/*.toml \
+		$flux_imp casign <u.pub >u.pub.signed.sudo
+'
+
+test_expect_success 'imp can sign user cert' '
+	$flux_imp casign <u.pub >u.pub.signed &&
+	mv u.pub u.pub.unsigned &&
+	mv u.pub.signed u.pub
+'
+
+test_expect_success 'user cert has expected userid' '
+	$certutil u get userid i >userid.out &&
+	id -u >userid.exp &&
+	test_cmp userid.exp userid.out
+'
+
+test_expect_success 'user cert has a uuid' '
+	$certutil u get uuid s
+'
+
+test_expect_success 'user cert has ctime <= now' '
+	ctime=$($certutil u get ctime t) &&
+	test $ctime -le $(date +%s)
+'
+
+test_expect_success 'user cert xtime - ctime = CA max-cert-ttl' '
+	max_cert_ttl=$($cf ca.max-cert-ttl) &&
+	ctime=$($certutil u get ctime t) &&
+	xtime=$($certutil u get xtime t) &&
+	test $(($xtime-$ctime)) -eq ${max_cert_ttl}
+'
+
+test_expect_success 'user cert max-sign-ttl = CA max-sign-ttl' '
+	max_sign_ttl=$($cf ca.max-sign-ttl) &&
+	val=$($certutil u get max-sign-ttl i) &&
+	test $val -eq ${max_sign_ttl}
+'
+
+test_expect_success 'CA verifies signed cert' '
+	$ca verify u
+'
+
+test_expect_success 'CA revokes cert' '
+	uuid=$($certutil u get uuid s) &&
+	$ca revoke $uuid
+'
+
+test_expect_success 'CA cannot verify revoked cert' '
+	test_must_fail $ca verify u
+'
+
+test_done

--- a/t/t1001-imp-casign.t
+++ b/t/t1001-imp-casign.t
@@ -109,4 +109,12 @@ test_expect_success 'CA cannot verify revoked cert' '
 	test_must_fail $ca verify u
 '
 
+test_expect_success 'imp casign fails on /dev/zero input' '
+	test_must_fail $flux_imp casign </dev/zero
+'
+
+test_expect_success 'imp casign fails on /dev/null input' '
+	test_must_fail $flux_imp casign </dev/null
+'
+
 test_done


### PR DESCRIPTION
I thought I'd put this up for comment (mainly to see if I'm using privilege separation correctly).

This adds a `casign` subcommand that accepts an unsigned user cert on stdin, signs it with the CA cert, and emits the signed user cert on stdout.  It's a very tentative stab at implementing #42.

It would be called by a flux-core keygen utility as part of generating a user cert.

The unpriv child just reads the cert in encoded kv form on stdin and adds it to the kv that is sent to the priv parent.  The parent uses its privilege to access the CA cert and uses it to sign the user cert (as the real uid), then emits the signed cert in encoded kv form on stdout.

No TOML config file, no source tree cert location, and no tests yet.