### PR TITLE
add version support for libflux-security.so

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,17 @@ AC_SUBST([AX_MINOR_VERSION])
 AC_SUBST([AX_POINT_VERSION])
 
 #
+# Library version
+# https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
+LIBFLUX_SECURITY_CURRENT=1
+LIBFLUX_SECURITY_REVISION=0
+LIBFLUX_SECURITY_AGE=0
+AC_SUBST(
+  [LIBFLUX_SECURITY_VERSION_INFO],
+  [$LIBFLUX_SECURITY_CURRENT:$LIBFLUX_SECURITY_REVISION:$LIBFLUX_SECURITY_AGE]
+)
+
+#
 #  Initialize pkg-config for PKG_CHECK_MODULES to avoid conditional issues
 #
 PKG_PROG_PKG_CONFIG

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -35,6 +35,7 @@ libflux_security_la_LIBADD = \
 
 libflux_security_la_LDFLAGS = \
 	-Wl,--version-script=$(srcdir)/libflux-security.map \
+	-version-info @LIBFLUX_SECURITY_VERSION_INFO@ \
 	-shared -export-dynamic --disable-static
 
 libsecurity_la_SOURCES = \


### PR DESCRIPTION
Copy @chu11's scheme for maintaining library version information in top-level `configure.ac`. Start the `libflux-security.so` library version info at `1:0:0`.