### PR TITLE
imp: add tests for flux-imp kill, fix discovered issues

### DIFF
--- a/src/imp/kill.c
+++ b/src/imp/kill.c
@@ -53,6 +53,7 @@
 
 struct pid_info {
     pid_t pid;
+    uid_t pid_owner;
     char cg_path [4096];
     uid_t cg_owner;
 };
@@ -117,6 +118,18 @@ static uid_t path_owner (const char *path)
     return st.st_uid;
 }
 
+/*  return the owner of pid. -1 on failure.
+ */
+static uid_t pid_owner (pid_t pid)
+{
+    char path [128];
+    const int size = sizeof (path);
+    int n = snprintf (path, size, "/proc/%ju", (uintmax_t) pid);
+    if ((n < 0) || (n >= size))
+        return (pid_t) -1;
+    return path_owner (path);
+}
+
 static struct pid_info *pid_info_create (pid_t pid)
 {
     struct pid_info *pi = calloc (1, sizeof (*pi));
@@ -125,10 +138,13 @@ static struct pid_info *pid_info_create (pid_t pid)
     if (pid < 0)
         pid = -pid;
     pi->pid = pid;
+    if ((pi->pid_owner = pid_owner (pid)) == (uid_t) -1)
+        goto err;
     if (pid_systemd_cgroup_path (pid, pi->cg_path, sizeof (pi->cg_path)) < 0)
         goto err;
     if ((pi->cg_owner = path_owner (pi->cg_path)) == (uid_t) -1)
         goto err;
+
     return pi;
 err:
     free (pi);
@@ -163,7 +179,8 @@ static void check_and_kill_process (struct imp_state *imp, pid_t pid, int sig)
                     strerror (errno));
 
     /* Check if pid is in pids cgroup owned by IMP user */
-    if (p->cg_owner != user)
+    if (p->cg_owner != user
+        && p->pid_owner != user)
         imp_die (1,
             "kill: refusing request from uid=%ju to kill pid %jd (owner=%ju)",
             (uintmax_t) user,

--- a/src/imp/kill.c
+++ b/src/imp/kill.c
@@ -130,6 +130,11 @@ static uid_t pid_owner (pid_t pid)
     return path_owner (path);
 }
 
+static void pid_info_destroy (struct pid_info *pi)
+{
+    free (pi);
+}
+
 static struct pid_info *pid_info_create (pid_t pid)
 {
     struct pid_info *pi = calloc (1, sizeof (*pi));
@@ -147,7 +152,7 @@ static struct pid_info *pid_info_create (pid_t pid)
 
     return pi;
 err:
-    free (pi);
+    pid_info_destroy (pi);
     return NULL;
 }
 
@@ -192,6 +197,8 @@ static void check_and_kill_process (struct imp_state *imp, pid_t pid, int sig)
                     (intmax_t) pid,
                     (uintmax_t) sig,
                     strerror (errno));
+
+    pid_info_destroy (p);
 }
 
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -19,7 +19,8 @@ TESTSCRIPTS = \
 	t1001-imp-casign.t \
 	t1002-sign-munge.t \
 	t1003-sign-curve.t \
-	t2000-imp-exec.t
+	t2000-imp-exec.t \
+	t2001-imp-kill.t
 
 TESTS = \
 	$(TESTSCRIPTS)

--- a/t/t2001-imp-kill.t
+++ b/t/t2001-imp-kill.t
@@ -1,0 +1,114 @@
+#!/bin/sh
+#
+
+test_description='IMP kill basic functionality test
+
+Basic flux-imp kill failure handling
+'
+
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+. `dirname $0`/sharness.sh
+
+flux_imp=${SHARNESS_BUILD_DIRECTORY}/src/imp/flux-imp
+
+echo "# Using ${flux_imp}"
+
+test_expect_success 'flux-imp kill: returns error when run with no args' '
+	test_must_fail $flux_imp kill
+'
+test_expect_success 'flux-imp kill: returns error when run with 1 arg' '
+	test_must_fail $flux_imp kill 15
+'
+test_expect_success 'flux-imp kill: returns error with pid=0' '
+	test_must_fail $flux_imp kill 15 0
+'
+test_expect_success 'flux-imp kill: returns error with invalid signal' '
+	test_must_fail $flux_imp kill -15 0
+'
+test_expect_success 'flux-imp kill: checks exec.allowed-users' '
+	name=wronguser &&
+	cat <<-EOF >${name}.toml &&
+	[exec]
+	allowed-users = []
+	EOF
+	( export FLUX_IMP_CONFIG_PATTERN=${name}.toml &&
+	  test_must_fail $flux_imp kill 15 1234 >${name}.log 2>&1
+	) &&
+	test_debug "cat ${name}.log" &&
+	grep "kill command not allowed" ${name}.log && unset name
+'
+test_expect_success SUDO 'flux-imp kill: sudo: user must be in allowed-shells' '
+	name=wrongusersudo &&
+	cat <<-EOF >${name}.toml &&
+	allow-sudo = true
+	[exec]
+	allowed-users = []
+	EOF
+	test_must_fail $SUDO FLUX_IMP_CONFIG_PATTERN=${name}.toml \
+	      $flux_imp kill 15 1234 >${name}.log 2>&1 &&
+	test_debug "cat ${name}.log" &&
+	grep -i "kill command not allowed" ${name}.log && unset name
+'
+
+test "$chain_lint" = "t" || test_set_prereq NO_CHAIN_LINT
+test -d /sys/fs/cgroup/systemd && test_set_prereq SYSTEMD_CGROUP
+
+test_expect_success NO_CHAIN_LINT,SYSTEMD_CGROUP 'flux-imp kill: works in unpriv mode' '
+	name=allowed-user
+	cat <<-EOF >${name}.toml
+	allow-sudo = true
+	[exec]
+	allowed-users = [ "$(whoami)" ]
+	EOF
+	sleep 300 & pid=$! &&
+	FLUX_IMP_CONFIG_PATTERN=${name}.toml \
+	    $flux_imp kill 15 $pid >${name}.log 2>&1 &&
+	test_debug "cat ${name}.log" &&
+	test_expect_code 143 wait $pid
+'
+test_expect_success NO_CHAIN_LINT,SYSTEMD_CGROUP,SUDO 'flux-imp kill: works with sudo' '
+	name=allowed-user
+	cat <<-EOF >${name}.toml
+	allow-sudo = true
+	[exec]
+	allowed-users = [ "$(whoami)" ]
+	EOF
+	sleep 300 & pid=$! &&
+	$SUDO FLUX_IMP_CONFIG_PATTERN=${name}.toml \
+	    $flux_imp kill 15 $pid >${name}.log 2>&1 &&
+	test_expect_code 143 wait $pid
+'
+test_expect_success SYSTEMD_CGROUP 'flux-imp kill: fails for nonexistent pid' '
+	name=allowed-user &&
+	cat <<-EOF >${name}.toml &&
+	allow-sudo = true
+	[exec]
+	allowed-users = [ "$(whoami)" ]
+	EOF
+	for pid in `seq 10000 12000`; do
+            kill -s 0 ${pid} >/dev/null 2>&1 || break
+        done
+	( export FLUX_IMP_CONFIG_PATTERN=${name}.toml &&
+	    test_must_fail $flux_imp kill 15 $pid >${name}.log 2>&1
+	) &&
+	test_debug "cat ${name}.log" &&
+	grep "No such file or directory"  ${name}.log
+'
+test_expect_success SUDO,SYSTEMD_CGROUP 'flux-imp kill: fails for nonexistent pid under sudo' '
+	name=allowed-user &&
+	cat <<-EOF >${name}.toml &&
+	allow-sudo = true
+	[exec]
+	allowed-users = [ "$(whoami)" ]
+	EOF
+	for pid in `seq 10000 12000`; do
+            kill -s 0 ${pid} >/dev/null 2>&1 || break
+        done
+	test_must_fail $SUDO FLUX_IMP_CONFIG_PATTERN=${name}.toml \
+	    $flux_imp kill 15 $pid >${name}.log 2>&1 &&
+	test_debug "cat ${name}.log" &&
+	grep "No such file or directory"  ${name}.log
+'
+
+test_done


### PR DESCRIPTION
This PR adds the `flux-imp kill` tests promised in #110. 

Additionally a memleak fix found along the way, and for testing, allow non-root users running the IMP to kill their own processes. (Still pondering if this one should require an option.)