### PR TITLE
github: update actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
@@ -19,17 +19,17 @@ jobs:
     outputs:
         matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
     - id: set-matrix
-      run: echo "::set-output name=matrix::$(src/test/generate-matrix.py)"
+      run: echo "matrix=$(src/test/generate-matrix.py)" >> $GITHUB_OUTPUT
     - run: src/test/generate-matrix.py | jq -S .
-    - run: echo "::set-output name=GITHUB_BRANCH::${GITHUB_REF#refs/heads}"
-    - run: echo "::set-output name=GITHUB_TAG::${GITHUB_REF#refs/tags}"
-    - run: echo "::set-output name=EVENT_NAME::${{github.event_name}}"
-  
+    - run: echo "GITHUB_BRANCH=${GITHUB_REF#refs/heads}" >> $GITHUB_OUTPUT
+    - run: echo "GITHUB_TAG=${GITHUB_REF#refs/tags}" >> $GITHUB_OUTPUT
+    - run: echo "EVENT_NAME=${{github.event_name}}" >> $GITHUB_OUTPUT
+
   ci:
     needs: [ generate-matrix ]
     runs-on: ubuntu-20.04
@@ -41,7 +41,7 @@ jobs:
     name: ${{ matrix.name }}
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
@@ -50,7 +50,7 @@ jobs:
       if: matrix.create_release
       run: |
         # Ensure git-describe works on a tag.
-        #  (checkout@v2 action may have left current tag as
+        #  (checkout@v3 action may have left current tag as
         #   lightweight instead of annotated. See
         #   https://github.com/actions/checkout/issues/290)
         #
@@ -59,7 +59,7 @@ jobs:
         echo git describe now reports $(git describe --always)
 
     - name: docker buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
       if: matrix.needs_buildx
 
     - name: docker-run-checks
@@ -73,35 +73,20 @@ jobs:
 
     - name: coverage report
       if: success() && matrix.coverage
-      uses: codecov/codecov-action@v1
-
-    - name: prep release
-      id: prep_release
-      if: success() && matrix.create_release
-      run: echo "::set-output name=tarball::$(echo flux-security*.tar.gz)"
+      uses: codecov/codecov-action@858dd794fbb81941b6d60b0dca860878cba60fa9 # v3.1.1
 
     - name: create release
       id: create_release
-      if: success() && matrix.create_release
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      uses: actions/create-release@v1
+      if: |
+          success()
+          && matrix.create_release
+          && github.repository == 'flux-framework/flux-security'
+      env: ${{matrix.env}}
+      uses: softprops/action-gh-release@v1
       with:
         tag_name: ${{ matrix.tag }}
-        release_name: flux-security ${{ matrix.tag }}
+        name: flux-security ${{ matrix.tag }}
         prerelease: true
+        files: flux-security*.tar.gz
         body: |
-          View [Release Notes](https://github.com/${{ github.repository }}/blob/${{ github.ref }}/NEWS.md) for flux-security ${{ matrix.tag }}
-
-    - name: upload tarball
-      id: upload-tarball
-      if: success() && matrix.create_release
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      uses: actions/upload-release-asset@v1
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ${{ steps.prep_release.outputs.tarball }}
-        asset_name: ${{ steps.prep_release.outputs.tarball }}
-        asset_content_type: "application/gzip"
-
+          View [Release Notes](https://github.com/${{ github.repository }}/blob/${{ matrix.tag }}/NEWS.md) for flux-security ${{ matrix.tag }}


### PR DESCRIPTION
Problem: Github has deprecated set-output and nodejs 12 actions.

Update checkout and codecov actions. Also update the auto-release action to use softprops/action-gh-release@v1 since the github release and upload actions are no longer maintained.