### PR TITLE
detect typos during CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,12 @@ jobs:
     - run: git fetch origin master
     - uses: flux-framework/pr-validator@master
 
+  spelling:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+    - uses: crate-ci/typos@7ad296c72fa8265059cc03d1eda562fbdfcd6df2 # v1.9.0
+
   generate-matrix:
     # https://stackoverflow.com/questions/59977364
     name: Generate build matrix

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,8 @@
+[files]
+extend-exclude = [
+  "config/*",
+  "src/libtomlc99/*",
+  "src/libtap/*",
+  "t/sharness.sh",
+  "t/t0000-sharness.t"
+]

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -99,7 +99,6 @@ hostname
 io
 jobid
 jobids
-knowlege
 libpmi
 lwj
 mpi

--- a/src/imp/exec/user.c
+++ b/src/imp/exec/user.c
@@ -40,7 +40,7 @@ void imp_switch_user (uid_t uid)
     user = pwd->pw_name;
     gid = pwd->pw_gid;
 
-    /*  Intialize groups from /etc/group */
+    /*  Initialize groups from /etc/group */
     if (initgroups (user, gid) < 0)
         imp_die (1, "initgroups");
 

--- a/src/imp/kill.c
+++ b/src/imp/kill.c
@@ -162,7 +162,7 @@ int imp_kill_unprivileged (struct imp_state *imp, struct kv *kv)
         imp_die (1, "kill: invalid SIGNAL %s", imp->argv[2]);
 
     /*  PID of 0 is explicitly forbidden here as it could be used
-     *   to inadvertenly kill our parent.
+     *   to inadvertently kill our parent.
      */
     if ((pid = strtol (imp->argv[3], &p, 10)) == 0
         || *p != '\0')

--- a/src/imp/privsep.h
+++ b/src/imp/privsep.h
@@ -73,7 +73,7 @@ ssize_t privsep_write_kv (privsep_t *ps, struct kv *kv);
  *   on failure with errno set.
  *
  *  Specific errno values include:
- *    EINVAL  - Invalide privsep handle
+ *    EINVAL  - Invalid privsep handle
  *    E2BIG   - Remote tried to send kv that was too large
  */
 struct kv * privsep_read_kv (privsep_t *ps);

--- a/src/lib/sign.c
+++ b/src/lib/sign.c
@@ -222,7 +222,7 @@ static int signature_cat (const char *sig, void **buf, int *bufsz)
     int len = strlen (*buf);
     char *dst;
 
-    /* Grow buffer large enought to contain:
+    /* Grow buffer large enough to contain:
      * current header (len), '.' separator, signature, and final NUL.
      */
     if (grow_buf (buf, bufsz, strlen(sig) + len + 2) < 0)

--- a/src/lib/sign_curve.c
+++ b/src/lib/sign_curve.c
@@ -50,7 +50,7 @@ static void sc_destroy (struct sign_curve *sc)
     }
 }
 
-/* init - one time mechansim initialization
+/* init - one time mechanism initialization
  */
 static int op_init (flux_security_t *ctx, const cf_t *cf)
 {

--- a/src/libutil/cf.c
+++ b/src/libutil/cf.c
@@ -403,7 +403,7 @@ int cf_update_glob (cf_t *cf, const char *pattern, struct cf_error *error)
     globfree (&gl);
 
     /*
-     *  If glob sucessfully processed at least one file, update
+     *  If glob successfully processed at least one file, update
      *   caller's cf object with all new date in tmp object:
      */
     if ((count > 0) &&  json_object_update (cf, tmp) < 0) {

--- a/src/libutil/test/cf.c
+++ b/src/libutil/test/cf.c
@@ -296,7 +296,7 @@ void test_corner (void)
         "cf_get_in key=NULL fails with EINVAL");
     errno = 0;
     ok (cf_get_in (cf, "bar") == NULL && errno == ENOENT,
-        "cf_get_in key=(unknown) fails wtih ENOENT");
+        "cf_get_in key=(unknown) fails with ENOENT");
 
     /* cf_get_at
      */

--- a/src/libutil/test/kv.c
+++ b/src/libutil/test/kv.c
@@ -195,7 +195,7 @@ static void check_expansion (void)
         "kv_create works");
 
     /* Add entries
-     * Each entry wil be 32+3 + 1 + 32 + 1 = 69 bytes.
+     * Each entry will be 32+3 + 1 + 32 + 1 = 69 bytes.
      * Add 100 of them to ensure 4096 byte "chunk size" is exceeded,
      * so object has to grow at least once.
      */
@@ -228,7 +228,7 @@ static void bad_parameters (void)
     const char *entry;
     int len;
 
-    /* Create two kv objects:  kv (emtpy), and kv2 (non-empty).
+    /* Create two kv objects:  kv (empty), and kv2 (non-empty).
      */
     if (!(kv = kv_create ()))
         BAIL_OUT ("kv_create failed");

--- a/src/test/checks_run.sh
+++ b/src/test/checks_run.sh
@@ -66,7 +66,7 @@ export PATH=/usr/lib/ccache:$PATH
 # Ensure ccache dir exists
 mkdir -p $HOME/.ccache
 
-# clang+ccache requries second cpp pass:
+# clang+ccache requires second cpp pass:
 if echo "$CC" | grep -q "clang"; then
     CCACHE_CPP=1
 fi

--- a/src/test/docker/checks/Dockerfile
+++ b/src/test/docker/checks/Dockerfile
@@ -2,7 +2,7 @@ ARG IMAGESRC
 
 FROM $IMAGESRC
 
-# Allow username, UID, and GID to be overidden on
+# Allow username, UID, and GID to be overridden on
 #  docker build command line:
 #
 ARG USER=fluxuser

--- a/t/src/cf.c
+++ b/t/src/cf.c
@@ -81,7 +81,7 @@ void lookup (const cf_t *cf, char *key)
                 printf ("[array]\n");
                 break;
             case CF_UNKNOWN:
-                die ("unknwon type");
+                die ("unknown type");
                 break;
         }
     }


### PR DESCRIPTION
As with some other flux-framework projects, run the `crate-ci/typos` action in CI to detect typos.
Add a `.typos.toml` config file to exclude some files that are maintained elsewhere.
Fix detected typos.