### PR TITLE
test: avoid maybe-uninitialized error with gcc-16

### DIFF
--- a/src/libutil/test/kv.c
+++ b/src/libutil/test/kv.c
@@ -281,7 +281,7 @@ static void simple_test (void)
     bool b;
     time_t t;
     const char *key;
-    int len;
+    int len = 0;
     time_t now;
 
     if (time (&now) < 0)
@@ -392,8 +392,8 @@ static void simple_test (void)
 static void empty_object (void)
 {
     struct kv *kv, *kv2;
-    const char *buf;
-    int len;
+    const char *buf = NULL;
+    int len = 0;
 
     kv = kv_create ();
     ok (kv != NULL,


### PR DESCRIPTION
Problem: on Fedora rawide (Fedora 44) with gcc-16, compilation fails with the following error:

```
make[3]: Leaving directory '/builddir/build/BUILD/flux-security-0.14.0-build/flux-security-0.14.0/src/libutil' In function 'simple_test',
    inlined from 'main' at test/kv.c:849:5:
test/kv.c:381:11: error: 'len' may be used uninitialized [-Werror=maybe-uninitialized]
  381 |     kv3 = kv_decode (s, len);
      |           ^
test/kv.c: In function 'main':
test/kv.c:284:9: note: 'len' was declared here
  284 |     int len;
      |         ^
In function 'empty_object',
    inlined from 'main' at test/kv.c:850:5:
test/kv.c:406:11: error: 'buf' may be used uninitialized [-Werror=maybe-uninitialized]
  406 |     kv2 = kv_decode (buf, len);
      |           ^
test/kv.c: In function 'main':
test/kv.c:395:17: note: 'buf' was declared here
  395 |     const char *buf;
      |                 ^
In function 'empty_object',
    inlined from 'main' at test/kv.c:850:5:
test/kv.c:406:11: error: 'len' may be used uninitialized [-Werror=maybe-uninitialized]
  406 |     kv2 = kv_decode (buf, len);
      |           ^
test/kv.c: In function 'main':
test/kv.c:396:9: note: 'len' was declared here
  396 |     int len;
      |         ^
lto1: all warnings being treated as errors
```

Solution: give the indicated variables an initial value.

Just for completeness I tried playing around briefly with the optimization flags, and these errors only seemed to surface when link time optimization was enabled at O2 (or above), but since those are the default settings for rpmbuild, this might be helpful for easing future fedora rawhide/44 support.

That being said, these don't seem to be the only variables using this pattern, but they are the only ones flagged by the compiler; ergo, this patch is enough for everything to build without warnings, but perhaps it would be better to make the change more consistent, at least across this file?