### PR TITLE
testsuite: fix tests that do not work in some environments

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,12 @@
+on: pull_request
+jobs:
+  check-pr:
+    name: validate commits
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+    - run: git fetch origin master
+    - uses: flux-framework/pr-validator@master

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,17 @@
+pull_request_rules:
+  - name: rebase and merge when passing all checks
+    conditions:
+      - base=master
+      - status-success=continuous-integration/travis-ci/pr
+      - status-success="validate commits"
+      - label="merge-when-passing"
+      - label!="work-in-progress"
+      - "approved-reviews-by=@flux-framework/core"
+      - "#approved-reviews-by>0"
+      - "#changes-requested-reviews-by=0"
+      - -title~=^\[*[Ww][Ii][Pp]
+    actions:
+      merge:
+        method: merge
+        strict: smart
+        strict_method: rebase

--- a/t/t1002-sign-munge.t
+++ b/t/t1002-sign-munge.t
@@ -16,8 +16,8 @@ test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 # in sharness.d/03-munge.sh.  If that doesn't work, skip the whole test.
 if munge </dev/null | unmunge >/dev/null; then
 	echo "System munge works"
-	export MUNGE_SOCKET=$(munged --help | grep socket \
-					    | sed 's/.*\[\(.*\)\]$/\1/')
+	export MUNGE_SOCKET=$(munged --help \
+	                      | sed -n '/-S, --socket/s/.*\[\(.*\)\]$/\1/p')
 elif munged --version; then
 	test_set_prereq SIDEMUNGE
 	export MUNGED=munged  # needed by 03-munge.sh


### PR DESCRIPTION
This PR fixes a couple tests in flux-security that are broken on LC clusters.

 Nothing too major:

 * Update the method for determining system munged socket (newer MUNGE versions have another line that contains "socket" in the `--help` output)
 * Skip setuid tests in the IMP testsuite when running on a filesystem with nosuid (or other scenarios where setuid permissions cannot be set on executables)