### PR TITLE
build: bump minimum jansson version to 2.10

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -103,7 +103,7 @@ AC_HEADER_STDC
 #  Checks for packages
 #
 PKG_CHECK_MODULES([SODIUM], [libsodium >= 1.0.14], [], [])
-PKG_CHECK_MODULES([JANSSON], [jansson], [], [])
+PKG_CHECK_MODULES([JANSSON], [jansson >= 2.10], [], [])
 PKG_CHECK_MODULES([LIBUUID], [uuid], [], [])
 PKG_CHECK_MODULES([MUNGE], [munge], [], [])
 


### PR DESCRIPTION
For consistency to flux-core issue #3239, increase the minimum
jansson version to 2.10.