### PR TITLE
NEWS.md: add release notes for v0.8.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,17 @@
+flux-security version 0.8.0 - 2022-09-13
+----------------------------------------
+
+## New Features
+
+ * allow privileged IMP to linger during a job (#150)
+ * imp: exec: add PAM session support (#151)
+
+## Cleanup
+
+ * imp: address code review comments (#152)
+ * ci: remove fedora33 add fedora35 to ci builds (#149)
+ * github: fix typo in deploy action (#146)
+
 flux-security version 0.7.0 - 2022-06-06
 ----------------------------------------
 


### PR DESCRIPTION
This adds release notes for a v0.8.0. We had talked about pushing this out with the next TOSS release but I forgot to update `NEWS.md`.