### PR TITLE
build: clean up library install

### DIFF
--- a/config/ac_pkgconfig.m4
+++ b/config/ac_pkgconfig.m4
@@ -1,0 +1,29 @@
+# Thanks to Arnaud Quette for this bit of m4
+
+AC_DEFUN([AC_PKGCONFIG],
+[
+    pkgconfigdir='${libdir}/pkgconfig'
+    AC_MSG_CHECKING(whether to install pkg-config *.pc files)
+    AC_ARG_WITH(pkgconfig-dir,
+     AC_HELP_STRING([--with-pkgconfig-dir=PATH], [where to install pkg-config *.pc files (EPREFIX/lib/pkgconfig)]),
+     [
+        case "${withval}" in
+            yes|auto)
+            ;;
+            no)
+                pkgconfigdir=""
+            ;;
+            *)
+                pkgconfigdir="${withval}"
+            ;;
+        esac
+     ],
+     )
+    if test -n "${pkgconfigdir}"; then
+      AC_MSG_RESULT(${pkgconfigdir})
+    else
+      AC_MSG_RESULT(no)
+    fi
+    AM_CONDITIONAL(WITH_PKG_CONFIG, test -n "${pkgconfigdir}")
+    AC_SUBST(pkgconfigdir)
+])

--- a/configure.ac
+++ b/configure.ac
@@ -97,6 +97,7 @@ AC_CONFIG_FILES( \
   t/Makefile \
   src/Makefile \
   src/lib/Makefile \
+  src/lib/flux-security.pc \
   src/libtap/Makefile \
   src/libtomlc99/Makefile \
   src/libutil/Makefile \

--- a/configure.ac
+++ b/configure.ac
@@ -75,6 +75,8 @@ PKG_CHECK_MODULES([MUNGE], [munge], [], [])
 #
 AX_CODE_COVERAGE
 
+AC_PKGCONFIG
+
 #
 # Project directories
 #

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -70,4 +70,8 @@ test_sign_t_SOURCES = test/sign.c
 test_sign_t_CPPFLAGS = $(test_cppflags)
 test_sign_t_LDADD = $(test_ldadd)
 
+if WITH_PKG_CONFIG
+pkgconfig_DATA = flux-security.pc
+endif
+
 EXTRA_DIST = libflux-security.map

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -11,7 +11,7 @@ AM_CPPFLAGS = \
 	-DINSTALLED_CF_PATTERN=\"$(fluxcfdir)/*.toml\" \
 	$(SODIUM_CFLAGS) $(JANSSON_CFLAGS) $(MUNGE_CFLAGS)
 
-fluxlib_LTLIBRARIES = \
+lib_LTLIBRARIES = \
 	libflux-security.la
 
 noinst_LTLIBRARIES = \

--- a/src/lib/flux-security.pc.in
+++ b/src/lib/flux-security.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: flux-security
+Description: Flux Resource Manager Framework Security
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -lflux-security
+Cflags: -I${includedir}
+


### PR DESCRIPTION
This PR adds a .pc file for libflux-security.so and makes sure it gets installed into the proper directory.