### PR TITLE
imp: use cgroup_kill when cgroup begins with flux-

### DIFF
--- a/src/imp/cgroup.c
+++ b/src/imp/cgroup.c
@@ -197,7 +197,8 @@ struct cgroup_info *cgroup_info_create (void)
     /* Note: GNU basename(3) never modifies its argument. (_GNU_SOURCE
      * is defined in config.h.)
      */
-    if (strncmp (basename (cgroup->path), "imp-shell", 9) == 0)
+    if (strncmp (basename (cgroup->path), "imp-shell", 9) == 0
+        || strncmp (basename (cgroup->path), "flux-", 5) == 0)
         cgroup->use_cgroup_kill = true;
 
     return cgroup;

--- a/src/imp/pidinfo.c
+++ b/src/imp/pidinfo.c
@@ -172,6 +172,10 @@ int pid_kill_children (pid_t pid, int sig)
         return -1;
     }
     while (fscanf (fp, " %lu", &child) == 1) {
+        if (child <= 1 || (pid_t)child == pid) {
+            imp_warn ("Ignoring suspect pid %lu from %s", child, path);
+            continue;
+        }
         if (kill ((pid_t) child, sig) < 0) {
             saved_errno = errno;
             rc = -1;


### PR DESCRIPTION
Problem: the cgroup name prefix of "imp-shell" is hard coded in the IMP to select a signal forwarding strategy that ought to apply to flux-housekeeping/epilog/prolog if we move them from the system to the user systemd instance.

Check for the "flux-" unit name prefix too.
