### PR TITLE
imp run: wait for cgroup and call sd_notify()

### DIFF
--- a/src/imp/run.c
+++ b/src/imp/run.c
@@ -234,6 +234,9 @@ imp_run (struct imp_state *imp,
             imp_die (1, "waitpid: %s", strerror (errno));
     }
 
+    if (cgroup_wait_for_empty (imp->cgroup) < 0)
+        imp_warn ("error waiting for processes in cgroup");
+
     /* Exit with status of the child process */
     if (WIFEXITED (status))
         exit (WEXITSTATUS (status));


### PR DESCRIPTION
This prepares to let `imp run` run as the main process in a user systemd instance
- wait for cgroup to empty out before exiting
- call sd_notify() so Type=notify unit can be used (and allow NOTIFY_SOCKET to be passed thru the environment).

It is built on top of #201 