### PR TITLE
ci: modernize builders in CI and fix new `-fanalyzer` bugs

### DIFF
--- a/src/imp/exec/safe_popen.c
+++ b/src/imp/exec/safe_popen.c
@@ -33,7 +33,8 @@ void safe_popen_destroy (struct safe_popen *sp)
 {
     if (sp) {
         int saved_errno = errno;
-        fclose (sp->fp);
+        if (sp->fp)
+            fclose (sp->fp);
         free (sp);
         errno = saved_errno;
     }
@@ -56,6 +57,8 @@ struct safe_popen * safe_popen (const char *cmd)
         imp_warn ("Failed to setup child for popen: %s", strerror (errno));
         goto error;
     }
+    /* fdopen consumed pfds[0], don't close it again in error path */
+    pfds[0] = -1;
 
     if (sp->pid == 0) {
         /*  Child process: Use pfds[1] as stdout
@@ -63,10 +66,20 @@ struct safe_popen * safe_popen (const char *cmd)
         char **argv = argsplit (cmd);
         if (!argv) {
             fprintf (stderr, "imp: popen: failed to tokenize '%s'\n", cmd);
+            (void) close (pfds[0]);
+            (void) close (pfds[1]);
             _exit (126);
         }
+        /* dup2 copies pfds[1] to STDOUT_FILENO. The analyzer reports this
+         * as a leak (-Wanalyzer-fd-leak), but STDOUT is intentionally left
+         * open for exec - the exec'd process will inherit it as stdout.
+         * This is a known false positive suppressed via
+         * -Wno-error=analyzer-fd-leak.
+         */
         if (dup2 (pfds[1], STDOUT_FILENO) < 0) {
             fprintf (stderr, "imp: popen: dup2: %s\n", strerror (errno));
+            (void) close (pfds[0]);
+            (void) close (pfds[1]);
             _exit (126);
         }
         (void) close (pfds[0]);
@@ -83,13 +96,17 @@ struct safe_popen * safe_popen (const char *cmd)
      */
     (void) close (pfds[1]);
 
+    /* Note: -fanalyzer reports a false positive leak of pfds[1] at function
+     * exit. It doesn't track that we closed it above. This is suppressed via
+     * -Wno-error=analyzer-fd-leak.
+     */
     return sp;
 error:
     safe_popen_destroy (sp);
-    if (pfds[0] > 0) {
+    if (pfds[0] >= 0)
         (void) close (pfds[0]);
+    if (pfds[1] >= 0)
         (void) close (pfds[1]);
-    }
     return NULL;
 }
 

--- a/src/imp/privsep.c
+++ b/src/imp/privsep.c
@@ -86,7 +86,9 @@ static void child_pfds_setup (privsep_t *ps)
      *  to bother passing to the unprivilged child.
      */
     ps->rfd = ps->upfds[0];
+    ps->upfds[0] = -1; /* Moved to rfd */
     ps->wfd = ps->ppfds[1];
+    ps->ppfds[1] = -1; /* Moved to wfd */
 
     close (ps->upfds[1]);
     ps->upfds[1] = -1;
@@ -101,7 +103,9 @@ static void parent_pfds_setup (privsep_t *ps)
      *  in parent, since they are only used in the child.
      */
     ps->rfd = ps->ppfds[0];
+    ps->ppfds[0] = -1; /* Moved to rfd */
     ps->wfd = ps->upfds[1];
+    ps->upfds[1] = -1; /* Moved to wfd */
     close (ps->ppfds[1]);
     ps->ppfds[1] = -1;
     close (ps->upfds[0]);
@@ -147,13 +151,23 @@ privsep_t * privsep_init (privsep_child_f fn, void *arg)
     ps->ppid = getpid ();
     ps->wfd = -1;
     ps->rfd = -1;
+    ps->upfds[0] = ps->upfds[1] = -1;
+    ps->ppfds[0] = ps->ppfds[1] = -1;
 
-    if (pipe2 (ps->upfds, O_CLOEXEC) < 0
-        || pipe2 (ps->ppfds, O_CLOEXEC) < 0) {
+    if (pipe2 (ps->upfds, O_CLOEXEC) < 0) {
         imp_warn ("privsep_init: pipe: %s\n", strerror (errno));
         privsep_destroy (ps);
         return (NULL);
     }
+    /* Help analyzer understand pipe2 modified the array */
+    assert (ps->upfds[0] >= 0 && ps->upfds[1] >= 0);
+
+    if (pipe2 (ps->ppfds, O_CLOEXEC) < 0) {
+        imp_warn ("privsep_init: pipe: %s\n", strerror (errno));
+        privsep_destroy (ps);
+        return (NULL);
+    }
+    assert (ps->ppfds[0] >= 0 && ps->ppfds[1] >= 0);
 
     if (run_unprivileged_child (ps, fn, arg) < 0) {
         privsep_destroy (ps);
@@ -189,6 +203,13 @@ void privsep_destroy (privsep_t *ps)
             close (ps->wfd);
         if (ps->rfd >= 0)
             close (ps->rfd);
+        /* Close any pipe fds that weren't moved to wfd/rfd yet */
+        for (int i = 0; i < 2; i++) {
+            if (ps->upfds[i] >= 0)
+                close (ps->upfds[i]);
+            if (ps->ppfds[i] >= 0)
+                close (ps->ppfds[i]);
+        }
         free (ps);
     }
 }

--- a/src/imp/test/pidinfo.c
+++ b/src/imp/test/pidinfo.c
@@ -29,8 +29,11 @@ static pid_t testchild_create (int nchildren)
         BAIL_OUT ("pipe: %s", strerror (errno));
 
     pid = fork ();
-    if (pid < 0)
+    if (pid < 0) {
+        close (pfd[0]);
+        close (pfd[1]);
         return -1;
+    }
     if (pid == 0) {
         pid_t cpid[nchildren];
 

--- a/src/libca/sigcert.c
+++ b/src/libca/sigcert.c
@@ -600,16 +600,22 @@ struct sigcert *sigcert_load (const char *name, bool secret)
         goto error;
     if (!(cert = sigcert_fread_public (fp)))
         goto error;
-    if (fclose (fp) < 0)
+    if (fclose (fp) < 0) {
+        fp = NULL; /* fclose() closes file even on error */
         goto error;
+    }
+    fp = NULL;
     // name - secret
     if (secret) {
         if (!(fp = fopen (name, "r")))
             goto error;
         if (sigcert_fread_secret (cert, fp) < 0)
             goto error;
-        if (fclose (fp) < 0)
+        if (fclose (fp) < 0) {
+            fp = NULL; /* fclose() closes file even on error */
             goto error;
+        }
+        fp = NULL;
     }
     return cert;
 inval:

--- a/src/libtap/tap.c
+++ b/src/libtap/tap.c
@@ -214,8 +214,10 @@ diag (const char *fmt, ...) {
     char *mesg, *line;
     int i;
     va_start(args, fmt);
-    if (!fmt)
+    if (!fmt) {
+        va_end(args);
         return 0;
+    }
     mesg = vstrdupf(fmt, args);
     line = mesg;
     for (i = 0; *line; i++) {

--- a/src/libutil/argsplit.c
+++ b/src/libutil/argsplit.c
@@ -15,6 +15,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 
 #include "argsplit.h"
 
@@ -54,20 +55,31 @@ char **argsplit (const char *args)
             s++;
     }
 
-    /*  Allocate return vector
+    /*  Allocate return vector: count+1 tokens plus NULL terminator
      */
-    if (!(argv = calloc (count+2, sizeof (char *))))
+    int argv_size = count + 2;
+    if (!(argv = calloc (argv_size, sizeof (char *))))
         goto error;
+    assert (argv_size > 0);
 
-    /*  Split into takens
+    /*  Split into tokens
      */
     i = 0;
     str = copy;
     while ((s = strtok_r (str, " \t", &sp))) {
+        str = NULL;
+        /* Defense-in-depth: verify we don't exceed allocated size. This
+         * protects against integer overflow in count, future logic bugs, and
+         * buffer overflows in security-critical setuid code. Should never
+         * trigger with correct counting logic.
+         */
+        if (i >= argv_size - 1) {
+            errno = EINVAL;
+            goto error;
+        }
         if (!(argv[i] = strdup (s)))
             goto error;
         i++;
-        str = NULL;
     }
     free (copy);
     return argv;

--- a/src/libutil/kv.c
+++ b/src/libutil/kv.c
@@ -194,6 +194,7 @@ static int kv_put_raw (struct kv *kv, const char *key, enum kv_type type,
     int vallen = strlen (val);
     if (kv_expand (kv, keylen + vallen + 3) < 0) // key\0Tval\0
         return -1;
+    assert (kv->buf != NULL);
     strlcpy (&kv->buf[kv->len], key, keylen + 1);
     kv->len += keylen + 1;
     kv->buf[kv->len++] = type;

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -169,7 +169,7 @@ matrix.add_build(
 matrix.add_build(
     name="fedora40",
     image="fedora40",
-    env=dict(CFLAGS="-fanalyzer"),
+    env=dict(CFLAGS="-fanalyzer -Wno-error=analyzer-fd-leak"),
 )
 
 # Fedora 40 ASan

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -129,6 +129,18 @@ matrix.add_build(
     jobs=2,
 )
 
+# Ubuntu: jammy
+matrix.add_build(
+    name="jammy",
+    image="jammy",
+)
+
+# Ubuntu: noble
+matrix.add_build(
+    name="noble",
+    image="noble",
+)
+
 # Ubuntu 20.04: py3.8
 matrix.add_build(
     name="focal",
@@ -141,19 +153,31 @@ matrix.add_build(
     image="el8",
 )
 
-# Fedora 34
+# RHEL9 clone
 matrix.add_build(
-    name="fedora34",
-    image="fedora34",
+    name="el9",
+    image="el9",
+)
+
+# RHEL10 clone
+matrix.add_build(
+    name="el10",
+    image="el10",
+)
+
+# Fedora 40
+matrix.add_build(
+    name="fedora40",
+    image="fedora40",
     env=dict(CFLAGS="-fanalyzer"),
 )
 
-# Fedora 38 ASan
+# Fedora 40 ASan
 matrix.add_build(
-    name="fedora38 - asan",
-    image="fedora38",
+    name="fedora40 - asan",
+    image="fedora40",
     args="--enable-sanitizers",
-    pam=False, # asan not compatible with PAM tests
+    pam=False,  # asan not compatible with PAM tests
 )
 
 # alpine


### PR DESCRIPTION
This PR updates the flux-security CI builders to match what we're testing in flux-core. 

The `-fanalyzer` build container is updated to fedora40, which found new issues that needed to be fixed or in one case worked around.