### PR TITLE
add release notes for v0.10.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+flux-security version 0.10.0 - 2023-05-05
+-----------------------------------------
+
+## Fixes
+ * imp: fix segfault on missing user (#171)
+
+## Build/Test
+ * testsuite: cover rfc38 kv test vectors (#173)
+ * ci: add `--enable-pam` to most CI builds (#172)
+ * ci: update build matrix to more closely match flux-core (#169)
+
+
 flux-security version 0.9.0 - 2023-05-15
 ----------------------------------------
 


### PR DESCRIPTION
We should probably create a new flux-security release to incorporate the fix for #171.

This just adds release notes for a flux-security v0.10.0 release. Note sure if we have more planned work for the next tag at this time.