### PR TITLE
update mergify config for move to travis-ci.com

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,7 +2,7 @@ pull_request_rules:
   - name: rebase and merge when passing all checks
     conditions:
       - base=master
-      - status-success=continuous-integration/travis-ci/pr
+      - status-success=Travis CI - Pull Request
       - status-success="validate commits"
       - label="merge-when-passing"
       - label!="work-in-progress"


### PR DESCRIPTION
flux-security has been migrated from travis-ci.org to travis-ci.com.

I think this is the one required change due to the migration.