### PR TITLE
check file permissions and ownership of configuration when running privileged code

### DIFF
--- a/src/imp/Makefile.am
+++ b/src/imp/Makefile.am
@@ -83,7 +83,8 @@ BUILT_SOURCES = \
 #  Installed flux-imp configuration pattern is locked down to
 #   the system path for security reasons.
 config.c:
-	@(echo "#include <stdlib.h>"; \
+	@(echo "#include \"src/libutil/cf.h\""; \
+	  echo "#include <stdlib.h>"; \
 	  echo ; \
 	  echo "const char *imp_get_security_config_pattern (void)"; \
 	  echo "{"; \
@@ -95,6 +96,14 @@ config.c:
 	  echo "{"; \
 	  echo "    return \"$(fluximpcfdir)/*.toml\";"; \
 	  echo "}"; \
+	  echo ; \
+	  echo "int imp_conf_init (__attribute__((unused)) cf_t *cf,"; \
+	  echo "        __attribute__((unused)) struct cf_error *error)"; \
+	  echo "{"; \
+	  echo "    return 0;"; \
+	  echo "}"; \
+	  echo ; \
+	  echo "int imp_get_security_flags (void) { return 0; }"; \
 	)> config.c
 
 #  Test version of flux-imp gets builddir config pattern by default,

--- a/src/imp/exec/exec.c
+++ b/src/imp/exec/exec.c
@@ -60,10 +60,11 @@ struct imp_exec {
 };
 
 extern const char *imp_get_security_config_pattern (void);
+extern int imp_get_security_flags (void);
 
 static flux_security_t *sec_init (void)
 {
-    flux_security_t *sec = flux_security_create (0);
+    flux_security_t *sec = flux_security_create (imp_get_security_flags ());
     const char *conf_pattern = imp_get_security_config_pattern ();
 
     if (!sec || flux_security_configure (sec, conf_pattern) < 0) {

--- a/src/imp/imp.c
+++ b/src/imp/imp.c
@@ -29,6 +29,9 @@
  */
 extern const char *imp_get_config_pattern (void);
 
+/*  External function used to initialize imp config object */
+extern int imp_conf_init (cf_t *cf, struct cf_error *error);
+
 /*  Static prototypes:
  */
 static void initialize_logging ();
@@ -137,7 +140,8 @@ static cf_t * imp_conf_load (const char *pattern)
         return (NULL);
 
     memset (&err, 0, sizeof (err));
-    if ((rc = cf_update_glob (cf, pattern, &err)) < 0) {
+    if (imp_conf_init (cf, &err) < 0
+        || (rc = cf_update_glob (cf, pattern, &err)) < 0) {
         imp_warn ("loading config: %s: %d: %s",
                  err.filename, err.lineno, err.errbuf);
         cf_destroy (cf);

--- a/src/lib/context.h
+++ b/src/lib/context.h
@@ -15,6 +15,11 @@
 extern "C" {
 #endif
 
+enum {
+    FLUX_SECURITY_DISABLE_PATH_PARANOIA     = 0x1,
+    FLUX_SECURITY_FORCE_PATH_PARANOIA       = 0x2,
+};
+
 typedef struct flux_security flux_security_t;
 
 typedef void (*flux_security_free_f)(void *arg);

--- a/src/lib/test/context.c
+++ b/src/lib/test/context.c
@@ -210,7 +210,7 @@ void test_corner (void)
         BAIL_OUT ("flux_security_create failed");
 
     errno = 0;
-    ok (flux_security_create (1) == NULL && errno == EINVAL,
+    ok (flux_security_create (128) == NULL && errno == EINVAL,
         "flux_security_create with unknown flag fails with EINVAL");
 
     errno = 0;

--- a/src/libutil/Makefile.am
+++ b/src/libutil/Makefile.am
@@ -30,7 +30,9 @@ libutil_la_SOURCES = \
 	sha256.h \
 	macros.h \
 	aux.c \
-	aux.h
+	aux.h \
+	strlcpy.c \
+	strlcpy.h
 
 TESTS = \
 	test_hash.t \

--- a/src/libutil/cf.c
+++ b/src/libutil/cf.c
@@ -315,7 +315,7 @@ int cf_update_glob (cf_t *cf, const char *pattern, struct cf_error *error)
     int errnum = 0;
     int rc = glob (pattern, GLOB_ERR, NULL, &gl);
 
-    tmp = cf_create ();
+    tmp = cf_copy (cf);
 
     switch (rc) {
         case 0:

--- a/src/libutil/cf.h
+++ b/src/libutil/cf.h
@@ -104,6 +104,10 @@ bool cf_array_contains (const cf_t *cf, const char *str);
 int cf_update (cf_t *cf, const char *buf, int len, struct cf_error *error);
 int cf_update_file (cf_t *cf, const char *filename, struct cf_error *error);
 
+/* Update table 'cf' with jansson-style pack format.
+ */
+int cf_update_pack (cf_t *cf, struct cf_error *error, const char *fmt, ...);
+
 /* Update table 'cf' with info parsed from all filenames matching the
  * wildcard 'pattern', following the rules for the glob(3) function call.
  * On success returns the number of individual files successfully parsed,

--- a/src/libutil/kv.c
+++ b/src/libutil/kv.c
@@ -24,6 +24,7 @@
 
 #include "timestamp.h"
 #include "kv.h"
+#include "strlcpy.h"
 
 #define KV_CHUNK 4096
 
@@ -193,10 +194,10 @@ static int kv_put_raw (struct kv *kv, const char *key, enum kv_type type,
     int vallen = strlen (val);
     if (kv_expand (kv, keylen + vallen + 3) < 0) // key\0Tval\0
         return -1;
-    strncpy (&kv->buf[kv->len], key, keylen + 1);
+    strlcpy (&kv->buf[kv->len], key, keylen + 1);
     kv->len += keylen + 1;
     kv->buf[kv->len++] = type;
-    strncpy (&kv->buf[kv->len], val, vallen + 1);
+    strlcpy (&kv->buf[kv->len], val, vallen + 1);
     kv->len += vallen + 1;
     return 0;
 }

--- a/src/libutil/strlcpy.c
+++ b/src/libutil/strlcpy.c
@@ -1,0 +1,55 @@
+/*	$OpenBSD: strlcpy.c,v 1.8 2003/06/17 21:56:24 millert Exp $	*/
+
+/*
+ * Copyright (c) 1998 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#if defined(LIBC_SCCS) && !defined(lint)
+static char *rcsid = "$OpenBSD: strlcpy.c,v 1.8 2003/06/17 21:56:24 millert Exp $";
+#endif /* LIBC_SCCS and not lint */
+
+#include <sys/types.h>
+#include <string.h>
+
+/*
+ * Copy src to string dst of size siz.  At most siz-1 characters
+ * will be copied.  Always NUL terminates (unless siz == 0).
+ * Returns strlen(src); if retval >= siz, truncation occurred.
+ */
+size_t
+strlcpy(char *dst, const char *src, size_t siz)
+{
+	register char *d = dst;
+	register const char *s = src;
+	register size_t n = siz;
+
+	/* Copy as many bytes as will fit */
+	if (n != 0 && --n != 0) {
+		do {
+			if ((*d++ = *s++) == 0)
+				break;
+		} while (--n != 0);
+	}
+
+	/* Not enough room in dst, add NUL and traverse rest of src */
+	if (n == 0) {
+		if (siz != 0)
+			*d = '\0';		/* NUL-terminate dst */
+		while (*s++)
+			;
+	}
+
+	return(s - src - 1);	/* count does not include NUL */
+}

--- a/src/libutil/strlcpy.h
+++ b/src/libutil/strlcpy.h
@@ -1,0 +1,12 @@
+#if HAVE_CONFIG_H
+#  include "config.h"
+#endif /* HAVE_CONFIG_H */
+
+#if !HAVE_STRLCPY
+size_t strlcpy(char *dst, const char *src, size_t siz);
+/*
+ *  Copy src to string dst of size siz.  At most siz-1 characters
+ *    will be copied.  Always NUL terminates (unless siz == 0).
+ *  Returns strlen(src); if retval >= siz, truncation occurred.
+ */
+#endif /* !HAVE_STRLCPY */

--- a/src/libutil/test/cf.c
+++ b/src/libutil/test/cf.c
@@ -522,6 +522,34 @@ void test_update_glob (void)
 
 }
 
+void test_update_pack (void)
+{
+    cf_t *cf;
+    struct cf_error error;
+
+    if (!(cf = cf_create ()))
+        BAIL_OUT ("cf_create");
+
+    ok (cf_update_pack (NULL, &error, NULL) < 0 && errno == EINVAL,
+        "cf_update_pack (NULL, &error, NULL) fails with EINVAL: %s",
+        error.errbuf);
+    ok (cf_update_pack (cf, &error, NULL) < 0 && errno == EINVAL,
+        "cf_update_pack (cf, &error, NULL) fails with EINVAL: %s",
+        error.errbuf);
+
+    ok (cf_update_pack (cf, &error, "{{") < 0 && errno == EINVAL,
+        "cf_update_pack with invalid format fails: %s",
+        error.errbuf);
+
+    ok (cf_update_pack (cf, &error, "{s:i}", "test", 42) == 0,
+        "cf_update_pack works");
+
+    ok (cf_int64 (cf_get_in (cf, "test")) == 42,
+        "cf_update_pack set correct value in cf object");
+
+    cf_destroy (cf);
+}
+
 void test_check (void)
 {
     cf_t *cf;
@@ -635,6 +663,7 @@ int main (int argc, char *argv[])
     test_corner ();
     test_update_file ();
     test_update_glob ();
+    test_update_pack ();
     test_check ();
     test_array_contains ();
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -15,6 +15,7 @@ T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
 TESTSCRIPTS = \
 	t0000-sharness.t \
 	t0100-sudo-unit-tests.t \
+	t0101-cf-path-security.t \
 	t1000-imp-basic.t \
 	t1001-imp-casign.t \
 	t1002-sign-munge.t \

--- a/t/t0101-cf-path-security.t
+++ b/t/t0101-cf-path-security.t
@@ -1,0 +1,112 @@
+#!/bin/sh
+#
+
+test_description='config file path security checks'
+
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+. `dirname $0`/sharness.sh
+
+if ! test_have_prereq SUDO; then
+   skip_all='skipping all cf security tests, sudo support not found'
+   test_done
+fi
+
+cf=${SHARNESS_BUILD_DIRECTORY}/t/src/cf
+sudo="sudo --preserve-env=FLUX_IMP_CONFIG_PATTERN"
+
+test_expect_success 'create temporary test directory in TMPDIR' '
+	CF_TESTDIR=$(mktemp -d -p ${TMPDIR:-/tmp}  \
+	             t0101-cf-security.XXXXXXXXXX) &&
+	FLUX_IMP_CONFIG_PATTERN="${CF_TESTDIR}/*.toml" &&
+	export CF_TESTDIR FLUX_IMP_CONFIG_PATTERN &&
+	cleanup "sudo rm $CF_TESTDIR/test.toml; sudo rmdir $CF_TESTDIR"
+'
+test_expect_success 'create valid test config' '
+	cat <<-EOF >${CF_TESTDIR}/test.toml
+	[tab]
+	id = 1
+	ok = "success"
+	value = "foo"
+	EOF
+'
+test_expect_success 'cf test program works' '
+	$cf tab.id &&
+	test $($cf tab.id) = 1
+'
+test_expect_success 'cf refuses to read config with insecure file ownership' '
+	name=bad-owner &&
+	test_must_fail $sudo $cf tab.ok 2>cf-${name}.err &&
+	test_debug "cat cf-${name}.err" &&
+	grep "${CF_TESTDIR}.*: insecure file ownership" cf-${name}.err
+'
+test_expect_success 'change ownership of test file' '
+	sudo chown root.root $CF_TESTDIR/*.toml
+'
+test_expect_success 'cf refuses to read config with insecure dir ownership' '
+	name=bad-dir-owner &&
+	test_must_fail $sudo $cf tab.ok 2>cf-${name}.err &&
+	test_debug "cat cf-${name}.err" &&
+	grep "${CF_TESTDIR}.*: Invalid ownership on parent" cf-${name}.err
+'
+test_expect_success 'change ownership of test dir' '
+	sudo chown root.root $CF_TESTDIR
+'
+test_expect_success 'cf now succeeds reading config' '
+	$sudo $cf tab.ok
+'
+test_expect_success 'cf reads config with current group write permissions' '
+	name=group-write &&
+	group=$(sudo id -n -g) &&
+	sudo chgrp $group $CF_TESTDIR/test.toml &&
+	sudo chmod 660 $CF_TESTDIR/test.toml &&
+	$sudo $cf tab.ok
+'
+test_expect_success 'cf refuses to read config w/ world write perms' '
+	name=world-write &&
+	sudo chmod 606 $CF_TESTDIR/test.toml &&
+	test_must_fail $sudo $cf tab.ok 2>cf-${name}.err &&
+	test_debug "cat cf-${name}.err" &&
+	grep "${CF_TESTDIR}.*: bad file permissions" cf-${name}.err
+'
+test_expect_success 'cf refuses to read config w/ other group write perms' '
+	name=other-group-write &&
+	sudo chgrp $(id -n -g) $CF_TESTDIR/test.toml &&
+	sudo chmod 660 $CF_TESTDIR/test.toml &&
+	test_must_fail $sudo $cf tab.ok 2>cf-${name}.err &&
+	test_debug "cat cf-${name}.err" &&
+	grep "${CF_TESTDIR}.*: bad file permissions" cf-${name}.err
+'
+test_expect_success 'reset file and directory permissions' '
+	sudo chgrp root $CF_TESTDIR/test.toml &&
+	sudo chmod 600 $CF_TESTDIR/test.toml &&
+	$sudo $cf tab.ok
+'
+test_expect_success 'cf refuses to read config w/ group writable directory' '
+	name=world-writeable-dir &&
+	sudo chgrp $(id -n -g) $CF_TESTDIR &&
+	sudo chmod 770 $CF_TESTDIR &&
+	test_must_fail $sudo $cf tab.ok 2>cf-${name}.err &&
+	test_debug "cat cf-${name}.err" &&
+	grep "${CF_TESTDIR}.*: parent directory is group-writeable" \
+	     cf-${name}.err
+'
+test_expect_success 'cf refuses to read config w/ world writable directory' '
+	name=world-writeable-dir &&
+	sudo chmod 707 $CF_TESTDIR &&
+	test_must_fail $sudo $cf tab.ok 2>cf-${name}.err &&
+	test_debug "cat cf-${name}.err" &&
+	grep "${CF_TESTDIR}.*: parent directory is world-writeable" \
+	     cf-${name}.err
+'
+test_expect_success 'cf allows group writable directory and sticky bit' '
+	sudo chgrp $(id -n -g) $CF_TESTDIR &&
+	sudo chmod 1770 $CF_TESTDIR &&
+	$sudo $cf tab.ok
+'
+test_expect_success 'cf allows world writable directory and sticky bit' '
+	name=world-writeable-sticky &&
+	sudo chmod 1707 $CF_TESTDIR &&
+	$sudo $cf tab.ok
+'
+test_done


### PR DESCRIPTION
As described in #101, TOML config files opened by the IMP should be checked for secure permissions and ownership. This PR adds a "paranoid" mode to `libutil/cf.c` which is enabled by default whenever the effective UID of the process is `0` or does not match the real UID (setuid mode). This mode can also be enabled by explicitly setting `enable-path-paranoia = true` in a `cf_t` object before calling one of the functions that reads from files (e.g. `cf_update_glob()`, `cf_update_file()`).

Paranoid mode can also be explicitly _disabled_ by setting `disable-path-paranoia = true`. This is only used (and only designed) for testing, where it is convenient to test the IMP running in sharness tests when reading from config files in the sharness trash directory with regular user ownership. Therefore, you will see that the test-only IMP `src/imp/flux-imp` is built with this setting enabled.

In order to allow setting these special configuration keys, a new `cf_update_pack(3)` function was introduced, which allows a config object to be created, some initial keys set, then configuration read from files. This is used to disable path-paranoia in the test IMP.

This concept also had to be extended to `flux_security_configure(3)`, which does not expose the `cf_t` interface. Therefore, two new flags were added which can be used with `flux_security_create(3)`:
```
enum {
    FLUX_SECURITY_DISABLE_PATH_PARANOIA     = 0x1,
    FLUX_SECURITY_FORCE_PATH_PARANOIA       = 0x2,
};
```

Only one of these flags may be used at a time. The test IMP, for example, uses `FLUX_SECURITY_DISABLE_PATH_PARANOIA` -- again, this flag should only be used in testing. Forcing path security checks, however, may actually be useful when a normal user process that is verifying signatures opens the config (root or setuid processes would get security checks by default)

You might be wondering why secure file and directory checks can't be the default. The problem is that we have several types of processes reading different types of configuration. For the IMP and perhaps (if required) the _system_ Flux instance, the reading process should ensure its configuration is secure. However, normal users should be able to use any signing or other config files they would like, whether they be system owned, or personal copies. Therefore it doesn't make sense to check the file and directory ownership and permissions in that case (there are just too many corner cases)

This is built on top of #121 to get the improved CI.