### PR TITLE
imp: Allow config file pattern to be overridden for build-tree IMP

### DIFF
--- a/src/imp/Makefile.am
+++ b/src/imp/Makefile.am
@@ -31,15 +31,17 @@ flux_imp_SOURCES = \
 	sudosim.h \
 	version.c \
 	whoami.c \
+	testconfig.h \
 	testconfig.c
 
-testconfig.c: $(top_builddir)/config/config.h
+testconfig.o: testconfig.h
+testconfig.h: $(top_builddir)/config/config.h
 	@(confdir=`cd $(srcdir) && pwd`/imp.conf.d; \
 	  echo "const char *imp_config_pattern = \"$$confdir/*.toml\";" \
-	 )> testconfig.c
+	 )> testconfig.h
 
 MOSTLYCLEANFILES = \
-	testconfig.c
+	testconfig.h
 
 EXTRA_DIST = \
 	imp.conf.d

--- a/src/imp/imp.c
+++ b/src/imp/imp.c
@@ -38,7 +38,10 @@
 #include "impcmd.h"
 #include "sudosim.h"
 
-extern const char *imp_config_pattern;
+/*
+ *  External function used to return current default config pattern.
+ */
+extern const char *imp_get_config_pattern (void);
 
 /*  Static prototypes:
  */
@@ -63,7 +66,7 @@ int main (int argc, char *argv[])
 
     /*  Configuration:
      */
-    if (!(imp.conf = imp_conf_load (imp_config_pattern)))
+    if (!(imp.conf = imp_conf_load (imp_get_config_pattern ())))
         imp_die (1, "Failed to load configuration");
 
     /*  Audit subsystem initialization

--- a/src/imp/imp.c
+++ b/src/imp/imp.c
@@ -154,7 +154,7 @@ static cf_t * imp_conf_load (const char *pattern)
         return (NULL);
     }
     else if (rc == 0) {
-        imp_warn ("%s: No config file(s) found");
+        imp_warn ("%s: No config file(s) found", pattern);
         cf_destroy (cf);
         return (NULL);
     }

--- a/src/imp/imp_log.h
+++ b/src/imp/imp_log.h
@@ -32,16 +32,16 @@ void imp_openlog ();
 void imp_closelog ();
 
 /*  Say a message to standard IMP logging destination(s) */
-void imp_say (const char *fmt, ...);
+void imp_say (const char *fmt, ...) __attribute__ ((format (printf, 1, 2)));
 
 /*  Emit warning to IMP logging destination(s) */
-void imp_warn (const char *fmt, ...);
+void imp_warn (const char *fmt, ...) __attribute__ ((format (printf, 1, 2)));
 
 /*  Issue a debug message to IMP logging destination(s) */
-void imp_debug (const char *fmt, ...);
+void imp_debug (const char *fmt, ...) __attribute__ ((format (printf, 1, 2)));
 
 /*  Print an error to IMP logging destination and exit with exit `code` */
-void imp_die (int code, const char *fmt, ...);
+void imp_die (int code, const char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
 
 /*
  *  Logging output provider prototype:

--- a/src/imp/privsep.c
+++ b/src/imp/privsep.c
@@ -89,7 +89,7 @@ void drop_privileges ()
 
      /*  Verify privilege cannot be restored */
     if (setreuid (-1, 0) == 0)
-        imp_die (1, "irreversible switch to uid %ld failed");
+        imp_die (1, "irreversible switch to uid %ju failed", (uintmax_t) ruid);
 }
 
 static void child_pfds_setup (privsep_t *ps)

--- a/src/imp/test/imp_log.c
+++ b/src/imp/test/imp_log.c
@@ -111,7 +111,7 @@ int main (void)
     /*  Test log output truncation */
     char buf [8192];
     reset_logbuf ();
-    imp_say (long_string (buf, 4200));
+    imp_say ("%s", long_string (buf, 4200));
     rc = strlen (testbuf);
     ok (rc > 0, "very long log message gets written (len = %d)", rc);
     ok (testbuf[rc - 1] == '+', "very long log message is truncated");

--- a/src/imp/testconfig.c
+++ b/src/imp/testconfig.c
@@ -1,0 +1,44 @@
+/*****************************************************************************\
+ *  Copyright (c) 2017 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#include <stdlib.h>
+
+#include "testconfig.h"
+
+/*
+ *  For build-tree/test IMP only! Return config patter from environment
+ *   if set, otherwise use built-in "test" configuration pattern, which
+ *   will point to src/imp/imp.conf.d
+ */
+const char * imp_get_config_pattern (void)
+{
+    const char *p = getenv ("FLUX_IMP_CONFIG_PATTERN");
+    if (p == NULL)
+         p = imp_config_pattern; /* From testconfig.h */
+    return (p);
+}
+
+/*
+ *  vi: ts=4 sw=4 expandtab
+ */

--- a/t/t1000-imp-basic.t
+++ b/t/t1000-imp-basic.t
@@ -24,8 +24,24 @@ test_expect_success 'flux-imp returns error when run with no args' '
 test_expect_success 'flux-imp version works' '
 	$flux_imp version | grep "flux-imp v"
 '
+test_expect_success 'FLUX_IMP_CONFIG_PATTERN works for test flux-imp' '
+	( export FLUX_IMP_CONFIG_PATTERN=/noexist &&
+        test_must_fail  $flux_imp version 2>config-reset.error ) &&
+	grep "No config file" config-reset.error
+'
+test_expect_success 'Bad IMP config generates error' '
+	echo "bad =" > bad.toml &&
+	( export FLUX_IMP_CONFIG_PATTERN=bad.toml &&
+	  test_must_fail $flux_imp version 2>bad-config.error ) &&
+	grep "loading config: bad.toml: 1: syntax error" bad-config.error
+'
 test_expect_success SUDO 'flux-imp version works under sudo' '
 	sudo $flux_imp version | grep "flux-imp v"
+'
+test_expect_success SUDO 'flux-imp fails under sudo if allow-sudo != true' '
+	echo "allow-sudo = false" > nosudo.toml &&
+	test_expect_code 1 \
+	  sudo FLUX_IMP_CONFIG_PATTERN=nosudo.toml $flux_imp version
 '
 test_expect_success SUDO 'flux-imp generates error if SUDO_USER is invalid' '
 	test_expect_code 1 sudo SUDO_USER=invalid $flux_imp version


### PR DESCRIPTION
Posting an early version of this (no tests yet) in case @garlick wants to base casign tests off the result (and give early feedback). Will try to work on a few tests tonight, though I just remembered there is a school function, so perhaps not until tomorrow AM.

Sorry this functionality wasn't here from the start.