### PR TITLE
doc: remove reference to flux-workflow-examples in config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ libltdl/
 /config/ltversion.m4
 /config/lt~obsolete.m4
 
+# Automake parallel-tests pull-in
+/config/test-driver
+
 # Object files
 *.o
 *.ko

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -154,8 +154,4 @@ intersphinx_mapping = {
         "https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/",
         None,
     ),
-    "workflow-examples": (
-        "https://flux-framework.readthedocs.io/projects/flux-workflow-examples/en/latest/",
-        None,
-    ),
 }


### PR DESCRIPTION
Problem: `flux-workflow-examples` repo was recently removed, but is still referenced by the `flux-security` documentation config

Update `doc/conf.py`

Also add `/config/test-driver` to `.gitignore` as it is pulled by Automake's parallel-tests feature and is polluting my `git status` output :rofl: 