### PR TITLE
imp: do not allow unprivileged exec by default 

### DIFF
--- a/src/imp/exec/exec.c
+++ b/src/imp/exec/exec.c
@@ -85,6 +85,11 @@ static bool imp_exec_shell_allowed (struct imp_exec *exec)
                               exec->shell);
 }
 
+static bool imp_exec_unprivileged_allowed (struct imp_exec *exec)
+{
+    return cf_bool (cf_get_in (exec->conf, "allow-unprivileged-exec"));
+}
+
 static void imp_exec_destroy (struct imp_exec *exec)
 {
     if (exec) {
@@ -270,8 +275,11 @@ int imp_exec_unprivileged (struct imp_state *imp, struct kv *kv)
         exit (0);
     }
 
-    /* Not in privilege separation mode, issue warning and process input
-     *  for testing purposes
+    if (!imp_exec_unprivileged_allowed (exec))
+        imp_die (1, "exec: IMP not installed setuid, operation disabled.");
+
+    /* Unprivileged exec allowed. Issue warning and process input for
+     *  testing purposes.
      */
     imp_warn ("Running without privilege, userid switching not available");
 

--- a/t/t2000-imp-exec.t
+++ b/t/t2000-imp-exec.t
@@ -38,6 +38,16 @@ test_expect_success 'flux-imp exec returns error with invalid JSON input ' '
 	echo "{" | test_must_fail $flux_imp exec shell arg
 '
 test_expect_success 'create configs for flux-imp exec and signer' '
+	cat <<-EOF >no-unpriv-exec.toml &&
+	allow-sudo = true
+	[sign]
+	max-ttl = 30
+	default-type = "none"
+	allowed-types = [ "none" ]
+	[exec]
+	allowed-users = [ "$(whoami)" ]
+	allowed-shells = [ "id", "echo" ]
+	EOF
 	cat <<-EOF >sign-none.toml &&
 	allow-sudo = true
 	[sign]
@@ -61,7 +71,14 @@ test_expect_success 'create configs for flux-imp exec and signer' '
 	allow-unprivileged-exec = true
 	EOF
 '
-test_expect_success 'flux-imp exec works in unprivileged mode' '
+test_expect_success 'flux-imp exec fails in unprivileged mode by default' '
+	( export FLUX_IMP_CONFIG_PATTERN=no-unpriv-exec.toml  &&
+	  fake_imp_input foo | \
+		test_must_fail $flux_imp exec echo good >noexec.out 2>&1
+	) &&
+	grep "IMP not installed setuid" noexec.out
+'
+test_expect_success 'flux-imp exec works in unprivileged mode if configured' '
 	( export FLUX_IMP_CONFIG_PATTERN=sign-none.toml  &&
 	  fake_imp_input foo | $flux_imp exec echo good >works.out
 	) &&

--- a/t/t2000-imp-exec.t
+++ b/t/t2000-imp-exec.t
@@ -47,6 +47,7 @@ test_expect_success 'create configs for flux-imp exec and signer' '
 	[exec]
 	allowed-users = [ "$(whoami)" ]
 	allowed-shells = [ "id", "echo" ]
+	allow-unprivileged-exec = true
 	EOF
 	cat <<-EOF >sign-none-allowed-munge.toml
 	allow-sudo = true
@@ -57,6 +58,7 @@ test_expect_success 'create configs for flux-imp exec and signer' '
 	[exec]
 	allowed-users = [ "$(whoami)" ]
 	allowed-shells = [ "id", "echo" ]
+	allow-unprivileged-exec = true
 	EOF
 '
 test_expect_success 'flux-imp exec works in unprivileged mode' '


### PR DESCRIPTION
It is giving me some heebie-jeebies that a system instance install of flux-core with the current flux-security where the IMP is *not* installed setuid will allow any user to run anything as user `flux`.

This PR cleans that up by having the IMP refuse to exec anything by default when installed unprivileged. Since the unprivileged exec is used in testing, a new config parameter `exec.allow-unprivileged-exec` is added.