### PR TITLE
enhance private context interface and other small fixes

### DIFF
--- a/src/lib/context.c
+++ b/src/lib/context.c
@@ -214,6 +214,24 @@ const cf_t *security_get_config (flux_security_t *ctx, const char *key)
 
 }
 
+int security_set_config (flux_security_t *ctx, const cf_t *cf)
+{
+    cf_t *new;
+    if (!ctx || !cf) {
+        errno = EINVAL;
+        security_error (ctx, NULL);
+        return (-1);
+    }
+    if (!(new = cf_copy (cf))) {
+        errno = ENOMEM;
+        security_error (ctx, "Failed to copy config object");
+        return (-1);
+    }
+    cf_destroy (ctx->config);
+    ctx->config = new;
+    return (0);
+}
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/lib/context.c
+++ b/src/lib/context.c
@@ -194,7 +194,7 @@ const cf_t *security_get_config (flux_security_t *ctx, const char *key)
 {
     const cf_t *cf;
 
-    if (!ctx || !key) {
+    if (!ctx) {
         errno = EINVAL;
         security_error (ctx, NULL);
         return NULL;
@@ -204,7 +204,9 @@ const cf_t *security_get_config (flux_security_t *ctx, const char *key)
         security_error (ctx, "configuration has not been loaded");
         return NULL;
     }
-    if (!(cf = cf_get_in (ctx->config, key))) {
+    if (key == NULL)
+        cf = ctx->config;
+    else if (!(cf = cf_get_in (ctx->config, key))) {
         security_error (ctx, "configuration object '%s' not found", key);
         return NULL;
     }

--- a/src/lib/context_private.h
+++ b/src/lib/context_private.h
@@ -9,7 +9,7 @@
  */
 void security_error (flux_security_t *ctx, const char *fmt, ...);
 
-/* Retrieve config object by 'key'.
+/* Retrieve config object by 'key', entire config if key == NULL.
  * Returns the object (do not free), or NULL on error.
  */
 const cf_t *security_get_config (flux_security_t *ctx, const char *key);

--- a/src/lib/context_private.h
+++ b/src/lib/context_private.h
@@ -14,4 +14,9 @@ void security_error (flux_security_t *ctx, const char *fmt, ...);
  */
 const cf_t *security_get_config (flux_security_t *ctx, const char *key);
 
+/* Set config object 'cf' as security handle configuration.
+ * 'cf' is copied internally and any existing configuration is destroyed.
+ */
+int security_set_config (flux_security_t *ctx, const cf_t *cf);
+
 #endif /* !_FLUX_SECURITY_CONTEXT_PRIVATE_H */

--- a/src/lib/sign.c
+++ b/src/lib/sign.c
@@ -252,7 +252,10 @@ static int signature_cat (const char *sig, void **buf, int *bufsz)
     int len = strlen (*buf);
     char *dst;
 
-    if (grow_buf (buf, bufsz, strlen(sig) + len + 1) < 0)
+    /* Grow buffer large enought to contain:
+     * current header (len), '.' separator, signature, and final NUL.
+     */
+    if (grow_buf (buf, bufsz, strlen(sig) + len + 2) < 0)
         return -1;
     dst = (char *)*buf + len;
     *dst++ = '.';

--- a/src/lib/sign.c
+++ b/src/lib/sign.c
@@ -302,6 +302,7 @@ const char *flux_sign_wrap (flux_security_t *ctx,
     if (signature_cat (sig, &sign->wrapbuf, &sign->wrapbufsz) < 0)
         goto error;
 
+    kv_destroy (header);
     return sign->wrapbuf;
 error:
     security_error (ctx, NULL);

--- a/src/lib/test/context.c
+++ b/src/lib/test/context.c
@@ -65,6 +65,10 @@ void test_basic (void)
     errno = 0;
     ok (security_get_config (ctx, "wrongname") == NULL && errno == ENOENT,
         "security_get_config key=wrongname fails with ENOENT");
+    cf = security_get_config (ctx, NULL);
+    ok (cf != NULL && cf_typeof (cf) == CF_TABLE && cf_get_in (cf, "foo"),
+        "security_get_config with NULL argument returns whole config");
+
     flux_security_destroy (ctx);
 }
 

--- a/src/libutil/test/cf.c
+++ b/src/libutil/test/cf.c
@@ -104,7 +104,7 @@ void test_basic (void)
     cf_cpy = cf_copy (cf);
     ok (cf_cpy != NULL,
         "cf_copy works");
-    ok (cf_typeof (cf) == CF_TABLE,
+    ok (cf_typeof (cf_cpy) == CF_TABLE,
         "cf_typeof says copy is CF_TABLE");
     cf_destroy (cf_cpy);
 

--- a/t/t1002-sign-munge.t
+++ b/t/t1002-sign-munge.t
@@ -144,6 +144,25 @@ test_expect_success 'init fails with bad [sign.munge] config' '
 	grep -q bogus bogussign.err
 '
 
+test_expect_success 'create sign.toml with none default-type' '
+	cat >sign.toml <<-EOT
+	[sign]
+	max-ttl = 60
+	default-type = "none"
+	allowed-types = [ "munge" ]
+	[sign.munge]
+	socket-path = "${MUNGE_SOCKET}"
+	EOT
+'
+
+test_expect_success 'message encoded with mechanism != munge fails' '
+	cat /dev/null >sign_none.in &&
+        ${sign} <sign_none.in >sign_none.out &&
+	test_must_fail ${verify} <sign_none.out 2>sign_none.err &&
+	test_debug cat sign_none.err &&
+	grep -q "mechanism=none not allowed" sign_none.err
+'
+
 test_expect_success SIDEMUNGE 'stop munged' '
 	munged_stop_daemon
 '


### PR DESCRIPTION
This is a list of small fixes split off of ongoing work. I wanted to submit these before they got too out of date.

The main functionality changes are minor and to only the private security context interface in `context_private.h`. The allow an existing `cf_t` config to be set directly in `flux_security_t` with a new `security_set_config()` call, and add a way to return the entire `cf_t` stored in the `flux_security_t` context by passing a `NULL` as the key in `security_get_context`.

These are needed to allow the IMP, which parses its own config, to share all the config tables it has with the security handle.

The minor fixes were found along the way and include fix for off-by-one error and leak found in sign.c, and a small typo in cf_copy() test.