### PR TITLE
NEWS.md: add release notes for v0.11.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+flux-security version 0.11.0 - 2023-12-17
+-----------------------------------------
+
+## Fixes
+ * port to musl and add alpine CI build (#182)
+
+## Build/Test
+ * testsuite: fix imp kill test (#180)
+ * build: address warnings from autogen.sh (#179)
+
+
 flux-security version 0.10.0 - 2023-05-05
 -----------------------------------------
 


### PR DESCRIPTION
A tagged version of flux-security that builds on alpine will be required for a flux-core alpine build for CI, since the first thing that is done is to build flux-security in the image. Therefore, let's create a v0.11. 0 tag for his purpose. Not much changed besides the porting effort, but tags are cheap...