### PR TITLE
improve certificate metadata

### DIFF
--- a/src/imp/casign.c
+++ b/src/imp/casign.c
@@ -104,7 +104,7 @@ static void sign_cert (cf_t *conf, struct sigcert *cert)
         imp_die (1, "casign: ca_create: %s", error);
     if (ca_load (ca, true, error) < 0)
         imp_die (1, "casign: ca_load: %s", error);
-    if (ca_sign (ca, cert, ttl, userid, error) < 0)
+    if (ca_sign (ca, cert, 0, ttl, userid, error) < 0)
         imp_die (1, "casign: ca_sign: %s", error);
     if (sigcert_fwrite_public (cert, stdout) < 0)
         imp_die (1, "casign: write stdout: %s", strerror (errno));

--- a/src/libutil/ca.c
+++ b/src/libutil/ca.c
@@ -55,6 +55,7 @@ static const struct cf_option ca_opts[] = {
     {"cert-path",       CF_STRING,   true},
     {"revoke-dir",      CF_STRING,   true},
     {"revoke-allow",    CF_BOOL,     true},
+    {"domain",          CF_STRING,   true},
     CF_OPTIONS_TABLE_END,
 };
 

--- a/src/libutil/ca.c
+++ b/src/libutil/ca.c
@@ -138,6 +138,7 @@ static int sign_with (const struct ca *ca, const struct sigcert *ca_cert,
     uuid_t uuid_bin;
     uuidstr_t uuid;
     time_t now;
+    const char *ca_uuid;
 
     if (ttl > max_cert_ttl) {
         errno = EINVAL;
@@ -159,6 +160,14 @@ static int sign_with (const struct ca *ca, const struct sigcert *ca_cert,
     if (sigcert_meta_set (cert, "userid", SM_INT64, userid) < 0)
         goto error;
     if (sigcert_meta_set (cert, "max-sign-ttl", SM_INT64, max_sign_ttl) < 0)
+        goto error;
+    if (ca_cert != cert) {
+        if (sigcert_meta_get (ca_cert, "uuid", SM_STRING, &ca_uuid) < 0)
+            goto error;
+    }
+    else
+        ca_uuid = uuid;
+    if (sigcert_meta_set (cert, "issuer", SM_STRING, ca_uuid) < 0)
         goto error;
     if (sigcert_sign_cert (ca_cert, cert) < 0)
         goto error;

--- a/src/libutil/ca.c
+++ b/src/libutil/ca.c
@@ -136,6 +136,7 @@ static int sign_with (const struct ca *ca, const struct sigcert *ca_cert,
 {
     int64_t max_cert_ttl = cf_int64 (cf_get_in (ca->cf, "max-cert-ttl"));
     int64_t max_sign_ttl = cf_int64 (cf_get_in (ca->cf, "max-sign-ttl"));
+    const char *domain = cf_string (cf_get_in (ca->cf, "domain"));
     uuid_t uuid_bin;
     uuidstr_t uuid;
     time_t now;
@@ -169,6 +170,8 @@ static int sign_with (const struct ca *ca, const struct sigcert *ca_cert,
     else
         ca_uuid = uuid;
     if (sigcert_meta_set (cert, "issuer", SM_STRING, ca_uuid) < 0)
+        goto error;
+    if (sigcert_meta_set (cert, "domain", SM_STRING, domain) < 0)
         goto error;
     if (sigcert_sign_cert (ca_cert, cert) < 0)
         goto error;

--- a/src/libutil/ca.c
+++ b/src/libutil/ca.c
@@ -418,6 +418,34 @@ int ca_load (struct ca *ca, bool secret, ca_error_t e)
     return 0;
 }
 
+const struct sigcert *ca_get_cert (struct ca *ca, ca_error_t e)
+{
+    if (!ca || !ca->ca_cert) {
+        errno = EINVAL;
+        ca_error (e, NULL);
+        return NULL;
+    }
+    return ca->ca_cert;
+}
+
+int ca_set_cert (struct ca *ca, const struct sigcert *ca_cert, ca_error_t e)
+{
+    struct sigcert *cpy;
+
+    if (!ca || !ca_cert) {
+        errno = EINVAL;
+        ca_error (e, NULL);
+        return -1;
+    }
+    if (!(cpy = sigcert_copy (ca_cert))) {
+        ca_error (e, NULL);
+        return -1;
+    }
+    sigcert_destroy (ca->ca_cert);
+    ca->ca_cert = cpy;
+    return 0;
+}
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/libutil/ca.c
+++ b/src/libutil/ca.c
@@ -343,11 +343,11 @@ error:
     return -1;
 }
 
-int ca_keygen (struct ca *ca, ca_error_t e)
+int ca_keygen (struct ca *ca, int64_t ttl, ca_error_t e)
 {
     struct sigcert *cert = NULL;
 
-    if (!ca) {
+    if (!ca || ttl < 0) {
         errno = EINVAL;
         ca_error (e, NULL);
         return -1;
@@ -360,7 +360,7 @@ int ca_keygen (struct ca *ca, ca_error_t e)
      * we would add to a user certificate, except that
      * ca-capability = true.
      */
-    if (sign_with (ca, cert, cert, 0, 0, getuid (), true, e) < 0) {
+    if (sign_with (ca, cert, cert, 0, ttl, getuid (), true, e) < 0) {
         sigcert_destroy (cert);
         return -1;
     }

--- a/src/libutil/ca.c
+++ b/src/libutil/ca.c
@@ -343,11 +343,12 @@ error:
     return -1;
 }
 
-int ca_keygen (struct ca *ca, int64_t ttl, ca_error_t e)
+int ca_keygen (struct ca *ca, time_t not_valid_before_time,
+               int64_t ttl, ca_error_t e)
 {
     struct sigcert *cert = NULL;
 
-    if (!ca || ttl < 0) {
+    if (!ca || ttl < 0 || not_valid_before_time < 0) {
         errno = EINVAL;
         ca_error (e, NULL);
         return -1;
@@ -360,7 +361,8 @@ int ca_keygen (struct ca *ca, int64_t ttl, ca_error_t e)
      * we would add to a user certificate, except that
      * ca-capability = true.
      */
-    if (sign_with (ca, cert, cert, 0, ttl, getuid (), true, e) < 0) {
+    if (sign_with (ca, cert, cert, not_valid_before_time, ttl,
+                   getuid (), true, e) < 0) {
         sigcert_destroy (cert);
         return -1;
     }

--- a/src/libutil/ca.h
+++ b/src/libutil/ca.h
@@ -70,7 +70,8 @@ int ca_verify (const struct ca *ca, const struct sigcert *cert,
  * Return 0 on success, -1 on failure with errno set.
  * On failure, if 'error' is non-NULL, it will contain a textual error message.
  */
-int ca_keygen (struct ca *ca, int64_t ttl, ca_error_t error);
+int ca_keygen (struct ca *ca, time_t not_valid_before_time,
+               int64_t ttl, ca_error_t error);
 
 /* Store CA cert to configured path.
  * Return 0 on success, -1 on failure with errno set.

--- a/src/libutil/ca.h
+++ b/src/libutil/ca.h
@@ -1,6 +1,8 @@
 #ifndef _UTIL_CA_H
 #define _UTIL_CA_H
 
+#include <time.h>
+
 #include "sigcert.h"
 #include "cf.h"
 
@@ -35,13 +37,15 @@ void ca_destroy (struct ca *ca);
 
 /* Add/update CA-required metadata to 'cert', then sign it.
  * This function fails if the CA secret key has not been loaded with ca_load
- * or ca_keygen.  'ttl' (seconds) must not exceed 'max-cert-ttl' (0 = maximum).
+ * or ca_keygen.  'not_valid_before_time' can be a UTC wallclock time_t, or
+ * 0=now. 'ttl' (seconds) must not exceed 'max-cert-ttl' (0 = maximum).
  * 'userid' should be authenticated to match the requesting user (the owner
  * of the certificate). Return 0 on success, -1 on failure with errno set.
  * On failure, if 'error' is non-NULL, it will contain a textual error message.
  */
 int ca_sign (const struct ca *ca, struct sigcert *cert,
-             int64_t ttl, int64_t userid, ca_error_t error);
+             time_t not_valid_before_time, int64_t ttl,
+             int64_t userid, ca_error_t error);
 
 /* Add cert identified by 'uuid' to the revocation list.
  * This creates an empty file named 'uuid' in 'revoke-dir'.

--- a/src/libutil/ca.h
+++ b/src/libutil/ca.h
@@ -87,6 +87,12 @@ int ca_store (const struct ca *ca, ca_error_t error);
  */
 int ca_load (struct ca *ca, bool secret, ca_error_t error);
 
+/* Accessors for the CA cert.
+ * (Mainly for test at this time).
+ */
+const struct sigcert *ca_get_cert (struct ca *ca, ca_error_t error);
+int ca_set_cert (struct ca *ca, const struct sigcert *cert, ca_error_t error);
+
 #endif // _UTIL_CA_H
 
 /*

--- a/src/libutil/ca.h
+++ b/src/libutil/ca.h
@@ -70,7 +70,7 @@ int ca_verify (const struct ca *ca, const struct sigcert *cert,
  * Return 0 on success, -1 on failure with errno set.
  * On failure, if 'error' is non-NULL, it will contain a textual error message.
  */
-int ca_keygen (struct ca *ca, ca_error_t error);
+int ca_keygen (struct ca *ca, int64_t ttl, ca_error_t error);
 
 /* Store CA cert to configured path.
  * Return 0 on success, -1 on failure with errno set.

--- a/src/libutil/sigcert.c
+++ b/src/libutil/sigcert.c
@@ -142,6 +142,8 @@ struct sigcert *sigcert_create (void)
         goto error;
     if (crypto_sign_keypair (cert->public_key, cert->secret_key) < 0)
         goto error;
+    if (sigcert_meta_set (cert, "algorithm", SM_STRING, "ed25519") < 0)
+        goto error;
     cert->secret_valid = true;
     return cert;
 error:

--- a/src/libutil/test/ca.c
+++ b/src/libutil/test/ca.c
@@ -18,7 +18,8 @@ const char *conf_tmpl = \
 "max-sign-ttl = 30\n" \
 "cert-path = \"%s/ca-cert\"\n" \
 "revoke-dir = \"%s/ca-revoke\"\n" \
-"revoke-allow = true\n";
+"revoke-allow = true\n" \
+"domain = \"FLUX.TEST\"\n";
 
 static cf_t *cf;
 static char tmpdir[PATH_MAX + 1];

--- a/src/libutil/test/sigcert.c
+++ b/src/libutil/test/sigcert.c
@@ -74,6 +74,13 @@ void test_meta (void)
     cert = sigcert_create ();
     ok (cert != NULL,
         "sigcert_create works");
+
+    /* Check hardwired metadata
+     */
+    ok (sigcert_meta_get (cert, "algorithm", SM_STRING, &s) == 0
+       && !strcmp (s, "ed25519"),
+       "algorithm=ed25519 is set");
+
     ok (sigcert_meta_set (cert, "foo", SM_STRING, "bar") == 0,
         "sigcert_meta_set foo=bar");
     ok (sigcert_meta_set (cert, "baz", SM_INT64, 42LL) == 0,

--- a/src/libutil/test/signer.c
+++ b/src/libutil/test/signer.c
@@ -37,7 +37,7 @@ struct ca *create_ca (void)
 
     if (!(ca = ca_create (cf, e)))
         BAIL_OUT ("ca_create failed: %s", e);
-    if (ca_keygen (ca, e) < 0)
+    if (ca_keygen (ca, 0, e) < 0)
         BAIL_OUT ("ca_keygen failed: %s", e);
     cf_destroy (cf);
 

--- a/src/libutil/test/signer.c
+++ b/src/libutil/test/signer.c
@@ -37,7 +37,7 @@ struct ca *create_ca (void)
 
     if (!(ca = ca_create (cf, e)))
         BAIL_OUT ("ca_create failed: %s", e);
-    if (ca_keygen (ca, 0, e) < 0)
+    if (ca_keygen (ca, 0, 0, e) < 0)
         BAIL_OUT ("ca_keygen failed: %s", e);
     cf_destroy (cf);
 

--- a/src/libutil/test/signer.c
+++ b/src/libutil/test/signer.c
@@ -60,7 +60,7 @@ struct sigcert *create_cert (struct ca *ca, int64_t userid, int64_t ttl)
 
     if (!(cert = sigcert_create ()))
         BAIL_OUT ("sigcert_create failed");
-    if (ca_sign (ca, cert, ttl, userid, e) < 0)
+    if (ca_sign (ca, cert, 0, ttl, userid, e) < 0)
         BAIL_OUT ("ca_sign: %s", e);
     return cert;
 }

--- a/src/libutil/test/signer.c
+++ b/src/libutil/test/signer.c
@@ -18,7 +18,8 @@ const char *ca_cf = \
 "max-sign-ttl = 30\n" \
 "cert-path = \"/tmp/test-ca-cert\"\n" \
 "revoke-dir = \"/tmp/test-ca-revoke\"\n" \
-"revoke-allow = true\n";
+"revoke-allow = true\n" \
+"domain = \"FLUX.TEST\"\n";
 
 /* Generate CA certificate in memory.
  */

--- a/t/src/ca.c
+++ b/t/src/ca.c
@@ -82,7 +82,7 @@ static void keygen (void)
     struct ca *ca = init_ca ();
     ca_error_t error;
 
-    if (ca_keygen (ca, 0, error) < 0)
+    if (ca_keygen (ca, 0, 0, error) < 0)
         die ("ca_keygen: %s", error);
     if (ca_store (ca, error) < 0)
         die ("ca_store: %s", error);

--- a/t/src/ca.c
+++ b/t/src/ca.c
@@ -82,7 +82,7 @@ static void keygen (void)
     struct ca *ca = init_ca ();
     ca_error_t error;
 
-    if (ca_keygen (ca, error) < 0)
+    if (ca_keygen (ca, 0, error) < 0)
         die ("ca_keygen: %s", error);
     if (ca_store (ca, error) < 0)
         die ("ca_store: %s", error);

--- a/t/t1001-imp-casign.t
+++ b/t/t1001-imp-casign.t
@@ -33,6 +33,7 @@ new_ca_config() {
 	cert-path = "${SHARNESS_TRASH_DIRECTORY}/ca"
 	revoke-dir = "${SHARNESS_TRASH_DIRECTORY}/revoke.d"
 	revoke-allow = true
+	domain = "EXAMPLE.TEST"
 	EOT
 }
 


### PR DESCRIPTION
This PR expands the metadata included in each Flux certificate.

The CA cert is now self-signed through the same process that user certs are signed, so it now includes the same metadata:

* **uuid** -- a unique id for the cert
* **userid** -- real userid of the user that signed the cert
* **ctime** -- certificate create time
* **xtime** -- certificate expiration time
* **domain** -- (new) domain name string from the CA configuration, e.g. `HYPE.LLNL.GOV`
* **issuer** -- (new) the uuid of the cert that signed this cert
* **max-sign-ttl** -- max TTL for signatures by this cert (ignored in the CA cert for now)
* **algorithm** -- (new) always `ed25519` right now

The uuid/issuer relationship prepares for CA key management (#52), where the `issuer` in a user cert can be used to find one of several CA certs with matching `uuid` to validate it.

In this PR, the ctime and xtime are ignored in the CA cert.  CA cert expiration should be worked on in the context of #52 IMHO.

Fixes #49 