### PR TITLE
testsuite: fix cgroup mount dir detection in `t2000-imp-exec.t`

### DIFF
--- a/t/sharness.d/00-bail_out.sh
+++ b/t/sharness.d/00-bail_out.sh
@@ -1,0 +1,15 @@
+# Immediately bail out of the test script with the reason given in [$1].
+# See <https://testanything.org/tap-specification.html>.
+#
+# Taken from MUNGE:
+# https://github.com/dun/munge/blob/master/tests/sharness.d/00-bail_out.sh
+
+bail_out()
+{
+    local cmd="Bail out!" msg="$1"
+
+    say_color >&5 error "${cmd} ${msg}"
+    EXIT_OK=t
+    exit 1
+}
+

--- a/t/t2000-imp-exec.t
+++ b/t/t2000-imp-exec.t
@@ -15,6 +15,12 @@ sign=${SHARNESS_BUILD_DIRECTORY}/t/src/sign
 
 echo "# Using ${flux_imp}"
 
+CGROUP_MOUNT=$(awk '$3 == "cgroup2" {print $2}' /proc/self/mounts)
+test -n "$CGROUP_MOUNT" || bail_out "Failed to get cgroup2 mount dir!"
+CURRENT_CGROUP_PATH=$(cat /proc/self/cgroup | sed -n s/^0:://p)
+CGROUP_PATH="${CGROUP_MOUNT}${CURRENT_CGROUP_PATH}/imp-shell.$$"
+echo "using CGROUP_PATH=$CGROUP_PATH"
+
 fake_imp_input() {
 	printf '{"J":"%s"}' $(echo $1 | $sign)
 }
@@ -289,10 +295,6 @@ test_expect_success SUDO,NO_CHAIN_LINT,SYSTEMD_RUN \
 	test_expect_code 137 wait $pid
 '
 
-CGROUP_MOUNT=$(awk '/^cgroup2/ {print $2}' /proc/self/mounts)
-CURRENT_CGROUP_PATH=$(cat /proc/self/cgroup | sed -n s/^0:://p)
-CGROUP_PATH="${CGROUP_MOUNT}${CURRENT_CGROUP_PATH}/imp-shell.$$"
-echo "using CGROUP_PATH=$CGROUP_PATH"
 test_have_prereq SUDO &&
  $SUDO mkdir $CGROUP_PATH &&
  test_set_prereq CGROUPFS &&


### PR DESCRIPTION
The cgroup mount directory detection in `t2000-imp-exec.t` is flawed and could end up as empty on some distros. The test shoudl check for `cgroup2` in field 3 and not as the first field in `/proc/self/mounts`. 

This PR fixes the detection and adds a bail out if `CGROUP_MOUNT` is empty.