### PR TITLE
doc: fix manpage typo

### DIFF
--- a/doc/man5/flux-config-security-imp.rst
+++ b/doc/man5/flux-config-security-imp.rst
@@ -118,4 +118,4 @@ RFC 15: Independent Minister of Privilege for Flux: The Security IMP: https://fl
 SEE ALSO
 ========
 
-:man5:`flux-security-config`, :core:man5:`flux-config`, :man8:`flux-imp`
+:man5:`flux-config-security`, :core:man5:`flux-config`, :man8:`flux-imp`


### PR DESCRIPTION
Problem: The flux-config-security manpage was typoed as
flux-security-config.

Fix the typo.