### PR TITLE
build: enable PAM in `make deb`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,19 @@ Independent project for Flux security code and APIs.
 
 flux-security requires the following packages to build:
 
-**redhat**	| **ubuntu**		| **version**
-----------	| ----------		| -----------
-autoconf	| autoconf		|
-automake	| automake		|
-libtool		| libtool		|
-make		| make			|
-pkgconfig	| pkg-config	|
-libsodium-devel	| libsodium-dev		| >= 1.0.14
-jansson-devel	| libjansson-dev	|
-libuuid-devel	| uuid-dev		|
-munge-devel	| libmunge-dev		|
+**redhat**	| **ubuntu**		| **version** | **notes**
+----------	| ----------		| ----------- | ---------
+autoconf	| autoconf		|             |
+automake	| automake		|             |
+libtool		| libtool		|             |
+make		| make			|             |
+pkgconfig	| pkg-config	        |             |
+libsodium-devel	| libsodium-dev		| >= 1.0.14   |
+jansson-devel	| libjansson-dev	|             |
+libuuid-devel	| uuid-dev		|             |
+munge-devel	| libmunge-dev		|             |
+pam-devel	| libpam0g-dev		|             | for --enable-pam
+
 
 ##### Installing RedHat/CentOS Packages
 ```

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,8 @@ Build-Depends:
   libsodium-dev,
   libjansson-dev,
   uuid-dev,
-  libmunge-dev
+  libmunge-dev,
+  libpam0g-dev
 
 Homepage: https://github.com/flux-framework/flux-security
 Package: flux-security

--- a/debian/rules
+++ b/debian/rules
@@ -19,6 +19,10 @@
 override_dh_autoreconf:
 	@echo not running autogen.sh on dist product
 
+override_dh_auto_configure:
+	dh_auto_configure -- \
+                --enable-pam
+
 override_dh_auto_install:
 	dh_auto_install
 	find . -name '*.la' -delete

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -2,3 +2,4 @@ sphinx==3.4.3
 sphinx-rtd-theme>=0.5.2
 docutils>=0.14,<0.18
 Jinja2<3.1
+urllib3<2


### PR DESCRIPTION
The debian package created by `make deb` was accidentally missing `--enable-pam` so had no PAM support.

Furthermore, the IMP silently ignores the `pam-support = true` option in the config when built without PAM.

Add PAM development packages to the suggested requirements for this project and in the `debian/control` file, and add `--enable-pam` to the debian package build by default. Add an error if `pam-support=true` is specified but the IMP was not built with PAM enabled, and add a test for this error.