### PR TITLE
doc: add flux_security_aux_set(3)

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -5,11 +5,13 @@ SUBDIRS = . test
 MAN3_FILES_PRIMARY = \
 	man3/flux_security_create.3 \
 	man3/flux_security_last_error.3 \
+	man3/flux_security_aux_set.3 \
 	man3/flux_sign_unwrap.3 \
 	man3/flux_sign_wrap.3
 MAN3_FILES_SECONDARY = \
 	man3/flux_security_destroy.3 \
 	man3/flux_security_last_errnum.3 \
+	man3/flux_security_aux_get.3 \
 	man3/flux_sign_unwrap_anymech.3 \
 	man3/flux_sign_wrap_as.3
 MAN3_FILES = $(MAN3_FILES_PRIMARY) $(MAN3_FILES_SECONDARY)

--- a/doc/man3/flux_security_aux_set.rst
+++ b/doc/man3/flux_security_aux_set.rst
@@ -1,0 +1,70 @@
+========================
+flux_security_aux_set(3)
+========================
+
+
+SYNOPSIS
+========
+
+::
+
+   #include <flux/security/context.h>
+
+   typedef void (*flux_security_free_f)(void *arg);
+
+   int flux_security_aux_set (flux_security_t *ctx,
+                              const char *name,
+                              void *data,
+                              flux_security_free_f destroy);
+
+   void *flux_security_aux_get (flux_security_t *ctx,
+                                const char *name);
+
+
+DESCRIPTION
+===========
+
+``flux_security_aux_set()`` attaches application-specific data to the parent
+object *ctx*. It stores *data* by key *name*, with optional destructor
+*destroy*. The destructor, if non-NULL, is called when the parent object is
+destroyed, or when *name* is overwritten by a new value. If *data* is NULL,
+the destructor for a previous value, if any is called, but no new value is
+stored. If *name* is NULL, *data* is stored anonymously.
+
+``flux_security_aux_get()`` retrieves application-specific data by *name*.
+If the data was stored anonymously, it cannot be retrieved.
+
+
+RETURN VALUE
+============
+
+``flux_security_aux_get()`` returns data on success, or NULL on failure,
+with errno set.
+
+``flux_security_aux_set()`` returns 0 on success, or -1 on failure, with
+errno set.
+
+
+ERRORS
+======
+
+EINVAL
+   Some arguments were invalid.
+
+ENOMEM
+   Out of memory.
+
+ENOENT
+   ``flux_security_aux_get()`` could not find an entry for *key*.
+
+
+RESOURCES
+=========
+
+Flux: http://flux-framework.org
+
+
+SEE ALSO
+========
+
+:man3:`flux_security_create`

--- a/doc/man3/flux_security_create.rst
+++ b/doc/man3/flux_security_create.rst
@@ -46,3 +46,9 @@ RESOURCES
 Flux: http://flux-framework.org
 
 RFC 15: Independent Minister of Privilege for Flux: The Security IMP: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_15.html
+
+
+SEE ALSO
+========
+
+:man3:`flux_security_last_error`

--- a/doc/man3/flux_security_create.rst
+++ b/doc/man3/flux_security_create.rst
@@ -8,6 +8,8 @@ SYNOPSIS
 
 ::
 
+   #include <flux/security/context.h>
+
    flux_security_t *flux_security_create (int flags);
 
    void flux_security_destroy (flux_security_t *ctx);

--- a/doc/man3/flux_security_last_error.rst
+++ b/doc/man3/flux_security_last_error.rst
@@ -8,6 +8,8 @@ SYNOPSIS
 
 ::
 
+   #include <flux/security/context.h>
+
    const char *flux_security_last_error (flux_security_t *ctx);
 
    int flux_security_last_errnum (flux_security_t *ctx);

--- a/doc/man3/flux_sign_unwrap.rst
+++ b/doc/man3/flux_sign_unwrap.rst
@@ -47,7 +47,7 @@ a NULL value.
 
 ``flux_sign_unwrap_anymech()`` is identical to ``flux_sign_unwrap()``, except
 that signature verification can succeed even if the mechanism is not one of
-the configured allowed types.
+the allowed types defined by :man5:`flux-config-security-sign`.
 
 
 RETURN VALUE

--- a/doc/man3/flux_sign_unwrap.rst
+++ b/doc/man3/flux_sign_unwrap.rst
@@ -8,6 +8,8 @@ SYNOPSIS
 
 ::
 
+   #include <flux/security/sign.h>
+
    enum {
        FLUX_SIGN_NOVERIFY = 1,
    };

--- a/doc/man3/flux_sign_wrap.rst
+++ b/doc/man3/flux_sign_wrap.rst
@@ -8,6 +8,8 @@ SYNOPSIS
 
 ::
 
+   #include <flux/security/sign.h>
+
    const char *flux_sign_wrap (flux_security_t *ctx,
                                const void *buf,
                                int len,

--- a/doc/man3/flux_sign_wrap.rst
+++ b/doc/man3/flux_sign_wrap.rst
@@ -29,10 +29,11 @@ DESCRIPTION
 suitable for unwrapping with :man3:`flux_sign_unwrap`.  The signing user is
 taken to be the userid returned by :linux:man2:`getuid`.  *ctx* is a Flux
 security context from :man3:`flux_security_create`.  *mech_type* selects the
-signing mechanism (NULL for the configured default).  The *flags* parameter
-must be set to zero.  The function returns a NULL terminated credential string
-that remains valid until ``flux_sign_wrap()`` is called again.  The caller
-should not attempt to free the credential.
+signing mechanism, and may be set to NULL to select the default defined
+by :man5:`flux-config-security-sign`.  The *flags* parameter must be set to
+zero.  The function returns a NULL terminated credential string that remains
+valid until ``flux_sign_wrap()`` is called again.  The caller should not
+attempt to free the credential.
 
 ``flux_sign_wrap_as()`` is identical to ``flux_sign_wrap()``, except the
 signing user may be explicitly specified with the *userid* parameter.

--- a/doc/man3/index.rst
+++ b/doc/man3/index.rst
@@ -9,3 +9,4 @@ man3
   flux_sign_wrap
   flux_sign_unwrap
   flux_security_last_error
+  flux_security_aux_set

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -25,6 +25,8 @@ man_pages = [
     ('man3/flux_security_create', 'flux_security_destroy', 'Destroy Flux security context', [author], 3),
     ('man3/flux_security_last_error', 'flux_security_last_error', 'Get last error string', [author], 3),
     ('man3/flux_security_last_error', 'flux_security_last_errnum', 'Get last error number', [author], 3),
+    ('man3/flux_security_aux_set', 'flux_security_aux_set', 'Attach data to security context', [author], 3),
+    ('man3/flux_security_aux_set', 'flux_security_aux_get', 'Retrieve data from security context', [author], 3),
     ('man5/flux-config-security', 'flux-config-security', 'Flux security configuration files', [author], 5),
     ('man5/flux-config-security-imp', 'flux-config-security-imp', 'configure Flux IMP behavior', [author], 5),
     ('man5/flux-config-security-sign', 'flux-config-security-sign', 'configure Flux security signing library', [author], 5),

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -22,7 +22,7 @@ man_pages = [
     ('man3/flux_sign_unwrap', 'flux_sign_unwrap', 'Unwrap signed credential', [author], 3),
     ('man3/flux_sign_unwrap', 'flux_sign_unwrap_anymech', 'Unwrap signed credential', [author], 3),
     ('man3/flux_security_create', 'flux_security_create', 'Create Flux security context', [author], 3),
-    ('man3/flux_security_create', 'flux_security_destroy', 'Create Flux security context', [author], 3),
+    ('man3/flux_security_create', 'flux_security_destroy', 'Destroy Flux security context', [author], 3),
     ('man3/flux_security_last_error', 'flux_security_last_error', 'Get last error string', [author], 3),
     ('man3/flux_security_last_error', 'flux_security_last_errnum', 'Get last error number', [author], 3),
     ('man5/flux-config-security', 'flux-config-security', 'Flux security configuration files', [author], 5),


### PR DESCRIPTION
This adds a man page for `flux_security_aux_set()` and `flux_security_aux_get()`, and fills in some gaps in the recently added signing man pages.