### PR TITLE
add flux-security version accessors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ libtool
 .libs/
 libltdl/
 
+# generated library version header
+/src/lib/version.h
+
 # libtool pull-ins
 /config/libtool.m4
 /config/ltoptions.m4

--- a/config/ax_split_version.m4
+++ b/config/ax_split_version.m4
@@ -1,0 +1,38 @@
+# ===========================================================================
+#     https://www.gnu.org/software/autoconf-archive/ax_split_version.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_SPLIT_VERSION
+#
+# DESCRIPTION
+#
+#   Splits a version number in the format MAJOR.MINOR.POINT into its
+#   separate components.
+#
+#   Sets the variables.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Tom Howard <tomhoward@users.sf.net>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 10
+
+AC_DEFUN([AX_SPLIT_VERSION],[
+    AC_REQUIRE([AC_PROG_SED])
+    AX_MAJOR_VERSION=`echo "$VERSION" | $SED 's/\([[^.]][[^.]]*\).*/\1/'`
+    AX_MINOR_VERSION=`echo "$VERSION" | $SED 's/[[^.]][[^.]]*.\([[^.]][[^.]]*\).*/\1/'`
+    AX_POINT_VERSION=`echo "$VERSION" | $SED 's/[[^.]][[^.]]*.[[^.]][[^.]]*.\(.*\)/\1/'`
+    AC_MSG_CHECKING([Major version])
+    AC_MSG_RESULT([$AX_MAJOR_VERSION])
+    AC_MSG_CHECKING([Minor version])
+    AC_MSG_RESULT([$AX_MINOR_VERSION])
+    AC_MSG_CHECKING([Point version])
+    AC_MSG_RESULT([$AX_POINT_VERSION])
+])

--- a/configure.ac
+++ b/configure.ac
@@ -23,6 +23,15 @@ AC_DEFINE([_GNU_SOURCE], 1,
           [Define _GNU_SOURCE so that we get all necessary prototypes])
 
 #
+# Generate project versions from PACKAGE_VERSION (set from git describe above)
+#
+AX_SPLIT_VERSION
+AX_POINT_VERSION=$(echo $AX_POINT_VERSION | $SED 's/-.*$//')
+AC_SUBST([AX_MAJOR_VERSION])
+AC_SUBST([AX_MINOR_VERSION])
+AC_SUBST([AX_POINT_VERSION])
+
+#
 #  Initialize pkg-config for PKG_CHECK_MODULES to avoid conditional issues
 #
 PKG_PROG_PKG_CONFIG

--- a/configure.ac
+++ b/configure.ac
@@ -107,6 +107,7 @@ AC_CONFIG_FILES( \
   src/Makefile \
   src/lib/Makefile \
   src/lib/flux-security.pc \
+  src/lib/version.h \
   src/libtap/Makefile \
   src/libtomlc99/Makefile \
   src/libutil/Makefile \

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -19,7 +19,8 @@ noinst_LTLIBRARIES = \
 
 fluxsecurityinclude_HEADERS = \
 	context.h \
-	sign.h
+	sign.h \
+	version.h
 
 libflux_security_la_SOURCES =
 libflux_security_la_LIBADD = \
@@ -40,7 +41,8 @@ libsecurity_la_SOURCES = \
 	sign_mech.h \
 	sign_none.c \
 	sign_munge.c \
-	sign_curve.c
+	sign_curve.c \
+	version.c
 
 TESTS = \
 	test_context.t \

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -46,7 +46,8 @@ libsecurity_la_SOURCES = \
 
 TESTS = \
 	test_context.t \
-	test_sign.t
+	test_sign.t \
+	test_version.t
 
 check_PROGRAMS = \
 	$(TESTS)
@@ -74,6 +75,10 @@ test_context_t_LDADD = $(test_ldadd)
 test_sign_t_SOURCES = test/sign.c
 test_sign_t_CPPFLAGS = $(test_cppflags)
 test_sign_t_LDADD = $(test_ldadd)
+
+test_version_t_SOURCES = test/version.c
+test_version_t_CPPFLAGS = $(test_cppflags)
+test_version_t_LDADD = $(test_ldadd)
 
 if WITH_PKG_CONFIG
 pkgconfig_DATA = flux-security.pc

--- a/src/lib/test/version.c
+++ b/src/lib/test/version.c
@@ -1,0 +1,36 @@
+#include "src/lib/version.h"
+#include "src/libtap/tap.h"
+
+#include <string.h>
+
+int main (int argc, char *argv[])
+{
+    const char *s;
+    int a,b,c,d;
+    char vs[32];
+
+    plan (NO_PLAN);
+
+    d = flux_security_version (&a, &b, &c);
+    ok (d == (a<<16 | b<<8 | c),
+        "flux_security_version returned sane value");
+
+    lives_ok ({flux_security_version (NULL, NULL, NULL);},
+        "flux_security_version NULL, NULL, NULL doesn't crash");
+
+    snprintf (vs, sizeof (vs), "%d.%d.%d", a,b,c);
+    s = flux_security_version_string ();
+    ok (s != NULL && !strncmp (s, vs, strlen (vs)),
+        "flux_security_version_string returned expected string");
+    diag (s);
+
+
+
+    done_testing();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/lib/version.c
+++ b/src/lib/version.c
@@ -1,0 +1,50 @@
+/*****************************************************************************\
+ *  Copyright (c) 2018 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License as published
+ *  by the Free Software Foundation; either version 2.1 of the license,
+ *  or (at your option) any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program; if not, write to the Free Software Foundation,
+ *  Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "version.h"
+
+const char *flux_security_version_string (void)
+{
+    return FLUX_SECURITY_VERSION_STRING;
+}
+
+int flux_security_version (int *major, int *minor, int *patch)
+{
+    if (major)
+        *major = FLUX_SECURITY_VERSION_MAJOR;
+    if (minor)
+        *minor = FLUX_SECURITY_VERSION_MINOR;
+    if (patch)
+        *patch = FLUX_SECURITY_VERSION_PATCH;
+    return FLUX_SECURITY_VERSION_HEX;
+}
+
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/lib/version.h.in
+++ b/src/lib/version.h.in
@@ -1,0 +1,75 @@
+/*****************************************************************************\
+ *  Copyright (c) 2018 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License as published
+ *  by the Free Software Foundation; either version 2.1 of the license,
+ *  or (at your option) any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program; if not, write to the Free Software Foundation,
+ *  Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef _FLUX_SECURITY_VERSION_H
+#define _FLUX_SECURITY_VERSION_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Flux uses semantic versioning: <major>.<minor>.<patch>
+ */
+
+/* The VERSION_STRING may include a "-N-hash" suffix from git describe
+ * if this snapshot is not tagged.  This is not reflected in VERSION_PATCH.
+ */
+#define FLUX_SECURITY_VERSION_STRING    "@PACKAGE_VERSION@"
+#define FLUX_SECURITY_VERSION_MAJOR     @AX_MAJOR_VERSION@
+#define FLUX_SECURITY_VERSION_MINOR     @AX_MINOR_VERSION@
+#define FLUX_SECURITY_VERSION_PATCH     @AX_POINT_VERSION@
+
+/* The version in 3 bytes, for numeric comparison.
+ */
+#define FLUX_SECURITY_VERSION_HEX   ((FLUX_SECURITY_VERSION_MAJOR << 16) | \
+                                     (FLUX_SECURITY_VERSION_MINOR << 8) | \
+                                     (FLUX_SECURITY_VERSION_PATCH << 0))
+
+
+/* These functions return the compiled-in versions.
+ * Useful for determining the version of dynamically linked libflux-core.
+ */
+
+/* Returns FLUX_SECURITY_VERSION_STRING.
+ */
+const char *flux_security_version_string (void);
+
+/* If major is non-NULL set it to FLUX_SECURITY_VERSION_MAJOR.
+ * If minor is non-NULL set it to FLUX_SECURITY_VERSION_MINOR.
+ * If patch is non-NULL set it to FLUX_SECURITY_VERSION_PATCH.
+ * Returns FLUX_SECURITY_VERSION_HEX.
+ */
+int flux_security_version (int *major, int *minor, int *patch);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !_FLUX_SECURITY_VERSION_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+


### PR DESCRIPTION
This adds functions and macros for accessing the flux-security version, as was done for flux-core in flux-framework/flux-core#1817