### PR TITLE
configure: do not use distutils StrictVersion

### DIFF
--- a/config/am_check_pymod.m4
+++ b/config/am_check_pymod.m4
@@ -15,10 +15,7 @@ except:
         sys.exit(0)
 sys.exit(0)"], [prog="
 import sys
-try:
-    from distutils.version import StrictVersion as Version
-except ModuleNotFoundError:
-    from packaging.version import Version
+from packaging.version import Version
 import $1
 if not $2:
     sys.exit(1)

--- a/configure.ac
+++ b/configure.ac
@@ -77,12 +77,12 @@ AS_IF([test "x$enable_docs" != "xno"], [
 	PYTHON_VERSION=3
 	AM_PATH_PYTHON([3])
 	AM_CHECK_PYMOD(sphinx,
-	               [StrictVersion(sphinx.__version__) >= StrictVersion ('1.6.7')],
+	               [Version(sphinx.__version__) >= Version ('1.6.7')],
 	               [sphinx=true],
 	               [sphinx=false; AC_MSG_WARN([could not find sphinx to generate docs, version 1.6.7+ required])]
                        )
 	AM_CHECK_PYMOD(docutils,
-                       [StrictVersion(docutils.__version__) >= StrictVersion ('0.11.0')],
+                       [Version(docutils.__version__) >= Version ('0.11.0')],
                        [docutils=true],
                        [docutils=false; AC_MSG_WARN([could not find docutils to generate docs, version 0.11.0+ required])]
                        )


### PR DESCRIPTION
Problem: distutils StrictVersion is deprecated (along with distutils itself), but it is still used in testing for sphinx and docutils in configure.ac.

Drop distutils and use packaging.version.Version instead.