### PR TITLE
imp: exec: wait for job cgroup to be empty before exiting

### DIFF
--- a/src/imp/cgroup.h
+++ b/src/imp/cgroup.h
@@ -27,4 +27,8 @@ void cgroup_info_destroy (struct cgroup_info *cgroup);
  */
 int cgroup_kill (struct cgroup_info *cgroup, int sig);
 
+/*  Wait for all processes in cgroup (except this one) to exit.
+ */
+int cgroup_wait_for_empty (struct cgroup_info *cgroup);
+
 #endif /* !HAVE_IMP_CGROUP_H */

--- a/src/imp/exec/exec.c
+++ b/src/imp/exec/exec.c
@@ -293,6 +293,9 @@ int imp_exec_privileged (struct imp_state *imp, struct kv *kv)
             imp_die (1, "waitpid: %s", strerror (errno));
     }
 
+    if (cgroup_wait_for_empty (exec->imp->cgroup) < 0)
+        imp_warn ("error waiting for processes in job cgroup");
+
 #if HAVE_PAM
     /* Call privliged IMP plugins/containment finalization */
     if (imp_supports_pam (exec))

--- a/src/imp/signals.c
+++ b/src/imp/signals.c
@@ -93,7 +93,7 @@ void imp_setup_signal_forwarding (struct imp_state *imp)
 
     memset(&sa, 0, sizeof(sa));
     sa.sa_handler = fwd_signal;
-    sa.sa_flags = SA_RESTART;
+    sa.sa_flags = 0;
     sigemptyset(&sa.sa_mask);
 
     sigfillset (&mask);


### PR DESCRIPTION
This PR modifies `imp exec` to wait for an "empty" cgroup before exiting, where empty means `cgroup.procs` contains only the IMP's own PID.
