### PR TITLE
build: address warnings from autogen.sh

### DIFF
--- a/config/ac_pkgconfig.m4
+++ b/config/ac_pkgconfig.m4
@@ -5,7 +5,7 @@ AC_DEFUN([AC_PKGCONFIG],
     pkgconfigdir='${libdir}/pkgconfig'
     AC_MSG_CHECKING(whether to install pkg-config *.pc files)
     AC_ARG_WITH(pkgconfig-dir,
-     AC_HELP_STRING([--with-pkgconfig-dir=PATH], [where to install pkg-config *.pc files (EPREFIX/lib/pkgconfig)]),
+     AS_HELP_STRING([--with-pkgconfig-dir=PATH],[where to install pkg-config *.pc files (EPREFIX/lib/pkgconfig)]),
      [
         case "${withval}" in
             yes|auto)

--- a/config/am_check_pymod.m4
+++ b/config/am_check_pymod.m4
@@ -15,12 +15,15 @@ except:
         sys.exit(0)
 sys.exit(0)"], [prog="
 import sys
-from distutils.version import LooseVersion, StrictVersion
+try:
+    from distutils.version import StrictVersion as Version
+except ModuleNotFoundError:
+    from packaging.version import Version
 import $1
 if not $2:
     sys.exit(1)
 "])
-if $PYTHON -c "$prog" 1>&AC_FD_CC 2>&AC_FD_CC
+if $PYTHON -c "$prog" 1>&AS_MESSAGE_LOG_FD 2>&AS_MESSAGE_LOG_FD
   then
     eval "py_cv_mod_$py_mod_var=yes"
   else

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,6 @@
 # Prologue
 #
 
-# XXX: replace hard-coded version with git-describe 
 AC_INIT([flux-security],
          m4_esyscmd([git describe --always | awk '/.*/ {sub(/^v/, ""); printf "%s",$1; exit}']))
 

--- a/configure.ac
+++ b/configure.ac
@@ -69,7 +69,7 @@ AC_CHECK_LIB(m, floor)
 #
 #  Checks for programs
 #
-AC_PROG_CC_C99
+m4_version_prereq(2.70, [AC_PROG_CC], [AC_PROG_CC_C99])
 AM_PROG_CC_C_O
 AC_PROG_AWK
 AC_ARG_ENABLE([docs],

--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,7 @@ AC_CANONICAL_TARGET
 #
 AM_INIT_AUTOMAKE([subdir-objects tar-pax foreign])
 AM_SILENT_RULES([yes])
-AM_CONFIG_HEADER([config/config.h])
+AC_CONFIG_HEADERS([config/config.h])
 AM_MAINTAINER_MODE([enable])
 
 AC_DEFINE([_GNU_SOURCE], 1,

--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,7 @@ AC_INIT([flux-security],
 AC_CONFIG_AUX_DIR([config])
 AC_CONFIG_MACRO_DIR([config])
 AC_CONFIG_SRCDIR([NEWS.md])
-AC_CANONICAL_SYSTEM
+AC_CANONICAL_TARGET
 
 #
 #  Automake support:

--- a/configure.ac
+++ b/configure.ac
@@ -119,7 +119,6 @@ LT_INIT
 #
 #  Checks for header files
 #
-AC_HEADER_STDC
 AC_CHECK_HEADERS( \
   [linux/magic.h] \
 )

--- a/src/libtomlc99/Makefile.am
+++ b/src/libtomlc99/Makefile.am
@@ -51,7 +51,7 @@ test_toml_t_SOURCES = test/toml.c
 test_toml_t_LDADD = $(test_ldadd)
 test_toml_t_CPPFLAGS = $(test_cppflags)
 
-EXTRA_DIST = \
+EXTRA_DIST += \
 	BurntSushi_input/invalid/array-mixed-types-arrays-and-ints.toml \
 	BurntSushi_input/invalid/array-mixed-types-ints-and-floats.toml \
 	BurntSushi_input/invalid/array-mixed-types-strings-and-ints.toml \


### PR DESCRIPTION
Here are some fixes autoreconf warnings noted in  #178.  Much of this is just pulling over what others have already done in flux-core.

Fixes #178