### PR TITLE
ensure LICENSE is included in distribution tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,6 +8,7 @@ SUBDIRS = src doc etc t
 ACLOCAL_AMFLAGS = -I config
 EXTRA_DIST = \
 	config/tap-driver.sh \
+	LICENSE \
 	NOTICE.LLNS \
 	README.md \
 	NEWS.md

--- a/src/libtomlc99/Makefile.am
+++ b/src/libtomlc99/Makefile.am
@@ -9,6 +9,10 @@ AM_LDFLAGS = \
 
 AM_CPPFLAGS =
 
+EXTRA_DIST =
+	LICENSE \
+	README.md
+
 noinst_LTLIBRARIES = libtomlc99.la
 
 libtomlc99_la_SOURCES = \


### PR DESCRIPTION
The flux-security LICENSE file is not included in the `make dist` tarball.

Add it and the libtomlc99 LICENSE and README as well.