### PR TITLE
build: don't distribute version.h

### DIFF
--- a/src/imp/Makefile.am
+++ b/src/imp/Makefile.am
@@ -8,6 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	$(CODE_COVERAGE_CPPFLAGS) \
 	-I$(top_srcdir) \
+	-I$(top_builddir) \
 	-I$(top_srcdir)/src
 
 libexec_PROGRAMS = \

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -20,7 +20,9 @@ noinst_LTLIBRARIES = \
 
 fluxsecurityinclude_HEADERS = \
 	context.h \
-	sign.h \
+	sign.h
+
+nodist_fluxsecurityinclude_HEADERS = \
 	version.h
 
 libflux_security_la_SOURCES =

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -8,6 +8,7 @@ AM_LDFLAGS = \
 
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
+	-I$(top_builddir) \
 	-DINSTALLED_CF_PATTERN=\"$(fluxsecuritycfdir)/*.toml\" \
 	$(SODIUM_CFLAGS) $(JANSSON_CFLAGS) $(MUNGE_CFLAGS)
 

--- a/src/libca/Makefile.am
+++ b/src/libca/Makefile.am
@@ -9,6 +9,7 @@ AM_LDFLAGS = \
 
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
+	-I$(top_builddir) \
 	$(JANSSON_CFLAGS) $(SODIUM_CFLAGS) $(LIBUUID_CFLAGS)
 
 noinst_LTLIBRARIES = \

--- a/src/libutil/Makefile.am
+++ b/src/libutil/Makefile.am
@@ -9,6 +9,7 @@ AM_LDFLAGS = \
 
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
+	-I$(top_builddir) \
 	$(JANSSON_CFLAGS) $(SODIUM_CFLAGS) $(LIBUUID_CFLAGS)
 
 noinst_LTLIBRARIES = \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -44,6 +44,7 @@ check_LTLIBRARIES = \
 
 test_cppflags = \
 	-I$(top_srcdir) \
+	-I$(top_builddir) \
 	$(AM_CPPFLAGS) \
 	$(MUNGE_CFLAGS)
 


### PR DESCRIPTION
This PR tracks the build system changes for `version.h` in flux-framework/flux-core#1824.

Since `version.h` is generated by configure, it should not be included in `make dist`.

For VPATH builds, `-I$(top_builddir)` then needs to be searched for includes, not just `-I$(top_srcdir)`.