### PR TITLE
ci: update build matrix to more closely match flux-core

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,18 +2,6 @@ queue_rules:
   - name: default
     conditions:
       - base=master
-      - status-success="validate commits"
-      - status-success="bionic"
-      - status-success="bionic - 32 bit"
-      - status-success="bionic - gcc-8,distcheck"
-      - status-success="bionic - clang-6.0"
-      - status-success="coverage"
-      - status-success="focal"
-      - status-success="el7"
-      - status-success="el8"
-      - status-success="fedora34"
-      - status-success="fedora35"
-      - status-success="fedora35 - asan"
       - label="merge-when-passing"
       - label!="work-in-progress"
       - "approved-reviews-by=@flux-framework/core"

--- a/src/imp/imp.c
+++ b/src/imp/imp.c
@@ -39,7 +39,7 @@ static int  imp_state_init (struct imp_state *imp, int argc, char **argv);
 static cf_t * imp_conf_load (const char *pattern);
 static bool imp_is_privileged ();
 static bool imp_is_setuid ();
-static void initialize_sudo_support ();
+static void initialize_sudo_support (cf_t *conf);
 
 static void imp_child (privsep_t *ps, void *arg);
 static void imp_parent (struct imp_state *imp);

--- a/src/imp/run.c
+++ b/src/imp/run.c
@@ -65,7 +65,8 @@
 extern char **environ;
 
 #if CODE_COVERAGE_ENABLED
-extern void __gcov_flush ();
+void __gcov_dump (void);
+void __gcov_reset (void);
 #endif
 
 static const cf_t *imp_run_lookup (struct imp_state *imp,
@@ -183,7 +184,8 @@ imp_run (const char *name,
     args[0] = path;
     args[1] = NULL;
 #if CODE_COVERAGE_ENABLED
-    __gcov_flush ();
+    __gcov_dump ();
+    __gcov_reset ();
 #endif
     execve (path, (char **) args, env);
 

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -35,7 +35,7 @@ class BuildMatrix:
     def add_build(
         self,
         name=None,
-        image="bionic",
+        image="bookworm",
         args=default_args,
         jobs=2,
         env=None,
@@ -87,30 +87,30 @@ class BuildMatrix:
 matrix = BuildMatrix()
 
 # Ubuntu: no args
-matrix.add_build(name="bionic")
+matrix.add_build(name="bookworm")
 
 # Ubuntu: 32b
 matrix.add_build(
-    name="bionic - 32 bit",
+    name="bookworm - 32 bit",
     platform="linux/386",
 )
 
 # Ubuntu: gcc-8, content-s3, distcheck
 matrix.add_build(
-    name="bionic - gcc-8,distcheck",
+    name="bookworm - gcc-12,distcheck",
     env=dict(
-        CC="gcc-8",
-        CXX="g++8",
+        CC="gcc-12",
+        CXX="g++12",
         DISTCHECK="t",
     ),
 )
 
 # Ubuntu: clang-6.0
 matrix.add_build(
-    name="bionic - clang-6.0",
+    name="bookworm - clang-15,chain-lint",
     env=dict(
-        CC="clang-6.0",
-        CXX="clang++-6.0",
+        CC="clang-15",
+        CXX="clang++-15",
         chain_lint="t",
     ),
     command_args="--workdir=/usr/src/" + "workdir/" * 15,
@@ -129,12 +129,6 @@ matrix.add_build(
     image="focal",
 )
 
-# RHEL7 clone
-matrix.add_build(
-    name="el7",
-    image="el7",
-)
-
 # RHEL8 clone
 matrix.add_build(
     name="el8",
@@ -148,17 +142,10 @@ matrix.add_build(
     env=dict(CFLAGS="-fanalyzer"),
 )
 
-# Fedora 35
+# Fedora 38 ASan
 matrix.add_build(
-    name="fedora35",
-    image="fedora35",
-    env=dict(CFLAGS="-fanalyzer"),
-)
-
-# Fedora 35 ASan
-matrix.add_build(
-    name="fedora35 - asan",
-    image="fedora35",
+    name="fedora38 - asan",
+    image="fedora38",
     args="--enable-sanitizers"
 )
 print(matrix)


### PR DESCRIPTION
The CI in flux-core is being modernized to drop el7, bionic, and fedora35 images, and add Debian bookworm and fedora38.

Make similar changes here so that we can ensure flux-security is tested on the same sets of software as in flux-core's CI.
Include some minor fixes caught by more modern compilers now used in CI.