### PR TITLE
imp: fix kill functionality with unified cgroups hierarchy

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -118,6 +118,9 @@ LT_INIT
 #  Checks for header files
 #
 AC_HEADER_STDC
+AC_CHECK_HEADERS( \
+  [linux/magic.h] \
+)
 
 #
 #  Checks for packages

--- a/src/imp/kill.c
+++ b/src/imp/kill.c
@@ -22,9 +22,13 @@
  *  setting directs systemd to delegate ownership of the flux.service
  *  cgroup to the user under which Flux is runnng, e.g. "flux".
  *
- *  Since all jobs will executed within this cgroup or a child,
+ *  Since all Flux jobs will be executed within this cgroup or a child,
  *  flux-imp kill may authorize signal delivery to any task where
- *  the tasks cgroup is owned by the requesting user.
+ *  the task's cgroup is owned by the requesting user.
+ *
+ *  These assumptions hold even if Flux is using a systemd user instance
+ *  to launch multi-user jobs, since the systemd instance spawning jobs
+ *  will also be running under a delegated cgroup.
  *
  */
 

--- a/t/t2001-imp-kill.t
+++ b/t/t2001-imp-kill.t
@@ -52,7 +52,13 @@ test_expect_success SUDO 'flux-imp kill: sudo: user must be in allowed-shells' '
 '
 
 test "$chain_lint" = "t" || test_set_prereq NO_CHAIN_LINT
-test -d /sys/fs/cgroup/systemd && test_set_prereq SYSTEMD_CGROUP
+
+
+test "$(stat -fc %T /sys/fs/cgroup 2>/dev/null)" = "cgroup2fs" \
+  -o "$(stat -fc %T /sys/fs/cgroup/unified 2>/dev/null)" = "cgroup2fs" \
+  -o "$(stat -fc %T /sys/fs/cgroup/systemd 2>/dev/null)" = "cgroup2fs" \
+  -o "$(stat -fc %T /sys/fs/cgroup/systemd 2>/dev/null)" = "cgroupfs" \
+     && test_set_prereq SYSTEMD_CGROUP
 
 test_expect_success NO_CHAIN_LINT,SYSTEMD_CGROUP 'flux-imp kill: works in unpriv mode' '
 	name=allowed-user

--- a/t/t2002-imp-run.t
+++ b/t/t2002-imp-run.t
@@ -59,7 +59,8 @@ test_expect_success 'create test shell scripts' '
 	env
 	EOF
 	chmod +x $TESTDIR/test.sh &&
-	touch $TESTDIR/noexec.sh
+	touch $TESTDIR/noexec.sh &&
+	chmod 600 $TESTDIR/noexec.sh
 '
 test_expect_success SUDO 'set appropriate permissions for sudo based tests' '
 	$SUDO chown root.root $TESTDIR $TESTDIR/* &&


### PR DESCRIPTION
This PR allows the IMP `kill` functionality to work on distros and configurations where unified cgroups are in use.

A simple function is added which determines whether unified cgroups are active, and the mount point for the cgroups hierarchy, using the rules described at https://systemd.io/CGROUP_DELEGATION/. Otherwise, changes are minimal. 

I've tested this out on a local Ubuntu 22.04 system, but it would be good if @garlick could test this on his raspbian system as well.