### PR TITLE
etc: install config file for signing

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS =         src t
+SUBDIRS =         src etc t
 ACLOCAL_AMFLAGS = -I config
 EXTRA_DIST = \
 	config/tap-driver.sh \

--- a/configure.ac
+++ b/configure.ac
@@ -83,8 +83,8 @@ AC_PKGCONFIG
 AS_VAR_SET(fluxlibdir, $libdir/flux)
 AC_SUBST(fluxlibdir)
 
-AS_VAR_SET(fluxcfdir, $sysconfdir/flux/conf.d)
-AC_SUBST(fluxcfdir)
+AS_VAR_SET(fluxsecuritycfdir, $sysconfdir/flux/security/conf.d)
+AC_SUBST(fluxsecuritycfdir)
 
 AS_VAR_SET(fluxsecurityincludedir, $includedir/flux/security)
 AC_SUBST(fluxsecurityincludedir)
@@ -103,6 +103,7 @@ AC_CONFIG_FILES( \
   src/libutil/Makefile \
   src/libca/Makefile \
   src/imp/Makefile \
+  etc/Makefile \
 )
 
 AC_OUTPUT

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -1,0 +1,1 @@
+dist_fluxsecuritycf_DATA = sign.toml

--- a/etc/sign.toml
+++ b/etc/sign.toml
@@ -1,0 +1,4 @@
+[sign]
+max-ttl = 1209600  # 2 weeks
+default-type = "munge"
+allowed-types = [ "munge" ]

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -8,7 +8,7 @@ AM_LDFLAGS = \
 
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
-	-DINSTALLED_CF_PATTERN=\"$(fluxcfdir)/*.toml\" \
+	-DINSTALLED_CF_PATTERN=\"$(fluxsecuritycfdir)/*.toml\" \
 	$(SODIUM_CFLAGS) $(JANSSON_CFLAGS) $(MUNGE_CFLAGS)
 
 lib_LTLIBRARIES = \


### PR DESCRIPTION
This PR moves the default config file location to `$sysconfdir/flux/security/conf.d`, and installs a default config file for signing.

The config file location change keeps flux-core and flux-security configs separate so that security components like the IMP don't parse irrelevant (and possibly voluminous or conflicting) TOML, and vice versa.

The default config file allows the installed flux-security package to be functional without manual configuration.  At the moment this allows code in flux-core to configure flux-security with a NULL config pattern and get something that works, which is convenient while we evaluate how to share configuration and security contexts within a flux instance.  When flux-security is packaged as an RPM or deb, we would tag this config file as a "noreplace" so that any installed config takes precedence.