### PR TITLE
deb: do not package config file

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -22,6 +22,7 @@ override_dh_autoreconf:
 override_dh_auto_install:
 	dh_auto_install
 	find . -name '*.la' -delete
+	find . -name '*.toml' -delete
 
 override_dh_fixperms:
 	dh_fixperms --exclude flux-imp


### PR DESCRIPTION
Problem: An example sign.toml is packaged in the resulting package after 'make deb', but this may overwrite an existing admin-installed config.

Remove all config files from the test package created by 'make deb'.