### PR TITLE
testsuite: fix imp kill test

### DIFF
--- a/t/t2001-imp-kill.t
+++ b/t/t2001-imp-kill.t
@@ -174,7 +174,7 @@ test_expect_success NO_CHAIN_LINT,SUID_ENABLED,USER_CGROUP \
 	echo "\$@"
 	printf "\$PPID\n" >$(pwd)/sleeper.pid
 	/bin/sleep "\$@" &
-	pid=$! &&
+	pid=\$! &&
 	trap "echo got SIGTERM; kill \$pid" SIGTERM
 	wait
 	echo sleep exited with \$? >&2

--- a/t/t2001-imp-kill.t
+++ b/t/t2001-imp-kill.t
@@ -159,7 +159,7 @@ test "$(FLUX_IMP_CONFIG_PATTERN=sign-none.toml ./flux-imp kill 0 $$ \
 waitfile()
 {
 	count=0
-	while ! grep "$2" $1 >/dev/null 2>&12>&1; do
+	while ! grep "$2" $1 >/dev/null 2>&1; do
 	    sleep 0.2
 	    count=$(($count + 1))
 	    test $count -gt 20 && break

--- a/t/t2001-imp-kill.t
+++ b/t/t2001-imp-kill.t
@@ -175,7 +175,7 @@ test_expect_success NO_CHAIN_LINT,SUID_ENABLED,USER_CGROUP \
 	printf "\$PPID\n" >$(pwd)/sleeper.pid
 	/bin/sleep "\$@" &
 	pid=\$! &&
-	trap "echo got SIGTERM; kill \$pid" SIGTERM
+	trap "echo got SIGTERM; kill \$pid" TERM
 	wait
 	echo sleep exited with \$? >&2
 	EOF

--- a/t/t2001-imp-kill.t
+++ b/t/t2001-imp-kill.t
@@ -161,7 +161,7 @@ waitfile()
 	count=0
 	while ! grep "$2" $1 >/dev/null 2>&12>&1; do
 	    sleep 0.2
-	    let count++
+	    count=$(($count + 1))
 	    test $count -gt 20 && break
 	done
 	grep "$2" $1 >/dev/null


### PR DESCRIPTION
This fixes a few problems in the last test of `t2001-imp-kill.t` which was being skipped more often than not and thus flew under the radar.