### PR TITLE
imp: fix kill operation when /proc is mounted with hidepid=2

### DIFF
--- a/src/imp/pidinfo.c
+++ b/src/imp/pidinfo.c
@@ -382,10 +382,6 @@ int pid_kill_children (pid_t pid, int sig)
         return -1;
     }
 
-    (void) snprintf (path, sizeof (path), "/proc/%ju", (uintmax_t) pid);
-    if (access (path, R_OK) < 0)
-        return -1;
-
     (void) snprintf (path, sizeof (path),
                     "/proc/%ju/task/%ju/children",
                     (uintmax_t) pid,


### PR DESCRIPTION
Problem: The access(2) check in pid_kill_children() seems to fail with ENOENT when /proc is mounted with hidepid=2, even though the flux-imp process is running with effective UID 0. This causes the IMP to abort the kill operation with:

  failed to signal flux-imp children: No such file or directory

Remove the brittle access(2) check and let the subsequent fopen(3) fail if the process no longer exists. This will trigger the fallback code, which will presumably find no processes to signal if the target PID really no longer exists, but this is preferrable to outright failure.

Fixes #154