### PR TITLE
imp: exec: send SIGKILL to cgroup/children on SIGUSR1

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,5 @@
-sphinx==3.4.3
+sphinx<6.0.0
 sphinx-rtd-theme>=0.5.2
 docutils>=0.14,<0.18
-Jinja2<3.1
 urllib3<2
+jinja2<3.10

--- a/src/imp/Makefile.am
+++ b/src/imp/Makefile.am
@@ -58,6 +58,8 @@ IMP_SOURCES = \
 	passwd.h \
 	pidinfo.c \
 	pidinfo.h \
+	signals.c \
+	signals.h \
 	kill.c \
 	run.c \
 	exec/user.h \

--- a/src/imp/Makefile.am
+++ b/src/imp/Makefile.am
@@ -60,6 +60,8 @@ IMP_SOURCES = \
 	pidinfo.h \
 	signals.c \
 	signals.h \
+	cgroup.c \
+	cgroup.h \
 	kill.c \
 	run.c \
 	exec/user.h \

--- a/src/imp/cgroup.c
+++ b/src/imp/cgroup.c
@@ -34,6 +34,9 @@
 #ifndef CGROUP_SUPER_MAGIC
 #define CGROUP_SUPER_MAGIC 0x27e0eb
 #endif
+#ifndef CGROUP2_SUPER_MAGIC
+#define CGROUP2_SUPER_MAGIC 0x63677270
+#endif
 #include <signal.h>
 
 #include "src/libutil/strlcpy.h"
@@ -123,7 +126,6 @@ static int cgroup_init_mount_dir_and_type (struct cgroup_info *cg)
     if (statfs (cg->mount_dir, &fs) < 0)
         return -1;
 
-#ifdef CGROUP2_SUPER_MAGIC
     /* if cgroup2 fs mounted: unified hierarchy for all users of cgroupfs
      */
     if (fs.f_type == CGROUP2_SUPER_MAGIC)
@@ -141,7 +143,6 @@ static int cgroup_init_mount_dir_and_type (struct cgroup_info *cg)
     if (fs.f_type == CGROUP2_SUPER_MAGIC)
         return 0;
 
-#endif /* CGROUP2_SUPER_MAGIC */
     /*  O/w, if /sys/fs/cgroup is mounted as tmpfs, we need to check
      *   for /sys/fs/cgroup/systemd mounted as cgroupfs (legacy).
      */

--- a/src/imp/cgroup.c
+++ b/src/imp/cgroup.c
@@ -1,0 +1,193 @@
+/************************************************************\
+ * Copyright 2024 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <errno.h>
+#include <dirent.h>
+#include <ctype.h>
+#include <stdbool.h>
+#include <limits.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/vfs.h>
+#ifdef HAVE_LINUX_MAGIC_H
+#include <linux/magic.h>
+#endif
+#ifndef TMPFS_MAGIC
+#define TMPFS_MAGIC 0x01021994 /* from linux/magic.h */
+#endif
+#ifndef CGROUP_SUPER_MAGIC
+#define CGROUP_SUPER_MAGIC 0x27e0eb
+#endif
+
+#include "src/libutil/strlcpy.h"
+
+#include "cgroup.h"
+#include "imp_log.h"
+
+/*
+ *  Look up the current cgroup relative path from /proc/self/cgroup.
+ *
+ *  If cgroup->unified is true, then look for the first entry where
+ *   'subsys' is an empty string.
+ *
+ *  Otherwise, use the `name=systemd` line.
+ *
+ *  See NOTES: /proc/[pid]/cgroup in cgroups(7).
+ */
+static int cgroup_init_path (struct cgroup_info *cgroup)
+{
+    int rc = -1;
+    int n;
+    FILE *fp;
+    size_t size = 0;
+    char *line = NULL;
+    int saved_errno;
+
+    if (!(fp = fopen ("/proc/self/cgroup", "r")))
+        return -1;
+
+    while ((n = getline (&line, &size, fp)) >= 0) {
+        char *nl;
+        char *relpath = NULL;
+        char *subsys = strchr (line, ':');
+        if ((nl = strchr (line, '\n')))
+            *nl = '\0';
+        if (subsys == NULL
+            || *(++subsys) == '\0'
+            || !(relpath = strchr (subsys, ':')))
+            continue;
+
+        /* Nullify subsys, relpath is already nul-terminated at newline */
+        *(relpath++) = '\0';
+
+        /*  If unified cgroups are being used, then stop when we find
+         *   subsys="". Otherwise stop at subsys="name=systemd":
+         */
+        if ((cgroup->unified && subsys[0] == '\0')
+            || (!cgroup->unified && strcmp (subsys, "name=systemd") == 0)) {
+            int len = sizeof (cgroup->path);
+            if (snprintf (cgroup->path,
+                          len,
+                          "%s%s",
+                          cgroup->mount_dir,
+                          relpath) < len)
+                rc = 0;
+            break;
+        }
+    }
+    if (rc < 0)
+        errno = ENOENT;
+
+    saved_errno = errno;
+    free (line);
+    fclose (fp);
+    errno = saved_errno;
+    return rc;
+}
+
+/*  Determine if this system is using the unified (v2) or legacy (v1)
+ *   cgroups hierarchy (See https://systemd.io/CGROUP_DELEGATION/)
+ *   and mount point for systemd managed cgroups.
+ */
+static int cgroup_init_mount_dir_and_type (struct cgroup_info *cg)
+{
+    struct statfs fs;
+
+    /*  Assume unified unless we discover otherwise
+     */
+    cg->unified = true;
+
+    /*  Check if either /sys/fs/cgroup or /sys/fs/cgroup/unified
+     *   are mounted as type cgroup2. If so, use this as the mount dir
+     *   (Note: these paths are guaranteed to fit in cg->mount_dir, so
+     *    no need to check for truncation)
+     */
+    (void) strlcpy (cg->mount_dir, "/sys/fs/cgroup", sizeof (cg->mount_dir));
+    if (statfs (cg->mount_dir, &fs) < 0)
+        return -1;
+
+#ifdef CGROUP2_SUPER_MAGIC
+    /* if cgroup2 fs mounted: unified hierarchy for all users of cgroupfs
+     */
+    if (fs.f_type == CGROUP2_SUPER_MAGIC)
+        return 0;
+
+    /*  O/w, check if cgroup2 unified hierarchy mounted at
+     *   /sys/fs/cgroup/unified
+     */
+    (void) strlcpy (cg->mount_dir,
+                    "/sys/fs/cgroup/unified",
+                    sizeof (cg->mount_dir));
+    if (statfs (cg->mount_dir, &fs) < 0)
+        return -1;
+
+    if (fs.f_type == CGROUP2_SUPER_MAGIC)
+        return 0;
+
+#endif /* CGROUP2_SUPER_MAGIC */
+    /*  O/w, if /sys/fs/cgroup is mounted as tmpfs, we need to check
+     *   for /sys/fs/cgroup/systemd mounted as cgroupfs (legacy).
+     */
+    if (fs.f_type == TMPFS_MAGIC) {
+
+        (void) strlcpy (cg->mount_dir,
+                        "/sys/fs/cgroup/systemd",
+                        sizeof (cg->mount_dir));
+        if (statfs (cg->mount_dir, &fs) == 0
+            && fs.f_type == CGROUP_SUPER_MAGIC) {
+            cg->unified = false;
+            return 0;
+        }
+    }
+
+    /*  Unable to determine cgroup mount point and/or unified vs legacy */
+    return -1;
+}
+
+void cgroup_info_destroy (struct cgroup_info *cg)
+{
+    if (cg) {
+        int saved_errno = errno;
+        free (cg);
+        errno = saved_errno;
+    }
+}
+
+struct cgroup_info *cgroup_info_create (void)
+{
+    struct cgroup_info *cgroup = calloc (1, sizeof (*cgroup));
+    if (!cgroup)
+        return NULL;
+
+    if (cgroup_init_mount_dir_and_type (cgroup) < 0
+        || cgroup_init_path (cgroup) < 0) {
+        cgroup_info_destroy (cgroup);
+        return NULL;
+    }
+    /* Note: GNU basename(3) never modifies its argument. (_GNU_SOURCE
+     * is defined in config.h.)
+     */
+    if (strncmp (basename (cgroup->path), "imp-shell", 9) == 0)
+        cgroup->use_cgroup_kill = true;
+
+    return cgroup;
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/imp/cgroup.c
+++ b/src/imp/cgroup.c
@@ -44,6 +44,13 @@
 #include "cgroup.h"
 #include "imp_log.h"
 
+static char *remove_leading_dotdot (char *relpath)
+{
+    while (strncmp (relpath, "/..", 3) == 0)
+        relpath += 3;
+    return relpath;
+}
+
 /*
  *  Look up the current cgroup relative path from /proc/self/cgroup.
  *
@@ -79,6 +86,11 @@ static int cgroup_init_path (struct cgroup_info *cgroup)
 
         /* Nullify subsys, relpath is already nul-terminated at newline */
         *(relpath++) = '\0';
+
+        /* Remove leading /.. in relpath. This could be due to cgroup
+         * mounted in a container.
+         */
+        relpath = remove_leading_dotdot (relpath);
 
         /*  If unified cgroups are being used, then stop when we find
          *   subsys="". Otherwise stop at subsys="name=systemd":

--- a/src/imp/cgroup.h
+++ b/src/imp/cgroup.h
@@ -22,4 +22,9 @@ struct cgroup_info *cgroup_info_create (void);
 
 void cgroup_info_destroy (struct cgroup_info *cgroup);
 
+/*  Send signal to all pids (excluding the current pid) in the
+ *  current cgroup.
+ */
+int cgroup_kill (struct cgroup_info *cgroup, int sig);
+
 #endif /* !HAVE_IMP_CGROUP_H */

--- a/src/imp/cgroup.h
+++ b/src/imp/cgroup.h
@@ -1,0 +1,25 @@
+/************************************************************\
+ * Copyright 2024 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef HAVE_IMP_CGROUP_H
+#define HAVE_IMP_CGROUP_H 1
+
+struct cgroup_info {
+    char mount_dir[PATH_MAX + 1];
+    char path[PATH_MAX + 1];
+    bool unified;
+    bool use_cgroup_kill;
+};
+
+struct cgroup_info *cgroup_info_create (void);
+
+void cgroup_info_destroy (struct cgroup_info *cgroup);
+
+#endif /* !HAVE_IMP_CGROUP_H */

--- a/src/imp/exec/exec.c
+++ b/src/imp/exec/exec.c
@@ -303,7 +303,7 @@ int imp_exec_privileged (struct imp_state *imp, struct kv *kv)
     if (WIFEXITED (status))
         exit (WEXITSTATUS (status));
     else if (WIFSIGNALED (status))
-        exit (WTERMSIG (status) + 128);
+        imp_raise (WTERMSIG (status));
     else
         exit (1);
 

--- a/src/imp/exec/exec.c
+++ b/src/imp/exec/exec.c
@@ -46,6 +46,7 @@
 #include "passwd.h"
 #include "user.h"
 #include "safe_popen.h"
+#include "signals.h"
 
 #if HAVE_PAM
 #include "pam.h"
@@ -66,8 +67,6 @@ struct imp_exec {
     const void *spec;
     int specsz;
 };
-
-static pid_t imp_child = (pid_t) -1;
 
 extern const char *imp_get_security_config_pattern (void);
 extern int imp_get_security_flags (void);
@@ -225,68 +224,10 @@ static void __attribute__((noreturn)) imp_exec (struct imp_exec *exec)
     imp_die (exit_code, "%s: %s", exec->shell, strerror (errno));
 }
 
-static void fwd_signal (int signal)
-{
-    if (imp_child > 0)
-        kill (imp_child, signal);
-}
-
-/*  Setup signal handlers in the IMP for common signals which
- *   we want to forward to any child process.
- */
-static void setup_signal_forwarding (void)
-{
-    struct sigaction sa;
-    sigset_t mask;
-    int i;
-    int signals[] = {
-        SIGTERM,
-        SIGINT,
-        SIGHUP,
-        SIGCONT,
-        SIGALRM,
-        SIGWINCH,
-        SIGTTIN,
-        SIGTTOU,
-    };
-    int nsignals =  sizeof (signals) / sizeof (signals[0]);
-
-    memset(&sa, 0, sizeof(sa));
-    sa.sa_handler = fwd_signal;
-    sa.sa_flags = SA_RESTART;
-    sigemptyset(&sa.sa_mask);
-
-    sigfillset (&mask);
-    for (i = 0; i < nsignals; i++) {
-        sigdelset (&mask, signals[i]);
-        if (sigaction(signals[i], &sa, NULL) < 0)
-            imp_warn ("sigaction (signal=%d): %s",
-                      signals[i],
-                      strerror (errno));
-    }
-    if (sigprocmask (SIG_SETMASK, &mask, NULL) < 0)
-       imp_die (1, "failed to block signals: %s", strerror (errno));
-}
-
-static void sigblock_all (void)
-{
-    sigset_t mask;
-    sigfillset (&mask);
-    if (sigprocmask (SIG_SETMASK, &mask, NULL) < 0)
-        imp_die (1, "failed to block signals: %s", strerror (errno));
-}
-
-static void sigunblock_all (void)
-{
-    sigset_t mask;
-    sigemptyset (&mask);
-    if (sigprocmask (SIG_SETMASK, &mask, NULL) < 0)
-        imp_die (1, "failed to unblock signals: %s", strerror (errno));
-}
-
 int imp_exec_privileged (struct imp_state *imp, struct kv *kv)
 {
     int status;
+    pid_t child;
     struct imp_exec *exec = imp_exec_create (imp);
     if (!exec)
         imp_die (1, "exec: failed to initialize state");
@@ -322,15 +263,17 @@ int imp_exec_privileged (struct imp_state *imp, struct kv *kv)
     }
 
     /* Block signals so parent IMP isn't unduly terminated */
-    sigblock_all ();
+    imp_sigblock_all ();
 
-    if ((imp_child = fork ()) < 0)
+    if ((child = fork ()) < 0)
         imp_die (1, "exec: fork: %s", strerror (errno));
 
-    if (imp_child == 0) {
+    imp_set_signal_child (child);
+
+    if (child == 0) {
 
         /* unblock all signals */
-        sigunblock_all ();
+        imp_sigunblock_all ();
 
         /* Irreversibly switch to user */
         imp_switch_user (exec->user_pwd->pw_uid);
@@ -342,10 +285,10 @@ int imp_exec_privileged (struct imp_state *imp, struct kv *kv)
     /* Ensure common signals received by this IMP are forwarded to
      *  the child process
      */
-    setup_signal_forwarding ();
+    imp_setup_signal_forwarding (imp);
 
     /* Parent: wait for child to exit */
-    while (waitpid (imp_child, &status, 0) != imp_child) {
+    while (waitpid (child, &status, 0) != child) {
         if (errno != EINTR)
             imp_die (1, "waitpid: %s", strerror (errno));
     }

--- a/src/imp/imp.c
+++ b/src/imp/imp.c
@@ -59,6 +59,11 @@ int main (int argc, char *argv[])
     if (!(imp.conf = imp_conf_load (imp_get_config_pattern ())))
         imp_die (1, "Failed to load configuration");
 
+    /*  Get current IMP cgroup information:
+     */
+    if (!(imp.cgroup = cgroup_info_create ()))
+        imp_die (1, "Failed to get current cgroup info");
+
     /*  Audit subsystem initialization
      */
     // Skip.

--- a/src/imp/imp_state.h
+++ b/src/imp/imp_state.h
@@ -13,12 +13,14 @@
 
 #include "src/libutil/cf.h"
 #include "privsep.h"
+#include "cgroup.h"
 
 struct imp_state {
     int        argc;
     char     **argv;        /* cmdline arguments from main() */
     cf_t      *conf;        /* IMP configuration */
     privsep_t *ps;          /* Privilege separation handle */
+    struct cgroup_info *cgroup;
 };
 
 #endif /* !HAVE_IMP_STATE_H */

--- a/src/imp/signals.c
+++ b/src/imp/signals.c
@@ -12,6 +12,7 @@
 #include <config.h>
 #endif
 
+#include <unistd.h>
 #include <signal.h>
 #include <errno.h>
 #include <string.h>
@@ -105,6 +106,17 @@ void imp_setup_signal_forwarding (struct imp_state *imp)
     }
     if (sigprocmask (SIG_SETMASK, &mask, NULL) < 0)
        imp_die (1, "failed to block signals: %s", strerror (errno));
+}
+
+void imp_raise (int sig)
+{
+    signal (sig, SIG_DFL);
+    if (raise (sig) == 0)
+        pause ();
+    /*  If we get here, either raise(3) failed or for some reason signal
+     *  failed to kill the IMP during pause(). Exit with standard 128+sig.
+     */
+    imp_die (128 + sig, "failed to raise signal %d", sig);
 }
 
 /* vi: ts=4 sw=4 expandtab

--- a/src/imp/signals.c
+++ b/src/imp/signals.c
@@ -1,0 +1,89 @@
+/************************************************************\
+ * Copyright 2024 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <signal.h>
+#include <errno.h>
+#include <string.h>
+
+#include "signals.h"
+#include "imp_log.h"
+
+static const struct imp_state *imp_state = NULL;
+static pid_t imp_child = (pid_t) -1;
+
+void imp_set_signal_child (pid_t child)
+{
+    imp_child = child;
+}
+
+void imp_sigblock_all (void)
+{
+    sigset_t mask;
+    sigfillset (&mask);
+    if (sigprocmask (SIG_SETMASK, &mask, NULL) < 0)
+        imp_die (1, "failed to block signals: %s", strerror (errno));
+}
+
+void imp_sigunblock_all (void)
+{
+    sigset_t mask;
+    sigemptyset (&mask);
+    if (sigprocmask (SIG_SETMASK, &mask, NULL) < 0)
+        imp_die (1, "failed to unblock signals: %s", strerror (errno));
+}
+
+static void fwd_signal (int signum)
+{
+    if (imp_child > 0)
+        kill (imp_child, signum);
+}
+
+void imp_setup_signal_forwarding (struct imp_state *imp)
+{
+    struct sigaction sa;
+    sigset_t mask;
+    int i;
+    int signals[] = {
+        SIGTERM,
+        SIGINT,
+        SIGHUP,
+        SIGCONT,
+        SIGALRM,
+        SIGWINCH,
+        SIGTTIN,
+        SIGTTOU,
+    };
+    int nsignals =  sizeof (signals) / sizeof (signals[0]);
+
+    imp_state = imp;
+
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = fwd_signal;
+    sa.sa_flags = SA_RESTART;
+    sigemptyset(&sa.sa_mask);
+
+    sigfillset (&mask);
+    for (i = 0; i < nsignals; i++) {
+        sigdelset (&mask, signals[i]);
+        if (sigaction(signals[i], &sa, NULL) < 0)
+            imp_warn ("sigaction (signal=%d): %s",
+                      signals[i],
+                      strerror (errno));
+    }
+    if (sigprocmask (SIG_SETMASK, &mask, NULL) < 0)
+       imp_die (1, "failed to block signals: %s", strerror (errno));
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/imp/signals.h
+++ b/src/imp/signals.h
@@ -1,0 +1,29 @@
+/************************************************************\
+ * Copyright 2024 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef HAVE_IMP_SIGNALS_H
+#define HAVE_IMP_SIGNALS_H 1
+
+#include <sys/types.h>
+#include "imp_state.h"
+
+/*  Set the target of IMP signal forwarding
+ */
+void imp_set_signal_child (pid_t child);
+
+/*  Setup RFC 15 standard IMP signal forwarding
+ */
+void imp_setup_signal_forwarding (struct imp_state *imp);
+
+void imp_sigblock_all (void);
+
+void imp_sigunblock_all (void);
+
+#endif /* !HAVE_IMP_SIGNALS_H */

--- a/src/imp/signals.h
+++ b/src/imp/signals.h
@@ -26,4 +26,9 @@ void imp_sigblock_all (void);
 
 void imp_sigunblock_all (void);
 
+/*  Set default signal disposition and then raise signal 'sig'.
+ *  If raise fails for any reason, then exit with standard 128+sig.
+ */
+void imp_raise (int sig) __attribute__ ((noreturn));;
+
 #endif /* !HAVE_IMP_SIGNALS_H */

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -177,7 +177,7 @@ else
     docker run --rm \
         --workdir=$WORKDIR \
         --volume=$TOP:$WORKDIR \
-        -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+        -v /sys/fs/cgroup:/sys/fs/cgroup:rw \
         ${PLATFORM} \
         $MOUNT_HOME_ARGS \
         -e CC \

--- a/t/t2000-imp-exec.t
+++ b/t/t2000-imp-exec.t
@@ -245,7 +245,6 @@ test_expect_success SUDO,NO_CHAIN_LINT 'flux-imp exec: setuid IMP lingers' '
         test_debug "cat sleeper.pid"
 	test -f sleeper.pid &&
 	pid=$(cat sleeper.pid) &&
-	test_debug "pstree -lup $pid" &&
 	test $(ps --no-header -o comm -p ${pid}) = "flux-imp" &&
 	kill -TERM $pid &&
 	test_expect_code 143 wait $imp_pid
@@ -257,7 +256,6 @@ test_expect_success SUDO,NO_CHAIN_LINT 'flux-imp exec: SIGUSR1 sends SIGKILL' '
 	wait_for_file sleeper.pid &&
 	test -f sleeper.pid &&
 	pid=$(cat sleeper.pid) &&
-	test_debug "echo pid=$pid; pstree -Tplu $imp_pid" &&
 	kill -USR1 $pid &&
 	test_expect_code 137 wait $imp_pid
 '


### PR DESCRIPTION
This PR updates the IMP to translate SIGUSR1 to SIGKILL for `flux-imp exec` as defined in RFC 15.

Additionally, if possible, the IMP will signal all members of its cgroup (besides itself) when delivering SIGKILL.

Finally, to better handle returning the proper wait status to _its_ parent, when the child of the IMP is terminated by a signal, the IMP raises that same signal to itself.

This is WIP pending real system testing.