### PR TITLE
cleanup comments and test

### DIFF
--- a/src/libtomlc99/test/toml.c
+++ b/src/libtomlc99/test/toml.c
@@ -366,7 +366,7 @@ void check_ucs_to_utf8 (void)
         "ucs_to_utf8: 0x10000 converted to 4-char UTF8");
     ok (toml_ucs_to_utf8 (0x1fffff, buf) == 4
         && !memcmp (buf, "\xf7\xbf\xbf\xbf", 4),
-        "ucs_to_utf8: 0x1ffff converted to 4-char UTF8");
+        "ucs_to_utf8: 0x1fffff converted to 4-char UTF8");
 
     ok (toml_ucs_to_utf8 (0x200000, buf) == 5
         && !memcmp (buf, "\xf8\x88\x80\x80\x80", 5),
@@ -408,8 +408,8 @@ void check_utf8_to_ucs (void)
 
     ok (toml_utf8_to_ucs ("\xf0\x90\x80\x80", 4, &code) == 4 && code == 0x10000,
         "utf8_to_ucs: 0x10000 converted from 4-char UTF8");
-    ok (toml_utf8_to_ucs ("\xf0\x90\x80\x80", 4, &code) == 4 && code == 0x10000,
-        "utf8_to_ucs: 0x10000 converted from 4-char UTF8");
+    ok (toml_utf8_to_ucs ("\xf7\xbf\xbf\xbf", 4, &code) == 4 && code == 0x1fffff,
+        "utf8_to_ucs: 0x1fffff converted from 4-char UTF8");
 
     ok (toml_utf8_to_ucs ("\xf8\x88\x80\x80\x80", 5, &code) == 5 && code == 0x200000,
         "utf8_to_ucs: 0x200000 converted from 5-char UTF8");

--- a/src/libutil/ca.h
+++ b/src/libutil/ca.h
@@ -22,23 +22,6 @@
  *
  * Cert revocation consists of placing the uuid of a cert in a directory
  * that is propagated along with the CA public key.
- *
- * TOML Configuration:
- *
- * [ca]
- * max-sign-ttl = 3600                         # max TTL (sec) for signing
- * max-cert-ttl = 3600                         # max TTL (sec) for certificate
- * cert-path = "/etc/flux-security/ca/cert"    # path to CA certificates
- * revoke-dir = "/etc/flux-security/ca/revoke" # path to revocation directory
- * revoke-allow = false                        # ca_revoke allowed here?
- *
- * CA-required metadata for signed public certs:
- *
- * uuid - unique id for cert, a key for revocation
- * ctime - create time (timestamp for cert signature)
- * xtime - expiration time (ctime + TTL)
- * max-sign-ttl - max TTL (seconds) for signatures
- * userid - owner of the cert, authenticated by CA
  */
 
 typedef char ca_error_t[200];

--- a/src/libutil/sigcert.c
+++ b/src/libutil/sigcert.c
@@ -910,9 +910,8 @@ int sigcert_verify (const struct sigcert *cert, const char *s)
     return length;
 }
 
-/* cert1 signs cert2.
- * Dump cert2 as JSON in a repeatable way, excluding secret + signature,
- * sign with cert1.  Add 'signature' attribute to [curve] stanza.
+/* Serialize cert2, excluding secret + signature, sign with cert1.
+ * Add 'signature' attribute to [curve] stanza.
  */
 int sigcert_sign_cert (const struct sigcert *cert1,
                        struct sigcert *cert2)


### PR DESCRIPTION
This PR includes a few commits pulled out of #53 that were not related.

Fix a typo in the new TOML UTF8 tests (will need to be applied to flux-core too), and tweak some comments.