### PR TITLE
lib: make flux_security_aux_get/set behave like flux-core API

### DIFF
--- a/src/lib/test/context.c
+++ b/src/lib/test/context.c
@@ -179,15 +179,14 @@ void test_aux (void)
     ok (flux_security_aux_get (ctx, "bar") == p,
         "flux_security_aux_get retrieves data");
 
-    errno = 0;
-    ok (flux_security_aux_set (ctx, "foo", p, aux_free) < 0 && errno == EEXIST,
-        "flux_security_aux_set key=existing fails with EEXIST");
-    ok (free_flag == 0,
-        "destructor not called");
+    ok (flux_security_aux_set (ctx, "foo", p, aux_free) == 0,
+        "flux_security_aux_set key=existing works");
+    ok (free_flag == 1,
+        "destructor was called");
 
     flux_security_destroy (ctx);
 
-    ok (free_flag == 2,
+    ok (free_flag == 3,
         "flux_security_destroy called aux destructor for each item");
 }
 

--- a/src/libutil/Makefile.am
+++ b/src/libutil/Makefile.am
@@ -27,7 +27,9 @@ libutil_la_SOURCES = \
 	timestamp.h \
 	sha256.c \
 	sha256.h \
-	macros.h
+	macros.h \
+	aux.c \
+	aux.h
 
 TESTS = \
 	test_hash.t \

--- a/src/libutil/Makefile.am
+++ b/src/libutil/Makefile.am
@@ -36,7 +36,8 @@ TESTS = \
 	test_tomltk.t \
 	test_cf.t \
 	test_kv.t \
-	test_sha256.t
+	test_sha256.t \
+	test_aux.t
 
 test_ldadd = \
 	$(top_builddir)/src/libutil/libutil.la \
@@ -73,3 +74,7 @@ test_kv_t_CPPFLAGS = $(test_cppflags)
 test_sha256_t_SOURCES = test/sha256.c
 test_sha256_t_LDADD = $(test_ldadd)
 test_sha256_t_CPPFLAGS = $(test_cppflags)
+
+test_aux_t_SOURCES = test/aux.c
+test_aux_t_LDADD = $(test_ldadd)
+test_aux_t_CPPFLAGS = $(test_cppflags)

--- a/src/libutil/aux.c
+++ b/src/libutil/aux.c
@@ -1,0 +1,178 @@
+/*****************************************************************************\
+ *  Copyright (c) 2018 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License as published
+ *  by the Free Software Foundation; either version 2.1 of the license,
+ *  or (at your option) any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program; if not, write to the Free Software Foundation,
+ *  Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <string.h>
+#include <errno.h>
+#include <stdlib.h>
+
+#include "aux.h"
+
+struct aux_item {
+    char *key;
+    void *val;
+    aux_free_f free_fn;
+    struct aux_item *next;
+};
+
+/* Destroy an aux item.
+ * It is assumed to already be unlinked from list.
+ */
+static void aux_item_destroy (struct aux_item *aux)
+{
+    if (aux) {
+        int saved_errno = errno;
+        if (aux->free_fn && aux->val)
+            aux->free_fn (aux->val);
+        free (aux->key);
+        free (aux);
+        errno = saved_errno;
+    }
+}
+
+/* Create an aux item.
+ * Return item on success, NULL on failure with errno set (ENOMEM).
+ */
+static struct aux_item *aux_item_create (const char *key,
+                                         void *val, aux_free_f free_fn)
+{
+    struct aux_item *aux;
+
+    if (!(aux = calloc (1, sizeof (*aux))))
+        return NULL;
+    if (key && !(aux->key = strdup (key)))
+        goto error;
+    aux->val = val;
+    aux->free_fn = free_fn;
+    return aux;
+error:
+    aux_item_destroy (aux);
+    return NULL;
+}
+
+/* Delete from 'head' an aux item that was stored under 'key', if any.
+ * 'head' is an in/out parameter.
+ */
+static void aux_item_delete (struct aux_item **head, const char *key)
+{
+    if (key && head) {
+        struct aux_item *item;
+
+        while ((item = *head)) {
+            if (item->key && !strcmp (item->key, key)) {
+                *head = item->next;
+                aux_item_destroy (item);
+                break;
+            }
+            head = &item->next;
+        }
+    }
+}
+
+/* Find in 'head' an aux item stored under 'key'.
+ * Returns item on success, NULL on failure.
+ */
+static struct aux_item *aux_item_find (struct aux_item *head, const char *key)
+{
+    if (key) {
+        while (head) {
+            if (head->key && !strcmp (key, head->key))
+                return head;
+            head = head->next;
+        }
+    }
+    return NULL;
+}
+
+/* Insert at the beginning of 'head' an aux 'item'.
+ * 'head' is an in/out parameter.
+ */
+static void aux_item_insert (struct aux_item **head, struct aux_item *item)
+{
+    if (head && item) {
+        if (*head)
+            item->next = *head;
+        *head = item;
+    }
+}
+
+/* Look up 'key' in 'head'.
+ * Returns value on success, NULL on failure with errno set (EINVAL, ENOENT).
+ */
+void *aux_get (struct aux_item *head, const char *key)
+{
+    struct aux_item *item;
+
+    if (!key) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(item = aux_item_find (head, key))) {
+        errno = ENOENT;
+        return NULL;
+    }
+    return item->val;
+}
+
+/* Insert ('key', 'value', 'free_fn') tuple in 'head'.
+ * If 'key' is present in list, remove it first.
+ * 'head' is an in/out parameter.
+ * Returns 0 on success, -1 on failure with errno set (EINVAL, ENOMEM).
+ */
+int aux_set (struct aux_item **head,
+             const char *key, void *val, aux_free_f free_fn)
+{
+    struct aux_item *item;
+
+    if (!head || (!key && !val) || (!val && free_fn) || (!key && !free_fn)) {
+        errno = EINVAL;
+        return -1;
+    }
+    aux_item_delete (head, key);
+    if (val) {
+        if (!(item = aux_item_create (key, val, free_fn)))
+            return -1;
+        aux_item_insert (head, item);
+    }
+    return 0;
+}
+
+/* Destroy aux list 'head', calling destructors on items that have them.
+ */
+void aux_destroy (struct aux_item **head)
+{
+    if (head) {
+        while (*head) {
+            struct aux_item *next = (*head)->next;
+            aux_item_destroy (*head);
+            *head = next;
+        }
+    }
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/libutil/aux.h
+++ b/src/libutil/aux.h
@@ -1,0 +1,38 @@
+#ifndef _UTIL_AUX_H
+#define _UTIL_AUX_H
+
+/* aux container - associate auxiliary data with a host object
+ *
+ * The object declares a 'struct aux_item *aux', initialized to NULL.
+ * The object's destructor calls aux_destroy (&aux).
+ * The object's aux_get/aux_set functions call aux_get ()/aux_set () below.
+ *
+ * An empty aux list is represented by a NULL pointer.
+ *
+ * It is legal to aux_set (key=NULL, value!=NULL).  aux_get (key=NULL) fails,
+ * but aux_destroy () calls the anonymous value's destructor, if any.
+ *
+ * It is legal to aux_set () a duplicate key.  The new value replaces the old,
+ * after calling its destructor, if any.
+ *
+ * It is legal to aux_set (key!=NULL, value=NULL).  Any value previously
+ * stored under key is deleted, calling its destructor, if any.
+ */
+
+typedef void (*aux_free_f)(void *arg);
+
+struct aux_item;
+
+int aux_set (struct aux_item **aux, const char *key,
+             void *val, aux_free_f free_fn);
+
+void *aux_get (struct aux_item *aux, const char *key);
+
+void aux_destroy (struct aux_item **aux);
+
+#endif /* !_UTIL_AUX_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/libutil/test/aux.c
+++ b/src/libutil/test/aux.c
@@ -1,0 +1,109 @@
+#include <string.h>
+#include <errno.h>
+
+#include "src/libtap/tap.h"
+#include "src/libutil/aux.h"
+
+int myfree_count;
+void myfree (void *arg)
+{
+    myfree_count++;
+}
+
+int main (int argc, char *argv[])
+{
+    struct aux_item *aux = NULL;
+
+    plan (NO_PLAN);
+
+    errno = 0;
+    ok (aux_get (aux, "frog") == NULL && errno == ENOENT,
+        "aux_get fails with ENOENT on unknown item");
+
+    /* set 1st item no destructor */
+    ok (aux_set (&aux, "frog", "ribbit", NULL) == 0,
+        "aux_set frog=ribbit free_fn=NULL works");
+    is (aux_get (aux, "frog"), "ribbit",
+        "aux_get frog returns ribbit");
+
+    /* set 2nd item with destructor */
+    ok (aux_set (&aux, "dog", "woof", myfree) == 0,
+        "aux_set dog=woof free_fn=myfree");
+    is (aux_get (aux, "dog"), "woof",
+        "aux_get dog returns woof");
+    is (aux_get (aux, "frog"), "ribbit",
+        "aux_get frog still returns ribbit");
+
+    /* set 3rd item with destructor */
+    ok (aux_set (&aux, "cow", "moo", myfree) == 0,
+        "aux_set cow=moo free_fn=myfree");
+    is (aux_get (aux, "cow"), "moo",
+        "aux_get cow returns moo");
+    is (aux_get (aux, "dog"), "woof",
+        "aux_get dog still returns woof");
+    is (aux_get (aux, "frog"), "ribbit",
+        "aux_get frog still returns ribbit");
+
+    /* aux_set duplicate */
+    myfree_count = 0;
+    ok (aux_set (&aux, "cow", "oink", myfree) == 0,
+        "aux_set cow=oink free_fn=myfree");
+    cmp_ok (myfree_count, "==", 1,
+        "dup key=cow triggered destructor");
+    is (aux_get (aux, "cow"), "oink",
+        "aux_get cow now returns oink");
+
+    /* aux_set val=NULL */
+    myfree_count = 0;
+    ok (aux_set (&aux, "cow", NULL, NULL) == 0,
+        "aux_set cow=NULL does not fail");
+    cmp_ok (myfree_count, "==", 1,
+        "and called destructor once");
+    errno = 0;
+    ok (aux_get (aux, "cow") == NULL && errno == ENOENT,
+        "aux_get cow fails with ENOENT");
+    ok (aux_set (&aux, "unknown-key", NULL, NULL) == 0,
+        "aux_set unknown-key=NULL does not fail");
+
+    /* invalid args */
+    errno = 0;
+    ok (aux_get (aux, NULL) == NULL && errno == EINVAL,
+        "aux_get key=NULL fails with EINVAL");
+    errno = 0;
+    ok (aux_set (&aux, NULL, NULL, NULL) < 0 && errno == EINVAL,
+        "aux_set key=NULL val=NULL fails with EINVAL");
+    errno = 0;
+    ok (aux_set (NULL, "frog", NULL, NULL) < 0 && errno == EINVAL,
+        "aux_set aux=NULL fails with EINVAL");
+    errno = 0;
+    ok (aux_set (&aux, NULL, NULL, NULL) < 0 && errno == EINVAL,
+        "aux_set key=NULL val=NULL fails with EINVAL");
+    errno = 0;
+    ok (aux_set (&aux, "frog", NULL, myfree) < 0 && errno == EINVAL,
+        "aux_set val=NULL free_fn!=NULL fails with EINVAL");
+    errno = 0;
+    ok (aux_set (&aux, NULL, "baz", NULL) < 0 && errno == EINVAL,
+        "aux_set key=NULL free_fn=NULL fails with EINVAL");
+
+    /* add anonymous item */
+    ok (aux_set (&aux, NULL, "foo", myfree) == 0,
+        "aux-set key=NULL works for anonymous items");
+
+    /* destroy */
+    myfree_count = 0;
+    aux_destroy (&aux);
+    cmp_ok (myfree_count, "==", 2,
+        "aux_destroy called myfree twice");
+    ok (aux == NULL,
+        "aux_destroy set aux to NULL");
+
+    lives_ok ({aux_destroy (NULL);},
+        "aux_destroy aux=NULL doesn't crash");
+
+    done_testing ();
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */


### PR DESCRIPTION
Following on flux-framework/flux-core#1797, switch the implementation behind `flux_security_aux_set()` and `flux_security_aux_get()` over to the common one from flux-core (and pull that in with its unit test).