### PR TITLE
doc: remove reference to flux-mini(1)

### DIFF
--- a/doc/man5/flux-config-security-sign.rst
+++ b/doc/man5/flux-config-security-sign.rst
@@ -6,7 +6,7 @@ flux-config-security-sign(5)
 DESCRIPTION
 ===========
 
-Flux jobs are signed by job submission tools like :core:man1:`flux-mini`.
+Flux jobs are signed by job submission tools like :core:man1:`flux-submit`.
 The signature is verified upon receipt by the Flux ``job-ingest`` service,
 and at launch time by :man8:`flux-imp`.  A signing library provided by the
 ``flux-security`` project performs the cryptographic signing and verification.

--- a/doc/man5/flux-config-security.rst
+++ b/doc/man5/flux-config-security.rst
@@ -37,7 +37,7 @@ Security configuration files, including the ``conf.d`` directory and individual
 
 There is no mechanism to tell Flux components to reread the Flux security
 configurations when they change.  Most Flux security users such as
-:core:man1:`flux-mini` or :man8:`flux-imp` are short lived and read the latest
+:core:man1:`flux-submit` or :man8:`flux-imp` are short lived and read the latest
 configuration on each invocation.  There are two considerations to be aware
 of when updating the signing configuration, however:
 


### PR DESCRIPTION
Problem: flux-mini(1) was lost to time but its references live on in the security documentation.

Update the documentation.