### PR TITLE
imp: add run subcommand

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -111,6 +111,8 @@ PKG_CHECK_MODULES([MUNGE], [munge], [], [])
 #  Other checks
 #
 AX_CODE_COVERAGE
+AS_IF([test x$enable_code_coverage = xyes], [
+    AC_DEFINE([CODE_COVERAGE_ENABLED], [1], [code coverage support])])
 
 AC_PKGCONFIG
 

--- a/src/imp/Makefile.am
+++ b/src/imp/Makefile.am
@@ -56,6 +56,7 @@ IMP_SOURCES = \
 	passwd.c \
 	passwd.h \
 	kill.c \
+	run.c \
 	exec/user.h \
 	exec/user.c \
 	exec/exec.c

--- a/src/imp/impcmd-list.c
+++ b/src/imp/impcmd-list.c
@@ -20,6 +20,8 @@ extern int imp_exec_unprivileged (struct imp_state *imp, struct kv *);
 extern int imp_exec_privileged (struct imp_state *imp, struct kv *);
 extern int imp_kill_unprivileged (struct imp_state *imp, struct kv *);
 extern int imp_kill_privileged (struct imp_state *imp, struct kv *);
+extern int imp_run_unprivileged (struct imp_state *imp, struct kv *);
+extern int imp_run_privileged (struct imp_state *imp, struct kv *);
 
 /*  List of supported imp commands, curated by hand for now.
  *   For each named command, the `child_fn` runs unprivileged and the
@@ -42,6 +44,9 @@ struct impcmd impcmd_list[] = {
     { "kill",
       imp_kill_unprivileged,
       imp_kill_privileged },
+    { "run",
+      imp_run_unprivileged,
+      imp_run_privileged },
 	{ NULL, NULL, NULL}
 };
 

--- a/src/imp/privsep.h
+++ b/src/imp/privsep.h
@@ -35,7 +35,7 @@ int privsep_wait (privsep_t *ps);
 
 /*  Free memory associated with privsep handle and close associated
  *   file descriptors to parent/child.
- */  
+ */
 void privsep_destroy (privsep_t *ps);
 
 /*  Return true if running in child.

--- a/src/imp/run.c
+++ b/src/imp/run.c
@@ -64,6 +64,10 @@
 
 extern char **environ;
 
+#if CODE_COVERAGE_ENABLED
+extern void __gcov_flush ();
+#endif
+
 static const cf_t *imp_run_lookup (struct imp_state *imp,
                                    const char *name)
 {
@@ -178,6 +182,9 @@ imp_run (const char *name,
 
     args[0] = path;
     args[1] = NULL;
+#if CODE_COVERAGE_ENABLED
+    __gcov_flush ();
+#endif
     execve (path, (char **) args, env);
 
     if (errno == EPERM || errno == EACCES)

--- a/src/imp/run.c
+++ b/src/imp/run.c
@@ -1,0 +1,338 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* flux-imp run
+ *
+ * PURPOSE:
+ *
+ *  Allow a non-privileged Flux instance to execute a configured
+ *   named executable in the [run] section (e.g. "prolog" or "epilog")
+ *
+ * OPERATION
+ *
+ *  Unprivileged child reads "command" requested to execute on command line,
+ *   and any allowed environment variables and sends kv struct to parent
+ *
+ *  Lookup configuration for "command"
+ *    - ensure calling user is allowed to execute "command"
+ *    - set absolute path for command
+ *    - capture allowed environment variables based on allowed-environment
+ *
+ *  Environment variables set by IMP:
+ *  - FLUX_OWNER_USERID - uid of the user running the IMP
+ *  - PATH - "/usr/sbin:/usr/bin:/sbin:/bin"
+ *  - HOME
+ *  - USER
+ *
+ *  - switch uid and gid to effective uid gid
+ *
+ *  - wait for child to terminate successfully
+ *
+ *  - execute command
+ */
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <errno.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <pwd.h>
+#include <signal.h>
+
+#include "src/libutil/kv.h"
+#include "src/libutil/path.h"
+
+#include "imp_log.h"
+#include "imp_state.h"
+#include "impcmd.h"
+#include "privsep.h"
+
+extern char **environ;
+
+static const cf_t *imp_run_lookup (struct imp_state *imp,
+                                   const char *name)
+{
+    struct path_error error;
+    const char *path;
+    const cf_t *cf;
+    const cf_t *run = cf_get_in (imp->conf, "run");
+
+    /*  Check for [run.name] configuration table:
+     */
+    if (!run || !(cf = cf_get_in (run, name)))
+        imp_die (1, "run: %s: no configuration found", name);
+
+    /*  Check for required members of [run.name]:
+     *   - 'path' must exist and be an absolute path
+     */
+    if (!(path = cf_string (cf_get_in (cf, "path")))
+        || path[0] == '\0'
+        || path[0] != '/')
+        imp_die (1, "run: %s: path is missing or invalid", name);
+
+    if (!path_is_secure (path, &error))
+        imp_die (1, "run: %s: %s", path, error.text);
+
+    return cf;
+}
+
+static bool run_user_allowed (const cf_t *cf_run)
+{
+    struct passwd *pwd;
+
+    if (!(pwd = getpwuid (getuid ())) || !pwd->pw_name)
+        imp_die (1, "Unable to lookup user");
+
+    return cf_array_contains (cf_get_in (cf_run, "allowed-users"),
+                              pwd->pw_name);
+}
+
+static bool run_env_var_allowed (const cf_t *allowed_env,
+                                 const char *name)
+{
+    if (strcmp (name, "FLUX_JOB_ID") == 0
+        || strcmp (name, "FLUX_JOB_USERID") == 0)
+        return true;
+    return cf_array_contains_match (allowed_env, name);
+}
+
+/*  Return a kv structure with the environment for this run command.
+ */
+static struct kv *get_run_env (struct kv *kv, const cf_t *allowed_env)
+{
+    struct kv *kv_env;
+    const char *var = NULL;
+
+    if (!(kv_env = kv_split (kv, "IMP_RUN_ENV_")))
+        return NULL;
+
+    while ((var = kv_next (kv_env, var))) {
+        if (!run_env_var_allowed (allowed_env, var))
+            kv_delete (kv_env, var);
+    }
+
+    /*  Capture uid that ran the imp as the "owner" */
+    if (kv_put (kv_env,
+                "FLUX_OWNER_USERID",
+                KV_INT64,
+                (int64_t) getuid()) < 0)
+        imp_die (1, "failed to put FLUX_IMP_USERID in environment");
+
+    return kv_env;
+}
+
+static void __attribute__((noreturn))
+imp_run (const char *name,
+         const cf_t *run_cf,
+         struct kv *kv_env)
+{
+    const char *path;
+    struct passwd *pwd;
+    char **env;
+    const char *args[2];
+    int exit_code;
+
+    if (!(path = cf_string (cf_get_in (run_cf, "path")))
+        || path[0] != '/')
+        imp_die (1, "run: %s: invalid path", name);
+
+    if (path[0] != '/')
+        imp_die (1, "run %s: relative path not allowed", name);
+
+    /*  Get passwd entry for current user to set HOME and USER */
+    if (!(pwd = getpwuid (getuid ())))
+        imp_die (1, "run: failed to find target user");
+
+    /*  Set HOME and USER */
+    if (kv_put (kv_env, "HOME", KV_STRING, pwd->pw_dir) < 0
+        || kv_put (kv_env, "USER", KV_STRING, pwd->pw_name) < 0)
+        imp_die (1, "run: failed to set HOME and USER in environment");
+
+    /*  Set PATH to a sane default */
+    if (kv_put (kv_env,
+                "PATH",
+                KV_STRING,
+                "/usr/sbin:/usr/bin:/sbin:/bin") < 0)
+        imp_die (1, "failed to put default PATH in environment");
+
+    if (kv_expand_environ (kv_env, &env) < 0)
+        imp_die (1, "Unable to set %s environment", name);
+
+    if (chdir ("/") < 0)
+        imp_die (1, "run: failed to chdir to /");
+
+    args[0] = path;
+    args[1] = NULL;
+    execve (path, (char **) args, env);
+
+    if (errno == EPERM || errno == EACCES)
+        exit_code = 126;
+    else
+        exit_code = 127;
+
+    imp_die (exit_code, "%s: %s", path, strerror (errno));
+}
+
+
+/*
+ *  Read command to run from privsep pipe
+ *  Check if user is allowed to run command
+ */
+int imp_run_privileged (struct imp_state *imp,
+                        struct kv *kv)
+{
+    struct kv *kv_env;
+    const char *name;
+    const cf_t *cf_run;
+
+    /*  Nullify environment. The environment for the target command
+     *   will be set explicitly in get_run_env() from variables passed
+     *   by the unprivileged child in struct kv.
+     */
+    environ = NULL;
+
+
+    if (privsep_wait (imp->ps) < 0)
+        imp_die (1, "run: unprivileged process exited abnormally");
+
+    /*  Get command to run as sent by child
+     */
+    if (kv_get (kv, "command", KV_STRING, &name) < 0
+        || name[0] == '\0')
+        imp_die (1, "run: command required");
+
+    /*  Ensure requesting user is allowed to run this command
+     */
+    cf_run = imp_run_lookup (imp, name);
+    if (!run_user_allowed (cf_run))
+        imp_die (1, "run: permission denied");
+
+    kv_env = get_run_env (kv, cf_get_in (cf_run, "allowed-environment"));
+    if (!kv_env)
+        imp_die (1, "run: error processing command environment");
+
+    if (setuid (geteuid()) < 0
+        || setgid (getegid()) < 0)
+        imp_die (1, "setuid: %s", strerror (errno));
+
+    imp_run (name, cf_run, kv_env);
+
+    return 0;
+}
+
+/*  Put all environment variables that match any entry in allowed_env
+ *   into `kv` as `IMP_RUN_ENV_${name}` for later inclusion in final
+ *   environment of run command by privileged parent process.
+ */
+static void imp_run_kv_putenv (struct kv *kv, const cf_t *allowed_env)
+{
+    char **env = environ;
+    char *p;
+    char name[129];
+
+    while (*env != NULL) {
+        if ((p = strchr (*env, '='))) {
+            size_t namelen = p - *env;
+
+            /*  Skip environment variables with excessively long names
+             */
+            if (namelen < sizeof (name)) {
+
+                /*  We know env var name will fit into name[] since length
+                 *   has already been checked. Use memcpy() and explicit
+                 *   NUL termination:
+                 */
+                memcpy (name, *env, namelen);
+                name[namelen] = '\0';
+
+                /*  If environment variable is allowed, create new 'name'
+                 *   with IMP_RUN_ENV_ prepended so the environment variable
+                 *   list can be split out by parent with kv_split()
+                 */
+                if (run_env_var_allowed (allowed_env, name)) {
+                    /*  We know name is <= 128 characters, add length
+                     *   of string "IMP_RUN_ENV_" to `var` to ensure there
+                     *   is space for the prepended kv key. Then it is
+                     *   safe to use sprintf(3).
+                     */
+                    char key[129 + 12];
+                    sprintf (key, "IMP_RUN_ENV_%s", name);
+                    kv_put (kv, key, KV_STRING, p+1);
+                }
+            }
+        }
+        env++;
+    }
+}
+
+static void imp_run_put_kv (const char *name,
+                            const cf_t *cf_run,
+                            struct kv *kv)
+{
+    const cf_t *allowed_env;
+
+    /*  Send command to parent
+     */
+    if (kv_put (kv, "command", KV_STRING, name) < 0)
+        imp_die (1, "run: failed to send command to parent");
+
+    /*  Pass allowed current environment as IMP_RUN_ENV_*
+     */
+    if ((allowed_env = cf_get_in (cf_run, "allowed-environment")))
+        imp_run_kv_putenv (kv, allowed_env);
+}
+
+int imp_run_unprivileged (struct imp_state *imp, struct kv *kv)
+{
+    const char *name;
+    const cf_t *cf_run;
+    struct kv *kv_env;
+
+   /*  Ensure a command name to run was given on command line
+     */
+   if (imp->argc < 3
+        || !(name = imp->argv[2])
+        || name[0] == '\0')
+        imp_die (1, "run: nothing to run");
+
+    cf_run = imp_run_lookup (imp, imp->argv[2]);
+
+    imp_run_put_kv (name, cf_run, kv);
+
+    if (imp->ps) {
+        if (privsep_write_kv (imp->ps, kv) < 0)
+            imp_die (1, "run: failed to communicate with privsep parent");
+        exit (0);
+    }
+
+    /*  Unprivileged imp run for testing
+     */
+
+    /*  Ensure user is allowed for parity with privileged `flux-imp run`:
+     */
+    if (!run_user_allowed (cf_run))
+        imp_die (1, "run: permission denied");
+
+    kv_env = get_run_env (kv, cf_get_in (cf_run, "allowed-environment"));
+    imp_run (imp->argv[2], cf_run, kv_env);
+
+    return 0;
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/libutil/Makefile.am
+++ b/src/libutil/Makefile.am
@@ -32,7 +32,9 @@ libutil_la_SOURCES = \
 	aux.c \
 	aux.h \
 	strlcpy.c \
-	strlcpy.h
+	strlcpy.h \
+	path.c \
+	path.h
 
 TESTS = \
 	test_hash.t \

--- a/src/libutil/Makefile.am
+++ b/src/libutil/Makefile.am
@@ -42,7 +42,8 @@ TESTS = \
 	test_cf.t \
 	test_kv.t \
 	test_sha256.t \
-	test_aux.t
+	test_aux.t \
+	test_path.t
 
 test_ldadd = \
 	$(top_builddir)/src/libutil/libutil.la \
@@ -83,3 +84,7 @@ test_sha256_t_CPPFLAGS = $(test_cppflags)
 test_aux_t_SOURCES = test/aux.c
 test_aux_t_LDADD = $(test_ldadd)
 test_aux_t_CPPFLAGS = $(test_cppflags)
+
+test_path_t_SOURCES = test/path.c
+test_path_t_LDADD = $(test_ldadd)
+test_path_t_CPPFLAGS = $(test_cppflags)

--- a/src/libutil/cf.c
+++ b/src/libutil/cf.c
@@ -18,6 +18,7 @@
 #include <string.h>
 #include <libgen.h>
 #include <glob.h>
+#include <fnmatch.h>
 #include <jansson.h>
 
 #include "src/libtomlc99/toml.h"
@@ -209,6 +210,23 @@ bool cf_array_contains (const cf_t *cf, const char *str)
             const cf_t *entry = cf_get_at (cf, i);
             if (cf_typeof (entry) == CF_STRING
                 && strcmp (cf_string (entry), str) == 0)
+                return true;
+        }
+    }
+    return false;
+}
+
+/*  Return true if 'str' matches any glob(7) pattern in cf array 'cf'.
+ *  False if array is NULL or is zero length, or does not match any pattern.
+ */
+bool cf_array_contains_match (const cf_t *cf, const char *str)
+{
+    int size;
+    if (str && cf && (size = cf_array_size (cf)) > 0) {
+        for (int i = 0; i < size; i++) {
+            const cf_t *entry = cf_get_at (cf, i);
+            if (cf_typeof (entry) == CF_STRING
+                && fnmatch (cf_string (entry), str, 0) == 0)
                 return true;
         }
     }

--- a/src/libutil/cf.h
+++ b/src/libutil/cf.h
@@ -97,6 +97,10 @@ int cf_array_size (const cf_t *cf);
  */
 bool cf_array_contains (const cf_t *cf, const char *str);
 
+/* Return true if array contains a pattern that matches str
+ */
+bool cf_array_contains_match (const cf_t *cf, const char *str);
+
 /* Update table 'cf' with info parsed from TOML 'buf' or 'filename'.
  * On success return 0.  On failure, return -1 with errno set.
  * If error is non-NULL, write error description there.

--- a/src/libutil/kv.h
+++ b/src/libutil/kv.h
@@ -90,6 +90,12 @@ int kv_encode (const struct kv *kv, const char **buf, int *len);
  */
 struct kv *kv_decode (const char *buf, int len);
 
+/* Return an environment constructed from the struct kv.
+ */
+int kv_expand_environ (const struct kv *kv, char ***envp);
+
+void kv_environ_destroy (char ***envp);
+
 /* Iteration example:
  *
  *   const char *key = NULL;

--- a/src/libutil/path.c
+++ b/src/libutil/path.c
@@ -1,0 +1,135 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
+#include <stdio.h>
+#include <libgen.h>
+#include <stdarg.h>
+#include <string.h>
+#include <errno.h>
+#include <limits.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#include "path.h"
+#include "strlcpy.h"
+
+static void __attribute__ ((format (printf, 2, 3)))
+errprintf (struct path_error *error, const char *fmt, ...)
+{
+    va_list ap;
+    int saved_errno = errno;
+
+    if (error) {
+        memset (error, 0, sizeof (*error));
+        va_start (ap, fmt);
+        (void)vsnprintf (error->text, sizeof (error->text), fmt, ap);
+        va_end (ap);
+    }
+    errno = saved_errno;
+}
+
+static bool parent_dir_is_secure (const char *path,
+                                  struct path_error *error)
+{
+    struct stat st;
+    char buf [PATH_MAX + 1];
+    char *dir;
+
+    if (strlcpy (buf, path, sizeof (buf)) >= sizeof (buf)
+        || !(dir = dirname (buf))) {
+        errno = ENAMETOOLONG;
+        errprintf (error, "Unable to get dirname");
+        return false;
+    }
+    if (lstat (dir, &st) < 0) {
+        errprintf (error, "Unable to stat parent directory");
+        return false;
+    }
+    if (!S_ISDIR (st.st_mode)) {
+        errprintf (error,
+                   "Unable to check parent directory. Unexpected file type");
+        errno = EINVAL;
+        return false;
+    }
+    if ((st.st_uid != 0)
+        && (st.st_uid != geteuid ())) {
+        errprintf (error,
+                   "Invalid ownership on parent directory");
+        errno = EINVAL;
+        return false;
+    }
+    if (st.st_gid != 0
+        && st.st_gid != getegid ()
+        && (st.st_mode & S_IWGRP)
+        && !(st.st_mode & S_ISVTX)) {
+        errprintf (error,
+                   "parent directory is group-writeable without sticky bit");
+        errno = EINVAL;
+        return false;
+    }
+    if ((st.st_mode & S_IWOTH)
+        && !(st.st_mode & S_ISVTX)) {
+        errprintf (error,
+                   "parent directory is world-writeable without sticky bit");
+        errno = EINVAL;
+        return false;
+    }
+    errno = 0;
+    return true;
+}
+
+bool path_is_secure (const char *path, struct path_error *error)
+{
+    int is_symlink = 0;
+    struct stat st;
+
+    if ((path == NULL) || (*path == '\0')) {
+        errprintf (error, "Filename not defined");
+        return false;
+    }
+    if ((lstat (path, &st) == 0) && S_ISLNK (st.st_mode) == 1)
+        is_symlink = 1;
+    if (stat (path, &st) < 0) {
+        errprintf (error, "%s", strerror (errno));
+        return false;
+    }
+    if (!S_ISREG (st.st_mode)) {
+        errprintf (error, "File is not a regular file");
+        errno = EINVAL;
+        return false;
+    }
+    if (is_symlink) {
+        errprintf (error, "symbolic link");
+        errno = EINVAL;
+        return false;
+    }
+    if (st.st_uid != 0 && st.st_uid != geteuid ()) {
+        errprintf (error, "insecure file ownership");
+        errno = EINVAL;
+        return false;
+    }
+    if ((st.st_mode & S_IWOTH)
+        || ((st.st_mode & S_IWGRP) && (st.st_gid != getegid ()))) {
+        errprintf (error,
+                   "bad file permissions (%04o)",
+                   (st.st_mode & ~S_IFMT));
+        errno = EINVAL;
+        return false;
+    }
+    return parent_dir_is_secure (path, error);
+}
+
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/libutil/path.h
+++ b/src/libutil/path.h
@@ -1,0 +1,30 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _UTIL_PATH_H
+#define _UTIL_PATH_H
+
+#include <stdbool.h>
+
+struct path_error {
+    char text [128];
+};
+
+/*  Return true if file at `path` and its parent directory have secure
+ *   ownership and permissions. If false, error->text will be filled
+ *   in with a textual reason the file is not secure.
+ */
+bool path_is_secure (const char *path, struct path_error *error);
+
+#endif /* !_UTIL_PATH_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/libutil/test/cf.c
+++ b/src/libutil/test/cf.c
@@ -547,7 +547,7 @@ void test_update_glob (void)
 
     snprintf (p, sizeof (p), "%s/*.toml", dir);
 
-    ok (cf_update_glob (cf, p, &error) == 3, 
+    ok (cf_update_glob (cf, p, &error) == 3,
         "cf_update_glob successfully parsed 3 files");
 
     /* Check the cf object against 'opts'.

--- a/src/libutil/test/cf.c
+++ b/src/libutil/test/cf.c
@@ -739,6 +739,45 @@ void test_array_contains (void)
     cf_destroy (tab);
 }
 
+void test_array_contains_match (void)
+{
+    const char *array = "array = [ \"foo\", \"bar*\", \"baz?\" ]";
+    cf_t *tab;
+    const cf_t *cf;
+
+    if (!(tab = cf_create ()))
+        BAIL_OUT ("cf_create");
+    if (cf_update (tab, array, strlen (array), NULL) < 0)
+        BAIL_OUT ("cf_update");
+
+    cf = cf_get_in (tab, "array");
+
+    ok (cf_array_contains_match (NULL, NULL) == false,
+        "cf_array_contains_match (NULL, NULL) returns false");
+    ok (cf_array_contains_match (NULL, "barbaric") == false,
+        "cf_array_contains_match (NULL, \"barbaric\") returns false");
+    ok (cf_array_contains_match (cf, "") == false,
+        "cf_array_contains_match (cf, \"\") returns false");
+    ok (cf_array_contains_match (cf, "foobar") == false,
+        "cf_array_contains_match (cf, \"foobar\") returns false");
+    ok (cf_array_contains_match (cf, "foobar") == false,
+        "cf_array_contains_match (cf, \"foobar\") returns false");
+    ok (cf_array_contains_match (cf, "foobar") == false,
+        "cf_array_contains_match (cf, \"foobar\") returns false");
+    ok (cf_array_contains_match (cf, "bazaar") == false,
+        "cf_array_contains_match (cf, \"bazaar\") returns false");
+
+    ok (cf_array_contains_match (cf, "foo"),
+        "cf_array_contains_match (cf, \"foo\") returns true");
+    ok (cf_array_contains_match (cf, "bar"),
+        "cf_array_contains_match (cf, \"bar\") returns true");
+    ok (cf_array_contains_match (cf, "bar-none"),
+        "cf_array_contains_match (cf, \"bar-none\") returns true");
+    ok (cf_array_contains_match (cf, "baz1"),
+        "cf_array_contains_match (cf, \"baz1\") returns true");
+
+    cf_destroy (tab);
+}
 
 int main (int argc, char *argv[])
 {
@@ -753,6 +792,7 @@ int main (int argc, char *argv[])
     test_path_paranoia ();
     test_check ();
     test_array_contains ();
+    test_array_contains_match ();
 
     done_testing ();
 }

--- a/src/libutil/test/path.c
+++ b/src/libutil/test/path.c
@@ -1,0 +1,129 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <limits.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+
+#include "src/libtap/tap.h"
+#include "path.h"
+
+static void
+create_test_dir (const char *dir, char *prefix, char *path, size_t pathlen)
+{
+    snprintf (path, pathlen, "%s/%s.XXXXXX", dir ? dir : "/tmp", prefix);
+    if (!mkdtemp (path))
+        BAIL_OUT ("mkdtemp: %s: %s", path, strerror (errno));
+}
+
+static void
+create_test_file (const char *dir, char *prefix, char *path, size_t pathlen,
+                  const char *contents)
+{
+    int fd;
+    snprintf (path, pathlen, "%s/%s.XXXXXX.toml", dir ? dir : "/tmp", prefix);
+    fd = mkstemps (path, 5);
+    if (fd < 0)
+        BAIL_OUT ("mkstemp %s: %s", path, strerror (errno));
+    if (write (fd, contents, strlen (contents)) != strlen (contents))
+        BAIL_OUT ("write %s: %s", path, strerror (errno));
+    if (close (fd) < 0)
+        BAIL_OUT ("close %s: %s", path, strerror (errno));
+}
+
+void test_path_is_secure (void)
+{
+    char dir[PATH_MAX + 1];
+    char path[PATH_MAX + 1 + 10];  /* padding for "/bad1.toml" */
+    char spath[PATH_MAX + 1];
+    struct path_error error;
+
+    create_test_dir (getenv ("TMPDIR"), "cf-test", dir, sizeof (dir));
+    snprintf (path, sizeof (path), "%s/bad1.toml", dir);
+
+    memset (&error, 0, sizeof (error));
+
+    /*  Test non-regular file */
+    if (mknod (path, S_IFIFO|0700, 0) < 0)
+        BAIL_OUT ("mknod: %s: %s", path, strerror (errno));
+    ok (!path_is_secure (path, &error) && errno == EINVAL,
+        "path_is_secure fails on non-regular file: %s",
+        error.text);
+    if (unlink (path) < 0)
+        BAIL_OUT ("unlink %s: %s", path, strerror (errno));
+
+    /*  Test symlink */
+    memset (&error, 0, sizeof (error));
+    create_test_file (getenv ("TMPDIR"), "linky", spath, sizeof (spath), "foo");
+
+    if (symlink (spath, path) < 0)
+        BAIL_OUT ("link %s %s: %s", spath, path, strerror (errno));
+    ok (!path_is_secure (path, &error) && errno == EINVAL,
+        "path_is_secure fails on symlink: %s",
+        error.text);
+    if (unlink (path) < 0)
+        BAIL_OUT ("unlink %s: %s", path, strerror (errno));
+    if (unlink (spath) < 0)
+        BAIL_OUT ("unlink %s: %s", path, strerror (errno));
+
+    /*  Test ok permissions */
+    memset (&error, 0, sizeof (error));
+    create_test_file (dir, "good", path, sizeof (path), "bar");
+    if (chmod (path, 0600) < 0)
+        BAIL_OUT ("chmod %s: %s", path, strerror (errno));
+    ok (path_is_secure (path, &error),
+        "path_is_secure works on file with perms 0600");
+
+    /*  Test bad permissions */
+    memset (&error, 0, sizeof (error));
+    if (chmod (path, 0646) < 0)
+        BAIL_OUT ("chmod %s: %s", path, strerror (errno));
+    ok (!path_is_secure (path, &error) && errno == EINVAL,
+        "path_is_secure fails on world writeable file: %s",
+        error.text);
+
+    if (unlink (path) < 0)
+        BAIL_OUT ("unlink %s: %s", path, strerror (errno));
+    if (rmdir (dir) < 0)
+        BAIL_OUT ("rmdir %s: %s", path, strerror (errno));
+}
+
+static void test_bad_params ()
+{
+    ok (!path_is_secure (NULL, NULL),
+        "path_is_secure() fails on NULL path");
+    ok (!path_is_secure ("", NULL),
+        "path_is_secure() fails on empty path");
+    ok (!path_is_secure ("/noexist", NULL),
+        "path_is_secure() fails on nonexistent path");
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    test_bad_params ();
+    test_path_is_secure ();
+
+    done_testing ();
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -21,7 +21,8 @@ TESTSCRIPTS = \
 	t1002-sign-munge.t \
 	t1003-sign-curve.t \
 	t2000-imp-exec.t \
-	t2001-imp-kill.t
+	t2001-imp-kill.t \
+	t2002-imp-run.t
 
 TESTS = \
 	$(TESTSCRIPTS)

--- a/t/t2002-imp-run.t
+++ b/t/t2002-imp-run.t
@@ -1,0 +1,184 @@
+#!/bin/sh
+#
+
+test_description='IMP run basic functionality test
+
+Basic flux-imp run functionality and corner case handing tests
+'
+
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+. `dirname $0`/sharness.sh
+
+flux_imp=${SHARNESS_BUILD_DIRECTORY}/src/imp/flux-imp
+sign=${SHARNESS_BUILD_DIRECTORY}/t/src/sign
+
+echo "# Using ${flux_imp}"
+
+test_expect_success 'flux-imp run returns error when run with no args' '
+	test_must_fail $flux_imp run
+'
+test_expect_success 'flux-imp run returns error when run with invalid cmd' '
+	test_must_fail $flux_imp run foo
+'
+test_expect_success 'create configs for flux-imp exec and signer' '
+	TESTDIR=$(mktemp -d -p ${TMPDIR:-/tmp}  \
+                  t2002-imp-run-testdir.XXXXXXXXXX) &&
+	cat <<-EOF >$TESTDIR/test.toml
+	allow-sudo = true
+	[sign]
+	max-ttl = 30
+	default-type = "none"
+	allowed-types = [ "none" ]
+	[run.test]
+	allowed-users = [ "$(whoami)" ]
+	allowed-environment = [ "TEST_*", "EXACT_MATCH" ]
+	path = "$TESTDIR/test.sh"
+	[run.nopath]
+	allowed-users = [ "$(whoami)" ]
+	[run.noexec]
+	allowed-users = [ "$(whoami)" ]
+	path = "$TESTDIR/noexec.sh"
+	[run.badpath]
+	allowed-users = [ "$(whoami)" ]
+	path = "test.sh"
+	[run.notallowed]
+	allowed-users = [ ]
+	path = "$TESTDIR/test.sh"
+	[run.allowednotset]
+	path = "$TESTDIR/test.sh"
+	EOF
+'
+test_expect_success 'create test shell scripts' '
+	cat <<-EOF >$TESTDIR/test.sh &&
+	#!/bin/sh
+	echo uid=\$(id -u)
+	echo ruid=\$(id -r -u)
+	echo gid=\$(id -g)
+	echo rgid=\$(id -r -g)
+	env
+	EOF
+	chmod +x $TESTDIR/test.sh &&
+	touch $TESTDIR/noexec.sh
+'
+test_expect_success SUDO 'set appropriate permissions for sudo based tests' '
+	$SUDO chown root.root $TESTDIR $TESTDIR/* &&
+	$SUDO chmod 755 $TESTDIR $TESTDIR/test.sh &&
+	$SUDO chmod 644 $TESTDIR/test.toml
+'
+
+cat <<EOF >failure-tests.txt
+nopath:run path not set:path is missing or invalid
+noexec:path not executable:Permission denied
+badpath:path is missing or invalid
+notallowed:user not allowed:permission denied
+allowednotset:allowed-users not set:permission denied
+nocommand:no such command:no configuration found
+EOF
+export FLUX_IMP_CONFIG_PATTERN=${TESTDIR}/test.toml
+while read line; do
+    name=$(echo $line | awk -F: '{print $1}')
+    desc=$(echo $line | awk -F: '{print $2}')
+    err=$(echo $line  | awk -F: '{print $3}')
+    test_expect_success "flux-imp run must fail: $desc" '
+	test_must_fail $flux_imp run $name 2> $name.err &&
+	test_debug "cat $name.err" &&
+	grep "$err" $name.err
+    '
+done <failure-tests.txt
+
+#  Now run same set of tests under sudo if available:
+while read line; do
+    name=$(echo $line | awk -F: '{print $1}')
+    desc=$(echo $line | awk -F: '{print $2}')
+    err=$(echo $line  | awk -F: '{print $3}')
+    test_expect_success SUDO "flux-imp run must fail: $desc" '
+	test_must_fail $SUDO FLUX_IMP_CONFIG_PATTERN=$TESTDIR/test.toml \
+	    $flux_imp run $name 2> $name-sudo.err &&
+	test_debug "cat $name.err" &&
+	grep "$err" $name-sudo.err
+    '
+done <failure-tests.txt
+
+test_expect_success 'flux-imp run bails out with no configuration' '
+	(
+	export FLUX_IMP_CONFIG_PATTERN= &&
+	test_must_fail $flux_imp run test
+	)
+'
+test_expect_success SUDO 'flux-imp run: works under sudo' '
+	export SUDO="$SUDO --preserve-env=FLUX_IMP_CONFIG_PATTERN" &&
+	$SUDO --preserve-env=FLUX_IMP_CONFIG_PATTERN \
+	    $flux_imp run test >sudo-run.out 2>&1 &&
+	test_debug "cat sudo-run.out" &&
+	grep ^FLUX_OWNER_USERID=$(id -u) sudo-run.out &&
+	grep ^uid=0 sudo-run.out &&
+	grep ^gid=0 sudo-run.out &&
+	grep ^ruid=0 sudo-run.out &&
+	grep ^rgid=0 sudo-run.out &&
+	grep ^USER=root sudo-run.out
+'
+test_expect_success 'flux-imp run sets FLUX_OWNER_USERID' '
+	$flux_imp run test >run-test.out 2>&1 &&
+	test_debug "cat run-test.out" &&
+	grep ^FLUX_OWNER_USERID=$(id -u) run-test.out
+'
+test_expect_success 'flux-imp run filters environment' '
+	TEST_VAR=foo \
+	TEST_VAR_BAR=xxx \
+	EXACT_MATCH=yes \
+	EXACT_MATCH_BAD=xxx \
+	FOO=bar \
+	    $flux_imp run test >run-test-env.out &&
+	grep ^TEST_VAR=foo run-test-env.out &&
+	grep ^TEST_VAR_BAR run-test-env.out &&
+	grep ^EXACT_MATCH=yes run-test-env.out &&
+	test_expect_code 1 grep ^FOO=bar run-test-env.out &&
+	test_expect_code 1 grep ^EXACT_MATCH_BAD run-test-env.out
+'
+test_expect_success 'flux-imp run allows FLUX_JOB_ID and FLUX_JOB_USERID' '
+	FLUX_JOB_ID=1234 \
+	FLUX_JOB_USERID=$(id -u) \
+	    $flux_imp run test >run-test-uid-jobid.out &&
+	grep ^FLUX_JOB_ID=1234 run-test-uid-jobid.out &&
+	grep ^FLUX_JOB_USERID=$(id -u) run-test-uid-jobid.out
+'
+test_expect_success SUDO 'flux-imp run filters environment under sudo' '
+	$SUDO -E TEST_VAR=foo -E FOO=bar \
+	    $flux_imp run test >sudo-run-test-env.out &&
+	grep ^TEST_VAR=foo sudo-run-test-env.out &&
+	test_expect_code 1 grep ^FOO=bar sudo-run-test-env.out
+'
+test_expect_success SUDO 'flux-imp run allows FLUX_JOB_ID and FLUX_JOB_USERID' '
+	$SUDO -E FLUX_JOB_ID=1234 -E FLUX_JOB_USERID=$(id -u) \
+	    $flux_imp run test >sudo-run-test-uid-jobid.out &&
+	grep ^FLUX_JOB_ID=1234 sudo-run-test-uid-jobid.out &&
+	grep ^FLUX_JOB_USERID=$(id -u) sudo-run-test-uid-jobid.out
+'
+test_expect_success SUDO 'flux-imp run will not run file with bad ownership' '
+	$SUDO chown $USER $TESTDIR/test.sh &&
+	test_must_fail $SUDO $flux_imp run test &&
+	$SUDO chown root $TESTDIR/test.sh
+'
+test_expect_success SUDO 'flux-imp run will not run file with bad perms' '
+	$SUDO chmod 775 $TESTDIR/test.sh &&
+	test_must_fail $SUDO $flux_imp run test &&
+	$SUDO chmod 755 $TESTDIR/test.sh
+'
+test_expect_success SUDO 'flux-imp run checks ownership of parent dir' '
+	$SUDO chown $USER $TESTDIR &&
+	test_must_fail $SUDO $flux_imp run test &&
+	$SUDO chown root $TESTDIR
+'
+test_expect_success SUDO 'flux-imp run checks permission of parent dir' '
+	$SUDO chmod 777 $TESTDIR &&
+	test_must_fail $SUDO $flux_imp run test &&
+	$SUDO chmod 755 $TESTDIR
+'
+test_expect_success SUDO 'cleanup test directory (sudo)' '
+	$SUDO rm $TESTDIR/* && $SUDO rmdir $TESTDIR
+'
+test_expect_success 'cleanup test directory' '
+	if test -d $TESTDIR; then rm -rf $TESTDIR; fi
+'
+test_done


### PR DESCRIPTION
As described in #120, the IMP will need to assist the Flux system instance with execution of job prolog and epilog scripts, which typically require elevated privileges.

Instead of adding separate `flux-imp prolog` and `flux-imp epilog` subcommands, this PR adds a new `run` subcommand to the IMP which is invoked like `flux-imp run COMMAND`. Commands to execute under the IMP `run` subcommand are added to the IMP configuration under a `run` table by name, e.g. `[run.prolog]` and `[run.epilog]`. Required keys in these run command tables include:

  * `path` - the path to the executable to run
  *  `allowed-users` - an array of usernames that are allowed to run this command, e.g. `[ "flux" ]`
  *  `allowed-environment` - an array of environment variables and/or `glob(7)` patterns which match environment variables that the IMP will propagate to the command. By default only `FLUX_JOB_ID` and `FLUX_JOB_USERID` are propagated.

(Edit: actually `allowed-environment` key is not required)

The only other environment variables set in the executed command include:

 - `FLUX_OWNER_USERID` - the UID which called `flux-imp run COMMAND`
 - `HOME` and `USER` -  set appropriately to the privileged user running `COMMAND` (since these variables are often assumed to be present in many scripts)
 - `PATH` is set explicitly to `/usr/sbin:/usr/bin:/sbin:/bin`

This will allow the Flux system instance, when properly configured, to execute `flux-imp run prolog` and `flux-imp run epilog`, leaving a facility in place to give Flux the ability to execute other work with root privileges later (e.g. `flux-imp run healthcheck` or similar)

Fixes #120