### PR TITLE
imp: add limited exec support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -126,6 +126,9 @@ AC_SUBST(fluxsecuritycfdir)
 AS_VAR_SET(fluxsecurityincludedir, $includedir/flux/security)
 AC_SUBST(fluxsecurityincludedir)
 
+AS_VAR_SET(fluximpcfdir, $sysconfdir/flux/imp/conf.d)
+AC_SUBST(fluximpcfdir)
+
 #
 #  Epilogue
 #

--- a/configure.ac
+++ b/configure.ac
@@ -120,7 +120,7 @@ AC_PKGCONFIG
 AS_VAR_SET(fluxlibdir, $libdir/flux)
 AC_SUBST(fluxlibdir)
 
-AS_VAR_SET(fluxlibexecdir, $libexec/flux)
+AS_VAR_SET(fluxlibexecdir, $libexecdir/flux)
 AC_SUBST(fluxlibexecdir)
 
 AS_VAR_SET(fluxsecuritycfdir, $sysconfdir/flux/security/conf.d)

--- a/configure.ac
+++ b/configure.ac
@@ -120,6 +120,9 @@ AC_PKGCONFIG
 AS_VAR_SET(fluxlibdir, $libdir/flux)
 AC_SUBST(fluxlibdir)
 
+AS_VAR_SET(fluxlibexecdir, $libexec/flux)
+AC_SUBST(fluxlibexecdir)
+
 AS_VAR_SET(fluxsecuritycfdir, $sysconfdir/flux/security/conf.d)
 AC_SUBST(fluxsecuritycfdir)
 

--- a/src/imp/Makefile.am
+++ b/src/imp/Makefile.am
@@ -82,9 +82,17 @@ BUILT_SOURCES = \
 #  Installed flux-imp configuration pattern is locked down to
 #   the system path for security reasons.
 config.c:
-	@(echo "const char *imp_get_config_pattern (void)"; \
-          echo "{"; \
-          echo "    return \"$(fluxsecuritycfdir)/*.toml\";"; \
+	@(echo "#include <stdlib.h>"; \
+	  echo ; \
+	  echo "const char *imp_get_security_config_pattern (void)"; \
+	  echo "{"; \
+	  echo "    /* Always use built-in config path */"; \
+	  echo "    return NULL;"; \
+	  echo "}"; \
+	  echo ; \
+	  echo "const char *imp_get_config_pattern (void)"; \
+	  echo "{"; \
+	  echo "    return \"$(fluximpcfdir)/*.toml\";"; \
 	  echo "}"; \
 	)> config.c
 

--- a/src/imp/Makefile.am
+++ b/src/imp/Makefile.am
@@ -54,7 +54,8 @@ EXTRA_DIST = \
 TESTS = \
 	test_imp_log.t \
 	test_privsep.t \
-	test_impcmd.t
+	test_impcmd.t \
+	test_passwd.t
 
 check_PROGRAMS = \
 	$(TESTS)
@@ -91,3 +92,10 @@ test_impcmd_t_SOURCES =  \
 	impcmd.h
 
 test_impcmd_t_LDADD = $(test_ldadd)
+
+test_passwd_t_SOURCES =  \
+	test/passwd.c \
+	passwd.c \
+	passwd.h
+
+test_passwd_t_LDADD = $(test_ldadd)

--- a/src/imp/Makefile.am
+++ b/src/imp/Makefile.am
@@ -42,7 +42,10 @@ flux_imp_SOURCES = \
 	testconfig.c \
 	casign.c \
 	passwd.c \
-	passwd.h
+	passwd.h \
+	exec/user.h \
+	exec/user.c \
+	exec/exec.c
 
 testconfig.o: testconfig.h
 testconfig.h: $(top_builddir)/config/config.h

--- a/src/imp/Makefile.am
+++ b/src/imp/Makefile.am
@@ -15,9 +15,14 @@ libexec_PROGRAMS = \
 	flux-imp
 
 flux_imp_LDADD = \
+	$(top_builddir)/src/lib/libflux-security.la \
 	$(top_builddir)/src/libca/libca.la \
 	$(top_builddir)/src/libutil/libutil.la \
 	$(top_builddir)/src/libtomlc99/libtomlc99.la
+
+flux_imp_LDFLAGS = \
+	-static
+
 
 flux_imp_SOURCES = \
 	imp.c \

--- a/src/imp/Makefile.am
+++ b/src/imp/Makefile.am
@@ -10,8 +10,15 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_builddir) \
 	-I$(top_srcdir)/src
-
+#
+#  Create two versions of flux-imp, one that will be used for testing
+#   flux-imp, and one that will be installed inst/flux-imp.
+#  The only difference is that the test version allows configuration
+#   pattern to be overridden for in-tree testing purposes.
+#
 libexec_PROGRAMS = \
+	inst/flux-imp
+noinst_PROGRAMS = \
 	flux-imp
 
 flux_imp_LDADD = \
@@ -20,11 +27,18 @@ flux_imp_LDADD = \
 	$(top_builddir)/src/libutil/libutil.la \
 	$(top_builddir)/src/libtomlc99/libtomlc99.la
 
+#
+#  Build the test-only version of flux-imp with -static, which seems
+#   to cause libtool to avoid creating a wrapper script (libtool's
+#   wrapper script is not compatible with setuid flux-imp tests). However,
+#   this embeds the builddir path to libflux-security into the DT_RUNPATH
+#   of the resulting executable, so DO NOT use this for the installed
+#   copy of the IMP (inst/flux-imp):
+#
 flux_imp_LDFLAGS = \
 	-static
 
-
-flux_imp_SOURCES = \
+IMP_SOURCES = \
 	imp.c \
 	imp_state.h \
 	imp_log.h \
@@ -38,8 +52,6 @@ flux_imp_SOURCES = \
 	sudosim.h \
 	version.c \
 	whoami.c \
-	testconfig.h \
-	testconfig.c \
 	casign.c \
 	passwd.c \
 	passwd.h \
@@ -47,14 +59,45 @@ flux_imp_SOURCES = \
 	exec/user.c \
 	exec/exec.c
 
-testconfig.o: testconfig.h
+flux_imp_SOURCES = \
+	testconfig.c \
+	$(IMP_SOURCES)
+
+nodist_flux_imp_SOURCES = \
+	testconfig.h
+
+inst_flux_imp_SOURCES = \
+	$(IMP_SOURCES)
+
+nodist_inst_flux_imp_SOURCES = \
+	config.c
+
+inst_flux_imp_LDADD = \
+	$(flux_imp_LDADD)
+
+BUILT_SOURCES = \
+	config.c \
+	testconfig.h
+
+#  Installed flux-imp configuration pattern is locked down to
+#   the system path for security reasons.
+config.c:
+	@(echo "const char *imp_get_config_pattern (void)"; \
+          echo "{"; \
+          echo "    return \"$(fluxsecuritycfdir)/*.toml\";"; \
+	  echo "}"; \
+	)> config.c
+
+#  Test version of flux-imp gets builddir config pattern by default,
+#   and allows override via FLUX_IMP_CONFIG_PATTERN (see testconfig.c).
 testconfig.h: $(top_builddir)/config/config.h
 	@(confdir=`cd $(srcdir) && pwd`/imp.conf.d; \
 	  echo "const char *imp_config_pattern = \"$$confdir/*.toml\";" \
 	 )> testconfig.h
 
 MOSTLYCLEANFILES = \
-	testconfig.h
+	testconfig.h \
+	config.c
 
 EXTRA_DIST = \
 	imp.conf.d

--- a/src/imp/Makefile.am
+++ b/src/imp/Makefile.am
@@ -35,7 +35,9 @@ flux_imp_SOURCES = \
 	whoami.c \
 	testconfig.h \
 	testconfig.c \
-	casign.c
+	casign.c \
+	passwd.c \
+	passwd.h
 
 testconfig.o: testconfig.h
 testconfig.h: $(top_builddir)/config/config.h

--- a/src/imp/Makefile.am
+++ b/src/imp/Makefile.am
@@ -16,7 +16,7 @@ AM_CPPFLAGS = \
 #  The only difference is that the test version allows configuration
 #   pattern to be overridden for in-tree testing purposes.
 #
-libexec_PROGRAMS = \
+fluxlibexec_PROGRAMS = \
 	inst/flux-imp
 noinst_PROGRAMS = \
 	flux-imp

--- a/src/imp/exec/exec.c
+++ b/src/imp/exec/exec.c
@@ -213,8 +213,8 @@ int imp_exec_privileged (struct imp_state *imp, struct kv *kv)
         imp_die (1, "exec: shell not in allowed-shells list");
 
     /* Ensure child exited with nonzero status */
-    if (privsep_destroy (imp->ps) < 0)
-        imp_die (1, "exec: error in unpriv imp child");
+    if (privsep_wait (imp->ps) < 0)
+        exit (1);
 
     /* Call privileged IMP plugins/containment */
 

--- a/src/imp/exec/exec.c
+++ b/src/imp/exec/exec.c
@@ -1,0 +1,284 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* exec - given valid signed 'J', execute a job shell as user
+ *
+ * Usage: flux-imp exec /path/to/job/shell arg
+ *
+ * Input:
+ *
+ * Signed J as key "J" in JSON object on stdin, path to requested
+ *  job shell and single argument on cmdline.
+ *
+ */
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <string.h>
+#include <errno.h>
+#include <assert.h>
+#include <jansson.h>
+
+
+#include "src/libutil/kv.h"
+#include "src/lib/context.h"
+#include "src/lib/sign.h"
+
+#include "imp_log.h"
+#include "imp_state.h"
+#include "impcmd.h"
+#include "privsep.h"
+#include "passwd.h"
+#include "user.h"
+
+struct imp_exec {
+    struct passwd *imp_pwd;
+    struct imp_state *imp;
+    flux_security_t *sec;
+    const cf_t *conf;
+
+    uid_t userid;
+    json_t *input;
+
+    const char *J;
+    const char *shell;
+    const char *arg;
+    const void *spec;
+    int specsz;
+};
+
+extern const char *imp_get_config_pattern (void);
+
+static flux_security_t *sec_init (void)
+{
+    flux_security_t *sec = flux_security_create (0);
+
+    if (!sec || flux_security_configure (sec, imp_get_config_pattern ()) < 0) {
+        imp_die (1, "exec: Error loading security context: %s",
+                    sec ? flux_security_last_error (sec) : strerror (errno));
+    }
+    return sec;
+}
+
+static bool imp_exec_user_allowed (struct imp_exec *exec)
+{
+    return cf_array_contains (cf_get_in (exec->conf, "allowed-users"),
+                              exec->imp_pwd->pw_name);
+}
+
+static bool imp_exec_shell_allowed (struct imp_exec *exec)
+{
+    return cf_array_contains (cf_get_in (exec->conf, "allowed-shells"),
+                              exec->shell);
+}
+
+static void imp_exec_destroy (struct imp_exec *exec)
+{
+    if (exec) {
+        flux_security_destroy (exec->sec);
+        json_decref (exec->input);
+        passwd_destroy (exec->imp_pwd);
+        free (exec);
+    }
+}
+
+static struct imp_exec *imp_exec_create (struct imp_state *imp)
+{
+    struct imp_exec *exec = calloc (1, sizeof (*exec));
+    if (exec) {
+        exec->userid = (uid_t) -1;
+        exec->imp = imp;
+        exec->sec = sec_init ();
+        exec->conf = cf_get_in (imp->conf, "exec");
+
+        if (!(exec->imp_pwd = passwd_from_uid (getuid ())))
+            imp_die (1, "exec: failed to find IMP user");
+    }
+    return exec;
+}
+
+static void imp_exec_unwrap (struct imp_exec *exec, const char *J)
+{
+    int64_t userid;
+
+    if (flux_sign_unwrap (exec->sec,
+                          J,
+                          &exec->spec,
+                          &exec->specsz,
+                          &userid,
+                          0) < 0)
+        imp_die (1, "exec: signature validation failed: %s",
+                 flux_security_last_error (exec->sec));
+
+    exec->userid = (uid_t) userid;
+}
+
+static void imp_exec_init_kv (struct imp_exec *exec, struct kv *kv)
+{
+    assert (exec != NULL && kv != NULL);
+
+    if (kv_get (kv, "J", KV_STRING, &exec->J) < 0)
+        imp_die (1, "exec: Error decoding J");
+    if (kv_get (kv, "shell_path", KV_STRING, &exec->shell) < 0)
+        imp_die (1, "exec: Failed to get job shell path");
+    if (kv_get (kv, "arg", KV_STRING, &exec->arg) < 0)
+        imp_die (1, "exec: Failed to get job shell arg");
+
+    imp_exec_unwrap (exec, exec->J);
+}
+
+static void imp_exec_init_stream (struct imp_exec *exec, FILE *fp)
+{
+    struct imp_state *imp;
+    json_error_t err;
+
+    assert (exec != NULL && exec->imp != NULL && fp != NULL);
+
+    imp = exec->imp;
+
+    /* shell path and `arg` come from imp->argv */
+    if (imp->argc < 4)
+        imp_die (1, "exec: missing arguments to exec subcommand");
+
+    exec->shell = imp->argv[2];
+
+    /*  Only a single argument to the shell is currently supported */
+    exec->arg = imp->argv[3];
+
+    /* Get input from JSON on stdin */
+    if (!(exec->input = json_loadf (fp, 0, &err))
+        || json_unpack_ex (exec->input,
+                           &err,
+                           0,
+                           "{s:s}",
+                           "J", &exec->J) < 0)
+        imp_die (1, "exec: invalid json input: %s", err.text);
+
+    imp_exec_unwrap (exec, exec->J);
+}
+
+static void __attribute__((noreturn)) imp_exec (struct imp_exec *exec)
+{
+    const char *args[3];
+    int exit_code;
+
+    /* Setup minimal environment */
+
+    /* Move to "safe" path (XXX: user's home directory?) */
+    if (chdir ("/") < 0)
+        imp_die (1, "exec: failed to chdir to /");
+
+    args[0] = exec->shell;
+    args[1] = exec->arg;
+    args[2] = NULL;
+    execvp (exec->shell, (char **) args);
+
+    if (errno == EPERM || errno == EACCES)
+        exit_code =  126;
+    exit_code = 127;
+    imp_die (exit_code, "%s: %s", exec->shell, strerror (errno));
+}
+
+int imp_exec_privileged (struct imp_state *imp, struct kv *kv)
+{
+    struct imp_exec *exec = imp_exec_create (imp);
+    if (!exec)
+        imp_die (1, "exec: failed to initialize state");
+
+    if (!imp_exec_user_allowed (exec))
+        imp_die (1, "exec: user %s not in allowed-users list",
+                    exec->imp_pwd->pw_name);
+
+    /* Init IMP input from kv object */
+    imp_exec_init_kv (exec, kv);
+
+    /* Paranoia checks
+     */
+    if (exec->userid == 0)
+        imp_die (1, "exec: switching to user root not supported");
+    if (!imp_exec_shell_allowed (exec))
+        imp_die (1, "exec: shell not in allowed-shells list");
+
+    /* Ensure child exited with nonzero status */
+    if (privsep_destroy (imp->ps) < 0)
+        imp_die (1, "exec: error in unpriv imp child");
+
+    /* Call privileged IMP plugins/containment */
+
+    /* Irreversibly switch to user */
+    imp_switch_user (exec->userid);
+
+    /* execute shell (NORETURN) */
+    imp_exec (exec);
+
+    return (-1);
+}
+
+/* Put all data from imp_exec into kv struct `kv`
+ */
+static void imp_exec_put_kv (struct imp_exec *exec,
+                                   struct kv *kv)
+{
+    if (kv_put (kv, "J", KV_STRING, exec->J) < 0)
+        imp_die (1, "exec: Error decoding J");
+    if (kv_put (kv, "shell_path", KV_STRING, exec->shell) < 0)
+        imp_die (1, "exec: Failed to get job shell path");
+    if (kv_put (kv, "arg", KV_STRING, exec->arg) < 0)
+        imp_die (1, "exec: Failed to get job shell arg");
+}
+
+int imp_exec_unprivileged (struct imp_state *imp, struct kv *kv)
+{
+    struct imp_exec *exec = imp_exec_create (imp);
+    if (!exec)
+        imp_die (1, "exec: initialization failure");
+
+    if (!imp_exec_user_allowed (exec))
+        imp_die (1, "exec: user %s not in allowed-users list",
+                    exec->imp_pwd->pw_name);
+
+    /* Read input from stdin, cmdline: */
+    imp_exec_init_stream (exec, stdin);
+
+    /* XXX; Parse jobspec if necessary, disabled for now: */
+    //if (!(jobspec = json_loads (spec, 0, &err)))
+    //   imp_die (1, "exec: failed to parse jobspec: %s", err.text);
+
+    if (imp->ps) {
+        if (!imp_exec_shell_allowed (exec))
+            imp_die (1, "exec: shell not in allowed-shells");
+
+        /* In privsep mode, write kv to privileged parent and exit */
+        imp_exec_put_kv (exec, kv);
+
+        if (privsep_write_kv (imp->ps, kv) < 0)
+            imp_die (1, "exec: failed to communicate with privsep parent");
+        imp_exec_destroy (exec);
+        exit (0);
+    }
+
+    /* Not in privilege separation mode, issue warning and process input
+     *  for testing purposes
+     */
+    imp_warn ("Running without privilege, userid switching not available");
+
+    imp_exec (exec);
+
+    /* imp_exec() does not return */
+    return -1;
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/imp/exec/exec.c
+++ b/src/imp/exec/exec.c
@@ -59,13 +59,14 @@ struct imp_exec {
     int specsz;
 };
 
-extern const char *imp_get_config_pattern (void);
+extern const char *imp_get_security_config_pattern (void);
 
 static flux_security_t *sec_init (void)
 {
     flux_security_t *sec = flux_security_create (0);
+    const char *conf_pattern = imp_get_security_config_pattern ();
 
-    if (!sec || flux_security_configure (sec, imp_get_config_pattern ()) < 0) {
+    if (!sec || flux_security_configure (sec, conf_pattern) < 0) {
         imp_die (1, "exec: Error loading security context: %s",
                     sec ? flux_security_last_error (sec) : strerror (errno));
     }

--- a/src/imp/exec/user.c
+++ b/src/imp/exec/user.c
@@ -1,0 +1,61 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <unistd.h> /* setresuid(2), setresgid(2) */
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <pwd.h>
+#include <grp.h>
+
+#include "imp_log.h"
+
+/*
+ *  Switch process to new UID/GID with supplementary group initialization
+ *   etc.
+ */
+void imp_switch_user (uid_t uid)
+{
+    gid_t gid = -1;
+    const char *user = NULL;
+
+    struct passwd *pwd = getpwuid (uid);
+    if (!pwd)
+        imp_die (1, "lookup userid=%ld failed: %s",
+                     (long) uid,
+                     strerror (errno));
+
+    user = pwd->pw_name;
+    gid = pwd->pw_gid;
+
+    /*  Intialize groups from /etc/group */
+    if (initgroups (user, gid) < 0)
+        imp_die (1, "initgroups");
+
+    /*  Set saved, effective, and real gids/uids */
+    if (setresgid (gid, gid, gid) < 0)
+        imp_die (1, "setresgid");
+    if (setresuid (uid, uid, uid) < 0)
+        imp_die (1, "setresuid");
+
+    /*  Verify privilege cannot be restored */
+    if (setreuid (-1, 0) == 0)
+        imp_die (1, "irreversible switch to uid %ld failed",
+                 (long) uid);
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/imp/exec/user.h
+++ b/src/imp/exec/user.h
@@ -1,0 +1,18 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef HAVE_IMP_EXEC_USER_H
+#define HAVE_IMP_EXEC_USER_H 1
+/*
+ *  Switch process to new UID/GID with supplementary group initialization
+ */
+void imp_switch_user (uid_t uid);
+
+#endif /* !HAVE_IMP_EXEC_USER_H */

--- a/src/imp/imp_log.h
+++ b/src/imp/imp_log.h
@@ -27,7 +27,8 @@ void imp_warn (const char *fmt, ...) __attribute__ ((format (printf, 1, 2)));
 void imp_debug (const char *fmt, ...) __attribute__ ((format (printf, 1, 2)));
 
 /*  Print an error to IMP logging destination and exit with exit `code` */
-void imp_die (int code, const char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
+void __attribute__((noreturn)) imp_die (int code, const char *fmt, ...)
+     __attribute__ ((format (printf, 2, 3)));
 
 /*
  *  Logging output provider prototype:

--- a/src/imp/impcmd-list.c
+++ b/src/imp/impcmd-list.c
@@ -16,6 +16,8 @@ extern int imp_whoami_unprivileged (struct imp_state *imp, struct kv *);
 extern int imp_whoami_privileged (struct imp_state *imp, struct kv *);
 extern int imp_casign_unprivileged (struct imp_state *imp, struct kv *);
 extern int imp_casign_privileged (struct imp_state *imp, struct kv *);
+extern int imp_exec_unprivileged (struct imp_state *imp, struct kv *);
+extern int imp_exec_privileged (struct imp_state *imp, struct kv *);
 
 /*  List of supported imp commands, curated by hand for now.
  *   For each named command, the `child_fn` runs unprivileged and the
@@ -32,6 +34,9 @@ struct impcmd impcmd_list[] = {
 	{ "casign",
 	  imp_casign_unprivileged,
       imp_casign_privileged },
+    { "exec",
+      imp_exec_unprivileged,
+      imp_exec_privileged },
 	{ NULL, NULL, NULL}
 };
 

--- a/src/imp/passwd.c
+++ b/src/imp/passwd.c
@@ -1,0 +1,60 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "passwd.h"
+
+static struct passwd * passwd_copy (struct passwd *arg)
+{
+    struct passwd *pwd = calloc (1, sizeof (*pwd));
+    if (pwd) {
+        pwd->pw_uid = arg->pw_uid;
+        pwd->pw_gid = arg->pw_gid;
+        if (!(pwd->pw_name = strdup (arg->pw_name))
+            || !(pwd->pw_passwd = strdup (arg->pw_passwd))
+            || !(pwd->pw_gecos = strdup (arg->pw_gecos))
+            || !(pwd->pw_dir = strdup (arg->pw_dir))
+            || !(pwd->pw_shell = strdup (arg->pw_shell))) {
+            passwd_destroy (pwd);
+            return NULL;
+        }
+    }
+    return pwd;
+}
+
+struct passwd * passwd_from_uid (uid_t uid)
+{
+    struct passwd *pwd = NULL;
+    if (!(pwd = getpwuid (uid)))
+        return NULL;
+    return passwd_copy (pwd);
+}
+
+void passwd_destroy (struct passwd *pwd)
+{
+    if (pwd) {
+        free (pwd->pw_name);
+        free (pwd->pw_passwd);
+        free (pwd->pw_gecos);
+        free (pwd->pw_dir);
+        free (pwd->pw_shell);
+        free (pwd);
+    }
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/imp/passwd.h
+++ b/src/imp/passwd.h
@@ -1,0 +1,28 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef HAVE_IMP_PASSWD_H
+#define HAVE_IMP_PASSWD_H 1
+
+#include <pwd.h>
+#include <sys/types.h>
+
+/*
+ *  Return a copy of the passwd entry for UID
+ *  Caller must free with passwd_destroy()
+ */
+struct passwd * passwd_from_uid (uid_t uid);
+
+/*
+ *  Free memory for a copy of passwd entry created by passwd_from_uid
+ */
+void passwd_destroy (struct passwd *pw);
+
+#endif /* !HAVE_IMP_PASSWD_H */

--- a/src/imp/privsep.c
+++ b/src/imp/privsep.c
@@ -164,26 +164,29 @@ privsep_t * privsep_init (privsep_child_f fn, void *arg)
     return (ps);
 }
 
-int privsep_destroy (privsep_t *ps)
+int privsep_wait (privsep_t *ps)
 {
     int status = 0;
-
-    if (ps->wfd > 0)
-        close (ps->wfd);
-    if (ps->rfd > 0)
-        close (ps->rfd);
-
     if (privsep_is_parent (ps)) {
         if (ps->cpid > (pid_t) 0) {
-            int status;
             kill (SIGTERM, ps->cpid);
             if (waitpid (ps->cpid, &status, 0) < 0)
                 status = -1;
+            ps->cpid = (pid_t) -1;
         }
     }
-
-    free (ps);
     return (status == 0 ? 0 : -1);
+}
+
+void privsep_destroy (privsep_t *ps)
+{
+    if (ps) {
+        if (ps->wfd > 0)
+            close (ps->wfd);
+        if (ps->rfd > 0)
+            close (ps->rfd);
+        free (ps);
+    }
 }
 
 bool privsep_is_parent (privsep_t *ps)

--- a/src/imp/privsep.c
+++ b/src/imp/privsep.c
@@ -144,6 +144,8 @@ privsep_t * privsep_init (privsep_child_f fn, void *arg)
         return (NULL);
     }
     ps->ppid = getpid ();
+    ps->wfd = -1;
+    ps->rfd = -1;
 
     if (pipe (ps->upfds) < 0 || pipe (ps->ppfds) < 0) {
         imp_warn ("privsep_init: pipe: %s\n", strerror (errno));
@@ -181,9 +183,9 @@ int privsep_wait (privsep_t *ps)
 void privsep_destroy (privsep_t *ps)
 {
     if (ps) {
-        if (ps->wfd > 0)
+        if (ps->wfd >= 0)
             close (ps->wfd);
-        if (ps->rfd > 0)
+        if (ps->rfd >= 0)
             close (ps->rfd);
         free (ps);
     }

--- a/src/imp/privsep.h
+++ b/src/imp/privsep.h
@@ -28,11 +28,15 @@ typedef void (*privsep_child_f) (privsep_t *ps, void *arg);
  */
 privsep_t * privsep_init (privsep_child_f fn, void *arg);
 
+/*  If this is the parent process, wait for child to exit.
+ *  Returns 0 if child exited normally, -1 if not.
+ */
+int privsep_wait (privsep_t *ps);
+
 /*  Free memory associated with privsep handle and close associated
- *   file descriptors to parent/child. If this is the parent process,
- *   it will wait for the child to exit.
+ *   file descriptors to parent/child.
  */  
-int privsep_destroy (privsep_t *ps);
+void privsep_destroy (privsep_t *ps);
 
 /*  Return true if running in child.
  */

--- a/src/imp/test/passwd.c
+++ b/src/imp/test/passwd.c
@@ -1,0 +1,41 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include <stdio.h>
+#include <errno.h>
+#include "passwd.h"
+
+#include "src/libtap/tap.h"
+
+int main (void)
+{
+    struct passwd *pwd;
+
+    /* check passwd_destroy() on NULL doesn't segfault */
+    lives_ok ({passwd_destroy (NULL);},
+        "passwd_destroy (NULL) doesn't segfault");
+
+    /* Get known UID 0 */
+    if (!(pwd = passwd_from_uid (0)))
+        BAIL_OUT ("passwd_from_uid() failed");
+    ok (pwd->pw_uid == 0,
+        "pwd->pw_uid is correct");
+    is (pwd->pw_name, "root",
+        "passwd_from_uid() returned correct entry for root");
+    passwd_destroy (pwd);
+
+    ok (!(pwd = passwd_from_uid (-1)),
+        "passwd_from_uid() fails on invalid uid");
+    done_testing ();
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/imp/test/privsep.c
+++ b/src/imp/test/privsep.c
@@ -96,7 +96,8 @@ static void test_privsep_basic (void)
     ok (geteuid() == 0,
         "parent retains effective uid == 0");
 
-    ok (privsep_destroy (ps) == 0, "privsep child exited normally");
+    ok (privsep_wait (ps) == 0, "privsep child exited normally");
+    privsep_destroy (ps);
 }
 
 static void child_kv_test (privsep_t *ps, void *arg __attribute__ ((unused)))
@@ -159,8 +160,9 @@ static void test_privsep_kv (void)
     ok (privsep_write_kv (ps, kv) >= 0,
         "privsep_write_kv");
 
-    ok (privsep_destroy (ps) == 0, "privsep child exited normally");
+    ok (privsep_wait (ps) == 0, "privsep child exited normally");
 
+    privsep_destroy (ps);
     kv_destroy (kv);
 }
 

--- a/src/imp/testconfig.c
+++ b/src/imp/testconfig.c
@@ -25,6 +25,16 @@ const char * imp_get_config_pattern (void)
     return (p);
 }
 
+/*  For build-tree/test IMP, return the same config path for
+ *   libflux-security as flux-imp. This is what the tests expect
+ *   and makes test writing easier (only one env var needed to
+ *   override config)
+ */
+const char * imp_get_security_config_pattern (void)
+{
+    return imp_get_config_pattern ();
+}
+
 /*
  *  vi: ts=4 sw=4 expandtab
  */

--- a/src/imp/testconfig.c
+++ b/src/imp/testconfig.c
@@ -13,7 +13,7 @@
 #include "testconfig.h"
 
 /*
- *  For build-tree/test IMP only! Return config patter from environment
+ *  For build-tree/test IMP only! Return config pattern from environment
  *   if set, otherwise use built-in "test" configuration pattern, which
  *   will point to src/imp/imp.conf.d
  */

--- a/src/libutil/cf.c
+++ b/src/libutil/cf.c
@@ -193,6 +193,23 @@ int cf_array_size (const cf_t *cf)
     return cf ? json_array_size (cf) : 0;
 }
 
+/*  Return true if 'str' appears in cf array 'cf'
+ *  False if array is NULL or is zero length, or doesn't contain str
+ */
+bool cf_array_contains (const cf_t *cf, const char *str)
+{
+    int size;
+    if (str && cf && (size = cf_array_size (cf)) > 0) {
+        for (int i = 0; i < size; i++) {
+            const cf_t *entry = cf_get_at (cf, i);
+            if (cf_typeof (entry) == CF_STRING
+                && strcmp (cf_string (entry), str) == 0)
+                return true;
+        }
+    }
+    return false;
+}
+
 /* Parse some TOML and merge it with 'cf' object.
  * If filename is non-NULL, take TOML from file, o/w use buf, len.
  */

--- a/src/libutil/cf.h
+++ b/src/libutil/cf.h
@@ -92,6 +92,11 @@ time_t cf_timestamp (const cf_t *cf);     // default: 0
  */
 int cf_array_size (const cf_t *cf);
 
+/* Return true if array contains string str.
+ * Return false if cf is NULL, is not an array, or doesn't contain str.
+ */
+bool cf_array_contains (const cf_t *cf, const char *str);
+
 /* Update table 'cf' with info parsed from TOML 'buf' or 'filename'.
  * On success return 0.  On failure, return -1 with errno set.
  * If error is non-NULL, write error description there.

--- a/src/libutil/test/cf.c
+++ b/src/libutil/test/cf.c
@@ -45,6 +45,7 @@ const char *tab3 = \
 "[tab3]\n" \
 "id = 3\n";
 
+
 const struct cf_option opts[] = {
     { "i", CF_INT64, true },
     { "d", CF_DOUBLE, true },
@@ -569,6 +570,62 @@ void test_check (void)
     cf_destroy (cf);
 }
 
+void test_array_contains (void)
+{
+    const char *array1 = "array = [ \"foo\", \"bar\", \"baz\" ]";
+    const char *array2 = "array2 = [ 1, 2, 3 ]";
+    cf_t *tab;
+    const cf_t *cf;
+
+    if (!(tab = cf_create ()))
+        BAIL_OUT ("cf_create");
+    if (cf_update (tab, array1, strlen (array1), NULL) < 0)
+        BAIL_OUT ("cf_update");
+    if (cf_update (tab, array2, strlen (array2), NULL) < 0)
+        BAIL_OUT ("cf_update");
+
+    cf = cf_get_in (tab, "array");
+
+    ok (cf_typeof (cf) == CF_ARRAY,
+        "cf_update of an array worked");
+    ok (cf_array_size (cf) == 3,
+        "array has expected number of elements");
+
+    ok (cf_array_contains (NULL, NULL) == false,
+        "cf_array_contains (NULL, NULL) returns false");
+    ok (cf_array_contains (NULL, "foo") == false,
+        "cf_array_contains (NULL, \"foo\") returns false");
+    ok (cf_array_contains (cf, NULL) == false,
+        "cf_array_contains (cf, NULL) returns false");
+    ok (cf_array_contains (cf, "") == false,
+        "cf_array_contains (cf, \"\") returns false");
+    ok (cf_array_contains (cf, "buzz") == false,
+        "cf_array_contains (cf, \"buzz\") returns false");
+    ok (cf_array_contains (cf, "foob") == false,
+        "cf_array_contains (cf, \"foob\") returns false");
+    ok (cf_array_contains (cf, "foo"),
+        "cf_array_contains (cf, \"foo\") returns true");
+    ok (cf_array_contains (cf, "bar"),
+        "cf_array_contains (cf, \"bar\") returns true");
+    ok (cf_array_contains (cf, "baz"),
+        "cf_array_contains (cf, \"baz\") returns true");
+
+
+    cf = cf_get_in (tab, "array2");
+
+    ok (cf_typeof (cf) == CF_ARRAY,
+        "cf_update of array2 worked");
+    ok (cf_array_size (cf) == 3,
+        "array2 has expected number of elements");
+    ok (cf_array_contains (cf, "") == false,
+        "cf_array_contains returns false for non-string array");
+    ok (cf_array_contains (cf, "foo") == false,
+        "cf_array_contains returns false for non-string array");
+
+    cf_destroy (tab);
+}
+
+
 int main (int argc, char *argv[])
 {
     plan (NO_PLAN);
@@ -579,6 +636,7 @@ int main (int argc, char *argv[])
     test_update_file ();
     test_update_glob ();
     test_check ();
+    test_array_contains ();
 
     done_testing ();
 }

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -12,7 +12,7 @@ TEST_EXTENSIONS = .t
 T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
 	$(top_srcdir)/config/tap-driver.sh
 
-TESTS = \
+TESTSCRIPTS = \
 	t0000-sharness.t \
 	t0100-sudo-unit-tests.t \
 	t1000-imp-basic.t \
@@ -20,13 +20,8 @@ TESTS = \
 	t1002-sign-munge.t \
 	t1003-sign-curve.t
 
-check_SCRIPTS = \
-	t0000-sharness.t \
-	t0100-sudo-unit-tests.t \
-	t1000-imp-basic.t \
-	t1001-imp-casign.t \
-	t1002-sign-munge.t \
-	t1003-sign-curve.t
+TESTS = \
+	$(TESTSCRIPTS)
 
 check_PROGRAMS = \
 	src/keygen \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -18,9 +18,13 @@ TESTSCRIPTS = \
 	t1000-imp-basic.t \
 	t1001-imp-casign.t \
 	t1002-sign-munge.t \
-	t1003-sign-curve.t
+	t1003-sign-curve.t \
+	t2000-imp-exec.t
 
 TESTS = \
+	$(TESTSCRIPTS)
+
+check_SCRIPTS = \
 	$(TESTSCRIPTS)
 
 check_PROGRAMS = \

--- a/t/t2000-imp-exec.t
+++ b/t/t2000-imp-exec.t
@@ -1,0 +1,119 @@
+#!/bin/sh
+#
+
+test_description='IMP exec basic functionality test
+
+Basic flux-imp exec functionality and corner case handing tests
+'
+
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+. `dirname $0`/sharness.sh
+
+flux_imp=${SHARNESS_BUILD_DIRECTORY}/src/imp/flux-imp
+sign=${SHARNESS_BUILD_DIRECTORY}/t/src/sign
+
+echo "# Using ${flux_imp}"
+
+fake_imp_input() {
+	printf '{"J":"%s"}' $(echo $1 | $sign)
+}
+
+test_expect_success 'flux-imp exec returns error when run with no args' '
+	test_must_fail $flux_imp exec
+'
+test_expect_success 'flux-imp exec returns error when run with only 1 arg' '
+	test_must_fail $flux_imp exec foo
+'
+test_expect_success 'flux-imp exec returns error with no input' '
+	test_must_fail $flux_imp exec shell arg < /dev/null
+'
+test_expect_success 'flux-imp exec returns error with bad input ' '
+	echo foo | test_must_fail $flux_imp exec shell arg
+'
+test_expect_success 'flux-imp exec returns error with bad JSON input ' '
+	echo "{}" | test_must_fail $flux_imp exec shell arg
+'
+test_expect_success 'flux-imp exec returns error with invalid JSON input ' '
+	echo "{" | test_must_fail $flux_imp exec shell arg
+'
+test_expect_success 'create configs for flux-imp exec and signer' '
+	cat <<-EOF >sign-none.toml &&
+	allow-sudo = true
+	[sign]
+	max-ttl = 30
+	default-type = "none"
+	allowed-types = [ "none" ]
+	[exec]
+	allowed-users = [ "$(whoami)" ]
+	allowed-shells = [ "id", "echo" ]
+	EOF
+	cat <<-EOF >sign-none-allowed-munge.toml
+	allow-sudo = true
+	[sign]
+	max-ttl = 30
+	default-type = "none"
+	allowed-types = [ "munge" ]
+	[exec]
+	allowed-users = [ "$(whoami)" ]
+	allowed-shells = [ "id", "echo" ]
+	EOF
+'
+test_expect_success 'flux-imp exec works in unprivileged mode' '
+	( export FLUX_IMP_CONFIG_PATTERN=sign-none.toml  &&
+	  fake_imp_input foo | $flux_imp exec echo good >works.out
+	) &&
+	cat >works.expected <<-EOF &&
+	good
+	EOF
+	test_cmp works.expected works.out
+'
+test_expect_success 'flux-imp exec fails when signature type not allowed' '
+	( export FLUX_IMP_CONFIG_PATTERN=./sign-none-allowed-munge.toml  &&
+	  fake_imp_input foo | \
+	    test_must_fail $flux_imp exec echo good >badmech.log 2>&1
+	) &&
+	test_debug "cat badmech.log" &&
+	grep "signature validation failed" badmech.log
+'
+test_expect_success 'flux-imp bails out with no configuration' '
+	( export FLUX_IMP_CONFIG_PATTERN=/nosuchthing &&
+	  fake_imp_input foo | \
+	    test_must_fail $flux_imp exec echo good >badconf.log 2>&1
+	) &&
+	grep -i "Failed to load configuration" badconf.log
+'
+test_expect_success 'flux-imp exec fails with invalid stdin input' '
+	( export FLUX_IMP_CONFIG_PATTERN=sign-none.toml &&
+	  echo foo | \
+	    test_must_fail $flux_imp exec echo good >badjson.log 2>&1
+	) &&
+	grep -i "invalid json input" badjson.log
+'
+test_expect_success 'flux-imp exec: shell must be in allowed users' '
+	sed "s/allowed-users =//" sign-none.toml > sign-none-nousers.toml &&
+	( export FLUX_IMP_CONFIG_PATTERN=sign-none-nousers.toml &&
+	  fake_imp_input foo | \
+	    test_must_fail $flux_imp exec echo good >nousers.log 2>&1
+	) &&
+	grep -i "not in allowed-users list" nousers.log
+'
+test_expect_success SUDO 'flux-imp exec: user must be in allowed-shells' '
+	( export FLUX_IMP_CONFIG_PATTERN=sign-none.toml &&
+	  fake_imp_input foo | \
+	    test_must_fail $SUDO FLUX_IMP_CONFIG_PATTERN=sign-none.toml \
+	      $flux_imp exec printf good >badshell.log 2>&1
+	) &&
+	grep -i "not in allowed-shells" badshell.log
+'
+test_expect_success SUDO 'flux-imp exec works under sudo' '
+	( export FLUX_IMP_CONFIG_PATTERN=sign-none.toml  &&
+          fake_imp_input foo | \
+	    $SUDO FLUX_IMP_CONFIG_PATTERN=sign-none.toml \
+	      $flux_imp exec id -u >id-sudo.out
+        ) &&
+	test_debug "echo expecting uid=$(id -u), got $(cat id-sudo.out)" &&
+	id -u > id-sudo.expected &&
+        test_cmp id-sudo.expected id-sudo.out
+'
+test_done


### PR DESCRIPTION
This PR adds a minimal working version of the `flux-imp exec` subcommand.
This version takes input as JSON on stdin. The current format requires a single key "J", expected to contain the users signed jobspec.

`flux-imp exec` reads the path to the job shell to execute plus 1 argument from the cmdline. This allows simply inserting `flux-imp exec` in front of the job shell invocation already being done by the job-exec module.

With the exec command comes a new `[exec]` table in the IMP's configuration. In order for `flux-imp exec` to be functional, the table must contain at least the following keys
```toml
[exec]
allowed-users = [ "list of users allowed to run imp exec" ]
allowed-shells = [ "list of shell paths allowed for imp exec" ]
```

Without either of these config keys either the IMP user or the job shell will not be allowed and thus `flux imp exec` will not be functional.

Additional changes of note:
 - The flux-imp build was split into an installed IMP (`inst/flux-imp`) and test IMP `./flux-imp`. The only difference is how the IMP reads its config. The test IMP's config can be overridden at runtime, and it reads IMP and libflux-security config from the same config pattern.

Closes #96