### PR TITLE
imp: support multiple arguments to job shell in exec

### DIFF
--- a/src/libutil/kv.h
+++ b/src/libutil/kv.h
@@ -94,7 +94,17 @@ struct kv *kv_decode (const char *buf, int len);
  */
 int kv_expand_environ (const struct kv *kv, char ***envp);
 
+/* Return an argv constructed from the struct kv.
+ */
+int kv_expand_argv (const struct kv *kv, char ***argvp);
+
+/* Return a struct kv encoded from argv array. Keys are string integers
+ *  starting at "0", e.g. "O", "1", "2", ...
+ */
+struct kv *kv_encode_argv (const char **argvp);
+
 void kv_environ_destroy (char ***envp);
+void kv_argv_destroy (char ***argvp);
 
 /* Iteration example:
  *

--- a/t/t2000-imp-exec.t
+++ b/t/t2000-imp-exec.t
@@ -135,4 +135,14 @@ test_expect_success SUDO 'flux-imp exec works under sudo' '
 	id -u > id-sudo.expected &&
         test_cmp id-sudo.expected id-sudo.out
 '
+test_expect_success SUDO 'flux-imp exec passes more than one argument to shell' '
+	( export FLUX_IMP_CONFIG_PATTERN=sign-none.toml  &&
+          fake_imp_input foo | \
+	    $SUDO FLUX_IMP_CONFIG_PATTERN=sign-none.toml \
+	      $flux_imp exec id --zero --user >id-sudo2.out
+        ) &&
+	test_debug "echo expecting uid=$(id -u), got $(cat -v id-sudo2.out)" &&
+	id --zero --user > id-sudo2.expected &&
+        test_cmp id-sudo2.expected id-sudo2.out
+'
 test_done


### PR DESCRIPTION
This PR addresses #127.

Instead of supporting only 1 argument, all arguments passed in the call the `flux-imp exec` are passed along to the job shell. This will allow the system instance to add extra options to the job shell based on configuration, e.g. a `--reconnect` option.

