### PR TITLE
Add option to build with asan and ubsan, and fix discovered errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,22 @@
 language: c
 sudo: true
+dist: bionic
 
 matrix:
   include:
-    - compiler: gcc
+    - compiler: gcc-8
       env: MAKECMDS="make && make distcheck"
     - compiler: clang
-    - compiler: gcc-5
-      env: CC=gcc-5 COVERAGE=t ARGS="--enable-code-coverage" MAKECMDS="make && make check-code-coverage && lcov -l flux*-coverage.info"
-    - compiler: gcc-7
-      env: CC=gcc-7
-    - compiler: clang-4.0
-      env: CC=clang-4.0
+    - compiler: gcc
+      env: COVERAGE=t ARGS="--enable-code-coverage" MAKECMDS="make && make check-code-coverage && lcov -l flux*-coverage.info"
+    - compiler: clang-6.0
+      env: CC=clang-6.0
 
 addons:
   apt:
-    sources:
-      - ubuntu-toolchain-r-test
-      - llvm-toolchain-trusty-4.0
     packages:
-      - gcc-5
-      - gcc-7
-      - clang-4.0
+      - gcc-8
+      - clang-6.0
       - lcov
       - libjansson-dev
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
       env: COVERAGE=t ARGS="--enable-code-coverage" MAKECMDS="make && make check-code-coverage && lcov -l flux*-coverage.info"
     - compiler: clang-6.0
       env: CC=clang-6.0
+    - compiler: gcc-8
+      env: ARGS="--enable-sanitizers" MAKECMDS="make check"
 
 addons:
   apt:

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,9 @@
+if SANITIZERS_ENABLED
+ASAN_OPTIONS  ?= verify_asan_link_order=0:check_initialization_order=1:detect_stack_use_after_return=1:detect_invalid_pointer_pairs=1:strict_string_checks=1
+UBSAN_OPTIONS ?= print_stacktrace=1
+export ASAN_OPTIONS
+export UBSAN_OPTIONS
+endif
 SUBDIRS =         src etc t
 ACLOCAL_AMFLAGS = -I config
 EXTRA_DIST = \

--- a/configure.ac
+++ b/configure.ac
@@ -48,6 +48,23 @@ AC_SUBST(
 PKG_PROG_PKG_CONFIG
 
 #
+#  If --enable-sanitizers add selected -fsanitize flags to build
+#
+AC_MSG_CHECKING([whether to enable sanitizers])
+AC_ARG_ENABLE([sanitizers],
+              AS_HELP_STRING([--enable-sanitizers], [add {L,A,UB}San to build]),
+[
+AC_MSG_RESULT($withval)
+CFLAGS="$CFLAGS -fsanitize=address -fsanitize=undefined -fsanitize-recover=all"
+CFLAGS="$CFLAGS -g -fno-omit-frame-pointer"
+LDFLAGS="$LDFLAGS -fsanitize=address -fsanitize=undefined"
+AC_DEFINE([SANITIZERS_ENABLED], 1,
+          [Define to 1 if flux-security was compiled with --enable-sanitizers])
+],
+[AC_MSG_RESULT(no)])
+AM_CONDITIONAL([SANITIZERS_ENABLED], [test "x$enable_sanitizers" != "xno" ])
+
+#
 #  Checks for programs
 #
 AC_PROG_CC_C99

--- a/src/imp/test/privsep.c
+++ b/src/imp/test/privsep.c
@@ -160,6 +160,8 @@ static void test_privsep_kv (void)
         "privsep_write_kv");
 
     ok (privsep_destroy (ps) == 0, "privsep child exited normally");
+
+    kv_destroy (kv);
 }
 
 static void child_write_ints (privsep_t *ps, void *arg)

--- a/src/lib/sign_curve.c
+++ b/src/lib/sign_curve.c
@@ -121,6 +121,7 @@ static struct sigcert *header_get_cert (const struct kv *header,
         goto error;
     if (!(cert = sigcert_decode (buf, len)))
         goto error;
+    kv_destroy (kv);
     return cert;
 error:
     kv_destroy (kv);
@@ -319,6 +320,7 @@ static int op_verify (flux_security_t *ctx, const struct kv *header,
         security_error (ctx, "sign-curve-verify: ctime is in the future");
         goto error_nomsg;
     }
+    sigcert_destroy (cert);
     return 0;
 error:
     security_error (ctx, NULL);

--- a/src/lib/test/context.c
+++ b/src/lib/test/context.c
@@ -167,13 +167,15 @@ void aux_free (void *data)
 void test_aux (void)
 {
     flux_security_t *ctx;
-    char *s, *p;
+    char *s, *p, *q;
 
     if (!(ctx = flux_security_create (0)))
         BAIL_OUT ("flux_security_create failed");
     if (!(s = strdup ("hello")))
         BAIL_OUT ("strdup failed");
     if (!(p = strdup ("goodbye")))
+        BAIL_OUT ("strdup failed");
+    if (!(q = strdup ("goodbye, again")))
         BAIL_OUT ("strdup failed");
 
     ok (flux_security_aux_get (ctx, "unknown") == NULL,
@@ -189,7 +191,7 @@ void test_aux (void)
     ok (flux_security_aux_get (ctx, "bar") == p,
         "flux_security_aux_get retrieves data");
 
-    ok (flux_security_aux_set (ctx, "foo", p, aux_free) == 0,
+    ok (flux_security_aux_set (ctx, "foo", q, aux_free) == 0,
         "flux_security_aux_set key=existing works");
     ok (free_flag == 1,
         "destructor was called");

--- a/src/libca/test/ca.c
+++ b/src/libca/test/ca.c
@@ -60,7 +60,8 @@ void cf_init (void)
 
 void cf_fini (void)
 {
-    char path[PATH_MAX + 1];
+    /* path requires room for PATH_MAX + format size */
+    char path[PATH_MAX + 16];
 
     (void)snprintf (path, sizeof (path), "%s/ca-cert", tmpdir);
     (void)unlink (path);
@@ -81,7 +82,7 @@ void test_basic (void)
     int64_t userid;
     int64_t ttl;
     const char *uuid;
-    char path[PATH_MAX + 1];
+    char path[PATH_MAX*2 + 1];
     int64_t i;
     const char *s;
     time_t t, ctime, not_valid_before_time;
@@ -182,7 +183,6 @@ void test_basic (void)
     ok (ca_verify (ca, badcert, NULL, NULL, e) < 0 && errno == EINVAL,
         "ca_verify fails with EINVAL");
     diag ("%s", e);
-    sigcert_destroy (badcert);
 
     /* Revoke cert
      */
@@ -194,6 +194,7 @@ void test_basic (void)
     ok (ca_verify (ca, badcert, NULL, NULL, e) < 0 && errno == EINVAL,
         "ca_verify fails with EINVAL");
     diag ("%s", e);
+    sigcert_destroy (badcert);
 
     /* clean up revocation dir */
     snprintf (path, sizeof (path), "%s/ca-revoke/%s", tmpdir, uuid);

--- a/src/libca/test/sigcert.c
+++ b/src/libca/test/sigcert.c
@@ -244,6 +244,7 @@ void test_fread_fwrite (void)
         "new cert is identical to original");
 
     sigcert_destroy (cert);
+    sigcert_destroy (cert2);
 
     cleanup_keypath ("test");
 }

--- a/src/libtomlc99/test/toml.c
+++ b/src/libtomlc99/test/toml.c
@@ -301,6 +301,7 @@ void parse_good_input (void)
         ok (parse_good_file (results.gl_pathv[i], errbuf, 255) == true,
             "%s: %s", basename (results.gl_pathv[i]), errbuf);
     }
+    globfree (&results);
 }
 
 /* Recreate the TOML input from the tomlc99/test/extra directory.

--- a/src/libutil/test/cf.c
+++ b/src/libutil/test/cf.c
@@ -440,7 +440,7 @@ void test_update_glob (void)
     char path2[PATH_MAX + 1];
     char path3[PATH_MAX + 1];
     char invalid[PATH_MAX + 1];
-    char p [1024];
+    char p [8192];
 
     cf_t *cf;
     const cf_t *cf2, *cf3;

--- a/src/libutil/test/tomltk.c
+++ b/src/libutil/test/tomltk.c
@@ -93,6 +93,8 @@ void test_json_ts(void)
 
     ok (tomltk_json_to_epoch (obj, &t2) == 0 && t == t2,
         "tomltk_json_to_epoch works, correct value");
+
+    json_decref (obj);
 }
 
 void test_tojson_t1 (void)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -37,7 +37,8 @@ check_PROGRAMS = \
 	src/verify \
 	src/xsign_munge \
 	src/xsign_curve \
-	src/uidlookup
+	src/uidlookup \
+	src/sanitizers-enabled
 
 check_LTLIBRARIES = \
 	src/getpwuid.la

--- a/t/sharness.d/01-asan.sh
+++ b/t/sharness.d/01-asan.sh
@@ -1,0 +1,8 @@
+##
+# Is flux-security built with --enable-sanitizers?
+##
+if ${SHARNESS_BUILD_DIRECTORY}/t/src/sanitizers-enabled; then
+    test_set_prereq ASAN
+else
+    test_set_prereq NO_ASAN
+fi

--- a/t/sharness.d/10-sudo.sh
+++ b/t/sharness.d/10-sudo.sh
@@ -4,3 +4,11 @@
 if sudo --non-interactive true >/dev/null 2>&1; then
     test_set_prereq SUDO
 fi
+##
+# Fixup sudo commandline if sanitizers are enabled.
+# LSan doesn't work under setuid or program run under sudo
+##
+SUDO=sudo
+if test_have_prereq ASAN; then
+    SUDO="sudo -E ASAN_OPTIONS=$ASAN_OPTIONS:detect_leaks=0"
+fi

--- a/t/src/sanitizers-enabled.c
+++ b/t/src/sanitizers-enabled.c
@@ -1,0 +1,30 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/*
+ * Exit with 0 if flux-security built with --enable-sanitizers,
+ *  o/w exit nonzero.
+ */
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+int main (int ac, char **av)
+{
+#if SANITIZERS_ENABLED
+    return 0;
+#else  /* !SANITIZERS_ENABLED */
+    return 1;
+#endif /* SANITIZERS_ENABLED  */
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/t/src/verify.c
+++ b/t/src/verify.c
@@ -81,7 +81,8 @@ int main (int argc, char **argv)
                           &userid, 0) < 0)
         die ("flux_sign_unwrap: %s", flux_security_last_error (ctx));
 
-    fwrite (payload, payloadsz, 1, stdout);
+    if (payload)
+        fwrite (payload, payloadsz, 1, stdout);
     if (ferror (stdout))
         die ("write stdout failed");
 

--- a/t/t0000-sharness.t
+++ b/t/t0000-sharness.t
@@ -19,6 +19,8 @@
 
 test_description='Test Sharness itself'
 
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 . `dirname $0`/sharness.sh
 
 ret="$?"

--- a/t/t0100-sudo-unit-tests.t
+++ b/t/t0100-sudo-unit-tests.t
@@ -16,6 +16,6 @@ test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 basedir=${SHARNESS_BUILD_DIRECTORY}/src
 
 test_expect_success SUDO 'privsep unit tests' '
-	sudo $basedir/imp/test_privsep.t
+	$SUDO $basedir/imp/test_privsep.t
 '
 test_done

--- a/t/t1000-imp-basic.t
+++ b/t/t1000-imp-basic.t
@@ -36,15 +36,15 @@ test_expect_success 'Bad IMP config generates error' '
 	grep "loading config: bad.toml: 1: syntax error" bad-config.error
 '
 test_expect_success SUDO 'flux-imp version works under sudo' '
-	sudo $flux_imp version | grep "flux-imp v"
+	$SUDO $flux_imp version | grep "flux-imp v"
 '
 test_expect_success SUDO 'flux-imp fails under sudo if allow-sudo != true' '
 	echo "allow-sudo = false" > nosudo.toml &&
 	test_expect_code 1 \
-	  sudo FLUX_IMP_CONFIG_PATTERN=nosudo.toml $flux_imp version
+	  $SUDO FLUX_IMP_CONFIG_PATTERN=nosudo.toml $flux_imp version
 '
 test_expect_success SUDO 'flux-imp generates error if SUDO_USER is invalid' '
-	test_expect_code 1 sudo SUDO_USER=invalid $flux_imp version
+	test_expect_code 1 $SUDO SUDO_USER=invalid $flux_imp version
 '
 test_expect_success 'flux-imp whoami works' '
 	$flux_imp whoami | sort -k2,2 > output.whoami &&
@@ -55,7 +55,7 @@ EOF
 	test_cmp expected.whoami output.whoami
 '
 test_expect_success SUDO 'flux-imp whoami works under sudo' '
-	sudo $flux_imp whoami | sort -k2,2 > output.whoami.sudo &&
+	$SUDO $flux_imp whoami | sort -k2,2 > output.whoami.sudo &&
 	test_debug cat output.whoami.sudo &&
 	cat <<-EOF > expected.whoami.sudo &&
 	flux-imp: privileged: uid=$(id -ru) euid=0 gid=$(id -rg) egid=0
@@ -68,7 +68,8 @@ test_expect_success SUDO 'create setuid copy of flux-imp for testing' '
 	sudo chmod 4755 ./flux-imp
 '
 test_expect_success SUDO 'setuid copy of flux-imp works' '
-	./flux-imp whoami | sort -k2,2 > output.whoami.setuid &&
+        ASAN_OPTIONS=$ASAN_OPTIONS:detect_leaks=0 \
+	 ./flux-imp whoami | sort -k2,2 > output.whoami.setuid &&
 	test_debug cat output.whoami.setuid &&
 	cat <<-EOF >expected.whoami.setuid &&
 	flux-imp: privileged: uid=$(id -ru) euid=0 gid=$(id -rg) egid=$(id -g)
@@ -77,7 +78,8 @@ test_expect_success SUDO 'setuid copy of flux-imp works' '
 	test_cmp expected.whoami.setuid output.whoami.setuid
 '
 test_expect_success SUDO 'flux-imp setuid ignores SUDO_USER' '
-	SUDO_USER=nobody ./flux-imp whoami | sort -k2,2 > output.whoami.no &&
+        ASAN_OPTIONS=$ASAN_OPTIONS:detect_leaks=0 \
+	 SUDO_USER=nobody ./flux-imp whoami | sort -k2,2 > output.whoami.no &&
 	test_debug cat output.whoami.no &&
 	cat <<-EOF >expected.whoami.no &&
 	flux-imp: privileged: uid=$(id -ru) euid=0 gid=$(id -rg) egid=$(id -g)

--- a/t/t1001-imp-casign.t
+++ b/t/t1001-imp-casign.t
@@ -59,7 +59,7 @@ test_expect_success 'create new user signing cert' '
 '
 
 test_expect_success SUDO 'imp casign works under sudo' '
-	sudo FLUX_IMP_CONFIG_PATTERN=${SHARNESS_TRASH_DIRECTORY}/conf.d/*.toml \
+	$SUDO FLUX_IMP_CONFIG_PATTERN=${SHARNESS_TRASH_DIRECTORY}/conf.d/*.toml \
 		$flux_imp casign <u.pub >u.pub.signed.sudo
 '
 

--- a/t/t1003-sign-curve.t
+++ b/t/t1003-sign-curve.t
@@ -17,7 +17,7 @@ ca=${SHARNESS_BUILD_DIRECTORY}/t/src/ca
 sign=${SHARNESS_BUILD_DIRECTORY}/t/src/sign
 verify=${SHARNESS_BUILD_DIRECTORY}/t/src/verify
 xsign=${SHARNESS_BUILD_DIRECTORY}/t/src/xsign_curve
-prelib=${SHARNESS_BUILD_DIRECTORY}/t/src/.libs/getpwuid.so
+prelib="${LD_PRELOAD} ${SHARNESS_BUILD_DIRECTORY}/t/src/.libs/getpwuid.so"
 uidlookup=${SHARNESS_BUILD_DIRECTORY}/t/src/uidlookup
 
 export FLUX_IMP_CONFIG_PATTERN=${SHARNESS_TRASH_DIRECTORY}/conf.d/*.toml


### PR DESCRIPTION
This PR adds an `--enable-sanitizers` option to `configure` which turns on `-fsanitize=address` and `-fsanitize=undefinied` (along with other requisite options), and enables a build with this option in travis-ci.

Along the way some minor fixes (mostly in tests) were discovered and fixed.

At the top-level Makefile, some default ASAN_OPTIONS and UBSAN_OPTIONS are set, so that `make check` from top builddir will run successfully. (However, it won't work from a subdir, so perhaps another method is required)

Some shenanigans were required to work around "issues" with LSan and sudo/setuid.

I can add more detail later, but wanted to get this up to see how Travis goes.