### PR TITLE
imp: exec: add PAM session support

### DIFF
--- a/config/x_ac_pam.m4
+++ b/config/x_ac_pam.m4
@@ -1,0 +1,29 @@
+##*****************************************************************************
+#  AUTHOR:
+#    Mark A. Grondona <mgrondona@llnl.gov>
+#
+#  SYNOPSIS:
+#    X_AC_PAM
+#
+#  DESCRIPTION:
+#    Test if PAM is requested and available.
+#    Sets PAM_LIBS and PAM_CPPFLAGS if requested and available
+##*****************************************************************************
+AC_DEFUN([X_AC_PAM], [
+  AC_ARG_ENABLE([pam],
+    AS_HELP_STRING([--enable-pam], [Enable PAM support for IMP exec]))
+    AS_IF([test "x$enable_pam" = "xyes"], [
+        AC_CHECK_LIB([pam], [pam_start], [ac_have_pam=yes; PAM_LIBS="-lpam"])
+	AC_CHECK_LIB([pam_misc],
+                     [misc_conv],
+                     [ac_have_pam_misc=yes; PAM_LIBS="$PAM_LIBS -lpam_misc"])
+	AC_SUBST(PAM_LIBS)
+	if test "x$ac_have_pam" = "xyes" -a "x$ac_have_pam_misc" = "xyes"; then
+	    AC_DEFINE([HAVE_PAM], [1], [Enable PAM support for flux-imp exec])
+        else
+            AC_MSG_ERROR([unable to locate PAM libraries]")
+        fi
+    ])
+  AM_CONDITIONAL(HAVE_PAM, [test "x$enable_pam" = "xyes"])
+])
+

--- a/configure.ac
+++ b/configure.ac
@@ -131,6 +131,11 @@ PKG_CHECK_MODULES([LIBUUID], [uuid], [], [])
 PKG_CHECK_MODULES([MUNGE], [munge], [], [])
 
 #
+#  Enable PAM Support?
+#
+X_AC_PAM
+
+#
 #  Other checks
 #
 AX_CODE_COVERAGE

--- a/doc/man5/flux-config-security-imp.rst
+++ b/doc/man5/flux-config-security-imp.rst
@@ -55,6 +55,18 @@ exec.allow-unprivileged-exec
    to execute arbitrary commands as the Flux system instance owner userid
    (e.g. ``flux``)
 
+exec.pam-support
+   A boolean value which, if true, enables PAM support for the IMP exec
+   subcommand, allowing a ``flux`` PAM stack to be executed for multi
+   user jobs. If enabled, the ``flux`` PAM stack must exist and have
+   at least one ``auth`` and one ``session`` module configured, e.g.::
+
+     auth    required pam_localuser.so
+     session required pam_limits.so
+
+   This option requires that the flux-security project was built with
+   ``--enable-pam``.
+
 The following keys in the ``[run]`` table configure ``flux-imp run``
 support, which is used to configure the ``flux-imp run`` command, which
 is used to allow the Flux system instance user to execute a prolog,

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -554,3 +554,6 @@ POSIX
 anymech
 enum
 NOVERIFY
+auth
+localuser
+pam

--- a/src/imp/Makefile.am
+++ b/src/imp/Makefile.am
@@ -64,6 +64,12 @@ IMP_SOURCES = \
 	exec/user.c \
 	exec/exec.c
 
+if HAVE_PAM
+IMP_SOURCES += \
+	exec/pam.h \
+	exec/pam.c
+endif
+
 flux_imp_SOURCES = \
 	testconfig.c \
 	$(IMP_SOURCES)

--- a/src/imp/Makefile.am
+++ b/src/imp/Makefile.am
@@ -25,7 +25,8 @@ flux_imp_LDADD = \
 	$(top_builddir)/src/lib/libflux-security.la \
 	$(top_builddir)/src/libca/libca.la \
 	$(top_builddir)/src/libutil/libutil.la \
-	$(top_builddir)/src/libtomlc99/libtomlc99.la
+	$(top_builddir)/src/libtomlc99/libtomlc99.la \
+	$(PAM_LIBS)
 
 #
 #  Build the test-only version of flux-imp with -static, which seems

--- a/src/imp/exec/pam.c
+++ b/src/imp/exec/pam.c
@@ -1,0 +1,83 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include "pam.h"
+
+#include <stddef.h>
+#include <stdio.h>
+
+#include "imp_log.h"
+
+#include <security/pam_appl.h>
+#include <security/pam_misc.h>
+
+static pam_handle_t *pam_h = NULL;
+
+int pam_setup (const char *user)
+{
+    struct pam_conv conv = {misc_conv, NULL};
+    int rc;
+
+    if ((rc = pam_start ("flux",
+                         user,
+                         &conv,
+                         &pam_h)) != PAM_SUCCESS) {
+        imp_warn ("pam_start: %s", pam_strerror (NULL, rc));
+        goto fail1;
+    }
+    if ((rc = pam_set_item (pam_h, PAM_USER, user)) != PAM_SUCCESS) {
+        imp_warn ("pam_set_item USER: %s", pam_strerror (pam_h, rc));
+        goto fail2;
+    }
+    if ((rc = pam_set_item (pam_h, PAM_RUSER, user)) != PAM_SUCCESS) {
+        imp_warn ("pam_set_item RUSER: %s", pam_strerror (pam_h, rc));
+        goto fail2;
+    }
+    if ((rc = pam_setcred (pam_h, PAM_ESTABLISH_CRED)) != PAM_SUCCESS) {
+        imp_warn ("pam_setcred: %s", pam_strerror (pam_h, rc));
+        goto fail2;
+    }
+    if ((rc = pam_open_session (pam_h, 0)) != PAM_SUCCESS) {
+        imp_warn ("pam_open_session: %s", pam_strerror (pam_h, rc));
+        goto fail3;
+    }
+    return 0;
+
+fail3:
+    pam_setcred (pam_h, PAM_DELETE_CRED);
+
+fail2:
+    pam_end (pam_h, rc);
+
+fail1:
+    pam_h = NULL;
+    return rc == PAM_SUCCESS ? 0 : -1;
+}
+
+void pam_finish ()
+{
+    int rc = 0;
+    if (pam_h != NULL) {
+        if ((rc = pam_close_session (pam_h, 0)) != PAM_SUCCESS) {
+            imp_warn ("pam_close_session: %s", pam_strerror (pam_h, rc));
+        }
+        if ((rc = pam_setcred (pam_h, PAM_DELETE_CRED)) != PAM_SUCCESS) {
+            imp_warn ("pam_setcred: %s", pam_strerror (pam_h, rc));
+        }
+        if ((rc = pam_end (pam_h, rc)) != PAM_SUCCESS) {
+            imp_warn ("pam_end: %s", pam_strerror (pam_h, rc));
+        }
+        pam_h = NULL;
+    }
+}
+
+/*
+ *  vi: sw=4 ts=4 expandtab
+ */

--- a/src/imp/exec/pam.h
+++ b/src/imp/exec/pam.h
@@ -1,0 +1,18 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef HAVE_IMP_PAM_H_
+#define HAVE_IMP_PAM_H_ 1
+
+int pam_setup (const char *user);
+
+void pam_finish ();
+
+#endif  // HAVE_IMP_PAM_H_

--- a/src/imp/version.c
+++ b/src/imp/version.c
@@ -18,7 +18,13 @@
 int imp_cmd_version (struct imp_state *imp __attribute__ ((unused)),
                      struct kv *kv __attribute__ ((unused)))
 {
+    bool n = 0;
     printf ("flux-imp v%s\n", PACKAGE_VERSION);
+#if HAVE_PAM
+    n += printf ("%s+pam", n ? " " : "");
+#endif
+    if (n)
+        printf ("\n");
     return (0);
 }
 

--- a/src/test/docker/checks/Dockerfile
+++ b/src/test/docker/checks/Dockerfile
@@ -30,6 +30,17 @@ RUN case $BASE_IMAGE in \
      *) (>&2 echo "Unknown BASE_IMAGE") ;; \
     esac
 
+RUN cd /tmp \
+ && mkdir pam_wrapper \
+ && cd pam_wrapper \
+ && wget -O - https://ftp.samba.org/pub/cwrap/pam_wrapper-1.1.4.tar.gz \
+     | tar xvz --strip-components 1 \
+ && mkdir obj \
+ && cd obj \
+ && cmake -DCMAKE_INSTALL_PREFIX=/usr -DLIB_SUFFIX=64 .. \
+ && make \
+ && sudo make install
+
 # Install extra dependencies if necessary here.
 #
 # Do not forget to run `apt update` on Ubuntu/bionic.

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -22,7 +22,8 @@ TESTSCRIPTS = \
 	t1003-sign-curve.t \
 	t2000-imp-exec.t \
 	t2001-imp-kill.t \
-	t2002-imp-run.t
+	t2002-imp-run.t \
+	t2003-imp-exec-pam.t
 
 TESTS = \
 	$(TESTSCRIPTS)

--- a/t/t2003-imp-exec-pam.t
+++ b/t/t2003-imp-exec-pam.t
@@ -1,0 +1,111 @@
+#!/bin/sh
+#
+
+test_description='IMP exec PAM functionality test'
+
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+. `dirname $0`/sharness.sh
+
+flux_imp=${SHARNESS_BUILD_DIRECTORY}/src/imp/flux-imp
+sign=${SHARNESS_BUILD_DIRECTORY}/t/src/sign
+
+echo "# Using ${flux_imp}"
+
+$flux_imp version > version.out
+if ! grep -q pam version.out; then
+	skip_all='Skipping PAM tests. IMP not built with PAM support'
+	test_done
+fi
+
+#  Check for libpam_wrapper.so
+LD_PRELOAD=libpam_wrapper.so $flux_imp version >ld_preload.out 2>&1
+if grep -i error ld_preload.out >/dev/null 2>&1; then
+	skip_all='libpam_wrapper.so not found. Skipping all tests'
+	test_done
+fi
+
+fake_imp_input() {
+	printf '{"J":"%s"}' $(echo $1 | $sign)
+}
+
+
+test_expect_success 'create config for flux-imp exec and signer' '
+	cat >sign-none.toml <<-EOF &&
+	allow-sudo = true
+	[sign]
+	max-ttl = 30
+	default-type = "none"
+	allowed-types = [ "none" ]
+	[exec]
+	allowed-users = [ "$(whoami)" ]
+	allowed-shells = [ "bash", "echo" ]
+	allow-unprivileged-exec = true
+	pam-support = true
+	EOF
+	export FLUX_IMP_CONFIG_PATTERN="$(pwd)"/sign-none.toml
+'
+test_expect_success 'create test pam.d/flux and limits.conf' '
+	mkdir pam.d &&
+	cat >pam.d/flux <<-EOF &&
+	auth    required pam_localuser.so
+	session required pam_limits.so conf=$(pwd)/limits.conf
+	EOF
+	cat >limits.conf <<-EOF
+	*     soft    nofile    543
+	EOF
+'
+
+test_expect_success 'create IMP test script for PAM testing' '
+	cat >imp-pam.sh <<-EOF &&
+	#!/bin/sh
+	export PAM_WRAPPER=1
+	export LD_PRELOAD=libpam_wrapper.so
+	export PAM_WRAPPER_SERVICE_DIR="$(pwd)"/pam.d
+	export FLUX_IMP_CONFIG_PATTERN="$(pwd)"/sign-none.toml
+	exec $flux_imp "\$@"
+	EOF
+	chmod +x imp-pam.sh
+'
+test_expect_success SUDO 'flux-imp exec invokes PAM stack' '
+	fake_imp_input foo | \
+	    $SUDO ./imp-pam.sh exec bash -c "ulimit -n" >ulimit.out &&
+	test_debug "cat ulimit.out" &&
+	test "$(cat ulimit.out)" = "543"
+'
+test_expect_success SUDO 'flux-imp exec fails on PAM auth failure' '
+	cat >pam.d/flux <<-EOF &&
+	auth    required pam_deny.so
+	session required pam_limits.so conf=$(pwd)/limits.conf
+	EOF
+	fake_imp_input foo | \
+	    test_must_fail $SUDO \
+	    ./imp-pam.sh exec bash -c "ulimit -n"
+'
+test_expect_success SUDO 'flux-imp exec fails on PAM open failure' '
+	cat >pam.d/flux <<-EOF &&
+	auth    required pam_localuser.so
+	session required pam_noexist.so
+	EOF
+	fake_imp_input foo | \
+	    test_must_fail $SUDO \
+	    ./imp-pam.sh exec bash -c "ulimit -n"
+'
+test_expect_success SUDO 'flux-imp exec fails on PAM session failure' '
+	cat >pam.d/flux <<-EOF &&
+	auth    required pam_localuser.so
+	session required pam_limits.so conf=$(pwd)/limits.conf
+	session required pam_deny.so
+	EOF
+	fake_imp_input foo | \
+	    test_must_fail $SUDO \
+	    ./imp-pam.sh exec bash -c "ulimit -n"
+'
+test_expect_success SUDO 'flux-imp exec fails on PAM config failure' '
+	cat >pam.d/flux <<-EOF &&
+	EOF
+	fake_imp_input foo | \
+	    test_must_fail $SUDO \
+	    ./imp-pam.sh exec bash -c "ulimit -n"
+'
+test_done


### PR DESCRIPTION
This is being put up as WIP for comments and review. It should not be merged until after #150.

This provides a solution to flux-framework/flux-pmix#40 and #148 where users have hit issues running on system-instance clusters where max locked memory must be increased. A few things to note here:
- The system instance will now require a PAM configuration file in `/etc/pam.d/flux` and (presumably) a `limits.conf` file with hard and soft resource limits. This should be added to the Flux Administrator's Guide.
- When running in a container, the `pam_limits.so` dependency will fail if a `limits.conf` file does not exist, a `/etc/pam.d/flux` file does not exist, or if the configured limits exceed the limits allocated to the container. This may require changes to the fluxorama containers to establish PAM support.

Potential to-do items:
- Slurm's PAM session configuration includes a header definition check `HAVE_PAM` which skips the PAM start and finish operations if these calls aren't supported by the system.
- The session configuration currently sets credentials (in my container) for user `flux`. The limits are the same, and the tests seem to work, but I don't know if this is what we want or not.