### PR TITLE
testsuite: cover rfc38 kv test vectors

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -64,6 +64,8 @@ AC_DEFINE([SANITIZERS_ENABLED], 1,
 [AC_MSG_RESULT(no)])
 AM_CONDITIONAL([SANITIZERS_ENABLED], [test "x$enable_sanitizers" != "xno" ])
 
+AC_CHECK_LIB(m, floor)
+
 #
 #  Checks for programs
 #

--- a/src/libutil/kv.c
+++ b/src/libutil/kv.c
@@ -204,7 +204,7 @@ static int kv_put_raw (struct kv *kv, const char *key, enum kv_type type,
 
 int kv_vput (struct kv *kv, const char *key, enum kv_type type, va_list ap)
 {
-    char s[80];
+    char s[512]; // -DBL_MAX with 6 digit precision + \0 is 318 characters
     const char *val = NULL;
 
     if (!kv || !valid_key (key))

--- a/src/libutil/kv.c
+++ b/src/libutil/kv.c
@@ -219,7 +219,7 @@ int kv_vput (struct kv *kv, const char *key, enum kv_type type, va_list ap)
             val = s;
             break;
         case KV_DOUBLE:
-            if (vsnprintf (s, sizeof (s), "%f", ap) >= sizeof (s))
+            if (vsnprintf (s, sizeof (s), "%.6f", ap) >= sizeof (s))
                 goto inval;
             val = s;
             break;


### PR DESCRIPTION
Problem: rfc38 specifies test vectors for kv, but these are not used by unit tests.
    
Add a new unit test section that covers these vectors.

Also, grow an internal static buffer in case very large doubles are ever encoded.
