### PR TITLE
ci: update github action versions and add dependabot to maintain them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "github: "
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -33,7 +33,7 @@ jobs:
         run: git fetch --tags || true
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
@@ -53,6 +53,6 @@ jobs:
            make -j 4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
@@ -15,8 +15,8 @@ jobs:
   spelling:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: crate-ci/typos@v1.39.0
+    - uses: actions/checkout@v6
+    - uses: crate-ci/typos@v1.45.0
 
   generate-matrix:
     # https://stackoverflow.com/questions/59977364
@@ -25,7 +25,7 @@ jobs:
     outputs:
         matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
@@ -47,7 +47,7 @@ jobs:
     name: ${{ matrix.name }}
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
@@ -65,7 +65,7 @@ jobs:
         echo git describe now reports $(git describe --always)
 
     - name: docker buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v4
       if: matrix.needs_buildx
 
     - name: docker-run-checks
@@ -74,7 +74,7 @@ jobs:
 
     - name: tmate debug
       if: ${{ !cancelled() && runner.debug }}
-      uses: mxschmitt/action-tmate@v3
+      uses: mxschmitt/action-tmate@v3.23
 
     - name: annotate errors
       if: failure() || cancelled()
@@ -83,7 +83,7 @@ jobs:
 
     - name: coverage report
       if: success() && matrix.coverage
-      uses: codecov/codecov-action@858dd794fbb81941b6d60b0dca860878cba60fa9 # v3.1.1
+      uses: codecov/codecov-action@v6
 
     - name: create release
       id: create_release
@@ -92,7 +92,7 @@ jobs:
           && matrix.create_release
           && github.repository == 'flux-framework/flux-security'
       env: ${{matrix.env}}
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         tag_name: ${{ matrix.tag }}
         name: flux-security ${{ matrix.tag }}

--- a/.typos.toml
+++ b/.typos.toml
@@ -14,6 +14,9 @@ extend-ignore-re = [
   # Allow Tru64
   'Tru64',
 ]
+[default.extend-words]
+cpy = "cpy"
+
 [default.extend-identifiers]
 gl_pathc = "gl_pathc"
 siz = "siz"

--- a/src/imp/exec/exec.c
+++ b/src/imp/exec/exec.c
@@ -325,7 +325,7 @@ int imp_exec_privileged (struct imp_state *imp, struct kv *kv)
     sd_notify (0, "STATUS=cgroup is now empty, exiting");
 
 #if HAVE_PAM
-    /* Call privliged IMP plugins/containment finalization */
+    /* Call privileged IMP plugins/containment finalization */
     if (imp_supports_pam (exec))
         pam_finish ();
 #endif /* HAVE_PAM */

--- a/src/libca/test/sigcert.c
+++ b/src/libca/test/sigcert.c
@@ -162,10 +162,10 @@ void test_load_store (void)
     name = new_keypath ("test");
     ok (stat (name, &sb) == 0 && !(sb.st_mode & (S_IRGRP|S_IROTH))
                               && !(sb.st_mode & (S_IWGRP|S_IWOTH)),
-        "secret cert file is not read/writeable by group,other");
+        "secret cert file is not read/writable by group,other");
     name = new_keypath ("test.pub");
     ok (stat (name, &sb) == 0 && !(sb.st_mode & (S_IWGRP|S_IWOTH)),
-        "public cert file mode not writeable by group,other");
+        "public cert file mode not writable by group,other");
 
     /* Load just the public key and verify keys are different
      */

--- a/src/libutil/path.c
+++ b/src/libutil/path.c
@@ -74,14 +74,14 @@ static bool parent_dir_is_secure (const char *path,
         && (st.st_mode & S_IWGRP)
         && !(st.st_mode & S_ISVTX)) {
         errprintf (error,
-                   "parent directory is group-writeable without sticky bit");
+                   "parent directory is group-writable without sticky bit");
         errno = EINVAL;
         return false;
     }
     if ((st.st_mode & S_IWOTH)
         && !(st.st_mode & S_ISVTX)) {
         errprintf (error,
-                   "parent directory is world-writeable without sticky bit");
+                   "parent directory is world-writable without sticky bit");
         errno = EINVAL;
         return false;
     }

--- a/src/libutil/test/cf.c
+++ b/src/libutil/test/cf.c
@@ -475,7 +475,7 @@ void test_path_paranoia (void)
     if (chmod (path, 0646) < 0)
         BAIL_OUT ("chmod %s: %s", path, strerror (errno));
     ok (cf_update_file (cf, path, &error) < 0 && errno == EINVAL,
-        "cf_update_file fails on world writeable file: %s",
+        "cf_update_file fails on world writable file: %s",
         error.errbuf);
 
     /*  Disabling enable-path-paranoia works */

--- a/src/libutil/test/path.c
+++ b/src/libutil/test/path.c
@@ -95,7 +95,7 @@ void test_path_is_secure (void)
     if (chmod (path, 0646) < 0)
         BAIL_OUT ("chmod %s: %s", path, strerror (errno));
     ok (!path_is_secure (path, &error) && errno == EINVAL,
-        "path_is_secure fails on world writeable file: %s",
+        "path_is_secure fails on world writable file: %s",
         error.text);
 
     if (unlink (path) < 0)

--- a/t/t0101-cf-path-security.t
+++ b/t/t0101-cf-path-security.t
@@ -83,20 +83,20 @@ test_expect_success 'reset file and directory permissions' '
 	$sudo $cf tab.ok
 '
 test_expect_success 'cf refuses to read config w/ group writable directory' '
-	name=world-writeable-dir &&
+	name=world-writable-dir &&
 	sudo chgrp $(id -n -g) $CF_TESTDIR &&
 	sudo chmod 770 $CF_TESTDIR &&
 	test_must_fail $sudo $cf tab.ok 2>cf-${name}.err &&
 	test_debug "cat cf-${name}.err" &&
-	grep "${CF_TESTDIR}.*: parent directory is group-writeable" \
+	grep "${CF_TESTDIR}.*: parent directory is group-writable" \
 	     cf-${name}.err
 '
 test_expect_success 'cf refuses to read config w/ world writable directory' '
-	name=world-writeable-dir &&
+	name=world-writable-dir &&
 	sudo chmod 707 $CF_TESTDIR &&
 	test_must_fail $sudo $cf tab.ok 2>cf-${name}.err &&
 	test_debug "cat cf-${name}.err" &&
-	grep "${CF_TESTDIR}.*: parent directory is world-writeable" \
+	grep "${CF_TESTDIR}.*: parent directory is world-writable" \
 	     cf-${name}.err
 '
 test_expect_success 'cf allows group writable directory and sticky bit' '
@@ -105,7 +105,7 @@ test_expect_success 'cf allows group writable directory and sticky bit' '
 	$sudo $cf tab.ok
 '
 test_expect_success 'cf allows world writable directory and sticky bit' '
-	name=world-writeable-sticky &&
+	name=world-writable-sticky &&
 	sudo chmod 1707 $CF_TESTDIR &&
 	$sudo $cf tab.ok
 '

--- a/t/t2000-imp-exec.t
+++ b/t/t2000-imp-exec.t
@@ -312,7 +312,7 @@ chmod +x run-in-cgroup.sh
 
 test_have_prereq SUDO &&
  $SUDO ./run-in-cgroup.sh $CGROUP_PATH cat /proc/self/cgroup &&
- test_set_prereq CGROUP_WRITEABLE
+ test_set_prereq CGROUP_WRITABLE
 
 
 #  Rewrite sleeper script so it results in a hierarchy of processes
@@ -323,7 +323,7 @@ printf "\$PPID\n" >$(pwd)/sleeper.pid
 EOF
 chmod +x sleeper.sh
 
-test_expect_success SUDO,CGROUPFS,NO_CHAIN_LINT,CGROUP_WRITEABLE \
+test_expect_success SUDO,CGROUPFS,NO_CHAIN_LINT,CGROUP_WRITABLE \
 	'flux-imp exec: SIGUSR1 sends SIGKILL via cgroup kill' '
 	fake_input_sign_none | \
 		$SUDO FLUX_IMP_CONFIG_PATTERN=sign-none.toml \
@@ -337,7 +337,7 @@ test_expect_success SUDO,CGROUPFS,NO_CHAIN_LINT,CGROUP_WRITEABLE \
 	test_must_be_empty ${CGROUP_PATH}/cgroup.procs
 '
 
-test_expect_success SUDO,CGROUPFS,NO_CHAIN_LINT,CGROUP_WRITEABLE \
+test_expect_success SUDO,CGROUPFS,NO_CHAIN_LINT,CGROUP_WRITABLE \
 	'flux-imp exec: SIGUSR1 waits for cgroup to be empty' '
 	fake_input_sign_none | \
 		$SUDO FLUX_IMP_CONFIG_PATTERN=sign-none.toml \


### PR DESCRIPTION
As was done in flux-core and other framework repos, refresh the version of github actions used in this repo and add dependabot to maintain them. Fix typos as required by the new version of `crate-ci/typos`.