### PR TITLE
fuzz: add initial fuzzing harness to flux-security using AFL++ and fix detected issues

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -3,6 +3,7 @@ extend-exclude = [
   "config/*",
   "src/libtomlc99/*",
   "src/libtap/*",
+  "src/libutil/test/tomltk.c",
   "src/common/libutil/strlcpy*",
   "t/sharness.sh",
   "t/t0000-sharness.t"

--- a/FUZZING.md
+++ b/FUZZING.md
@@ -1,0 +1,30 @@
+# Fuzzing flux-security
+
+Complete fuzzing documentation is available in [src/fuzz/README.md](src/fuzz/README.md).
+
+## Quick Start
+
+```bash
+# Install AFL++
+git clone https://github.com/AFLplusplus/AFLplusplus
+cd AFLplusplus && make && sudo make install
+
+# Build and fuzz
+cd flux-security
+CC=afl-clang-fast ./configure --enable-fuzzing
+make
+./scripts/fuzz.py start  # Auto-generates corpus if missing
+
+# Monitor progress
+./scripts/fuzz.py watch
+
+# Triage crashes
+./scripts/fuzz.py triage
+```
+
+See [src/fuzz/README.md](src/fuzz/README.md) for:
+- Detailed harness descriptions
+- Coverage expectations
+- Crash triage workflow
+- Integration with CI/CD
+- ClusterFuzzLite and OSS-Fuzz setup

--- a/configure.ac
+++ b/configure.ac
@@ -63,6 +63,21 @@ AC_DEFINE([SANITIZERS_ENABLED], 1,
 [AC_MSG_RESULT(no)])
 AM_CONDITIONAL([SANITIZERS_ENABLED], [test "x$enable_sanitizers" != "xno" ])
 
+#
+#  If --enable-fuzzing, check that AFL compiler is being used
+#
+AC_MSG_CHECKING([whether to enable AFL fuzzing harnesses])
+AC_ARG_ENABLE([fuzzing],
+              AS_HELP_STRING([--enable-fuzzing], [Build AFL fuzzing harnesses]),
+[
+AC_MSG_RESULT($enableval)
+AS_CASE([$CC],
+        [*afl-clang-fast*|*afl-gcc*|*afl-clang*], [],
+        [AC_MSG_ERROR([--enable-fuzzing requires CC to be an AFL compiler (afl-clang-fast, afl-gcc, etc.)])])
+],
+[AC_MSG_RESULT(no)])
+AM_CONDITIONAL([ENABLE_FUZZING], [test "x$enable_fuzzing" = "xyes"])
+
 AC_CHECK_LIB(m, floor)
 
 #
@@ -182,6 +197,7 @@ AC_CONFIG_FILES( \
   src/libutil/Makefile \
   src/libca/Makefile \
   src/imp/Makefile \
+  src/fuzz/Makefile \
   doc/Makefile \
   doc/test/Makefile \
   etc/Makefile \

--- a/scripts/fuzz.py
+++ b/scripts/fuzz.py
@@ -1,0 +1,809 @@
+#!/usr/bin/env python3
+"""
+AFL++ Fuzzing Helper for flux-security
+
+Unified tool for managing AFL fuzzing campaigns.
+Replaces multiple bash scripts with a single Python CLI.
+
+Usage:
+    ./fuzz.py start [--afl-path PATH] [--corpus-dir DIR]
+    ./fuzz.py stop
+    ./fuzz.py watch [--findings-dir DIR] [--refresh-secs N]
+    ./fuzz.py triage [--findings-dir DIR]
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+class FuzzConfig:
+    """Configuration for fuzzing operations"""
+
+    def __init__(self, args):
+        self.PROJECT_ROOT = self._find_project_root()
+        self.AFL_PATH = self._resolve_afl_path(getattr(args, 'afl_path', None))
+        self.CORPUS_DIR = self.PROJECT_ROOT / getattr(args, 'corpus_dir', 'corpus')
+        self.FINDINGS_DIR = self.PROJECT_ROOT / getattr(args, 'findings_dir', 'findings')
+
+    def _find_project_root(self) -> Path:
+        """Find project root by looking for configure.ac"""
+        current = Path(__file__).resolve().parent.parent
+        while current != current.parent:
+            if (current / "configure.ac").exists():
+                return current
+            current = current.parent
+        raise FileNotFoundError(
+            "Could not find project root (no configure.ac found)"
+        )
+
+    def _resolve_afl_path(self, provided_path: Optional[str]) -> Path:
+        """Auto-detect or use provided AFL++ path"""
+        if provided_path:
+            path = Path(provided_path)
+            if not (path / "afl-fuzz").exists():
+                raise FileNotFoundError(f"afl-fuzz not found at {path}")
+            return path
+
+        # Try common locations
+        candidates = [
+            Path.home() / "git" / "AFLplusplus",
+            Path("/usr/local/bin"),
+            Path("/usr/bin"),
+        ]
+
+        for path in candidates:
+            if (path / "afl-fuzz").exists():
+                return path
+
+        raise FileNotFoundError(
+            "AFL++ not found. Install it or use --afl-path\n"
+            "See: https://github.com/AFLplusplus/AFLplusplus"
+        )
+
+
+class FuzzerManager:
+    """Manages start/stop of fuzzing sessions"""
+
+    def __init__(self, config: FuzzConfig):
+        self.config = config
+
+    def start(self):
+        """Start all fuzzing harnesses in tmux"""
+        print("Starting all fuzzing harnesses...")
+        print()
+
+        # Check prerequisites
+        self._check_prerequisites()
+
+        # Kill existing session if present
+        if self._tmux_session_exists("fuzzing"):
+            print("⚠️  Existing 'fuzzing' session found. Stopping it first...")
+            subprocess.run(["tmux", "kill-session", "-t", "fuzzing"],
+                         stderr=subprocess.DEVNULL)
+            time.sleep(1)
+
+        # Create tmux session with 4 fuzzer windows
+        self._create_tmux_session()
+
+        print()
+        print("✅ All fuzzers started successfully!")
+        print()
+        print("Note: AFL_AUTORESUME=1 is set - will resume existing runs if found")
+        print("      To start fresh: rm -rf findings/")
+        print()
+        print("Single tmux session 'fuzzing' with 4 windows:")
+        print("  - fuzzer01: Primary fuzzer (sign_unwrap_noverify) [MASTER]")
+        print("  - fuzzer02: Full verification fuzzer (sign_unwrap) [SLAVE]")
+        print("  - fuzzer03: KV format fuzzer [SLAVE]")
+        print("  - fuzzer04: Config (cf) interface fuzzer [SLAVE]")
+        print()
+        print("Commands:")
+        print("  Attach session:     tmux attach -t fuzzing")
+        print("  Switch windows:     Ctrl+b then 0/1/2/3 (or n for next)")
+        print("  Detach:             Ctrl+b then d")
+        print("  Monitor stats:      ./fuzz.py watch")
+        print("  Triage crashes:     ./fuzz.py triage")
+        print("  Stop all:           ./fuzz.py stop")
+        print()
+        print("Let fuzzers run for at least 24-48 hours for meaningful results.")
+
+    def stop(self):
+        """Stop the fuzzing session"""
+        print("Stopping fuzzing session...")
+
+        if not self._tmux_session_exists("fuzzing"):
+            print("  No 'fuzzing' session found")
+            print()
+            print("⚠️  No active fuzzing session")
+        else:
+            subprocess.run(["tmux", "kill-session", "-t", "fuzzing"])
+            print("  Killed tmux session: fuzzing (all 4 fuzzers)")
+            print()
+            print("✅ Fuzzing session stopped")
+
+        print()
+        print("To view results:")
+        print("  Dashboard:          ./fuzz.py watch")
+        print("  Triage crashes:     ./fuzz.py triage")
+        print()
+
+        # Report crash count
+        crash_count = len(list(self.config.FINDINGS_DIR.glob("*/crashes/id:*")))
+        if crash_count > 0:
+            print(f"Crash files found: ⚠️  {crash_count} crashes")
+            print("  Run ./fuzz.py triage to investigate")
+        else:
+            print("Crash files found: ✅ No crashes")
+
+    def _generate_corpus(self):
+        """Generate seed corpus using generate-fuzz-corpus.sh"""
+        script = self.config.PROJECT_ROOT / "scripts" / "generate-fuzz-corpus.sh"
+        if not script.exists():
+            raise FileNotFoundError(f"Corpus generation script not found: {script}")
+
+        print("Generating seed corpus...")
+        result = subprocess.run(
+            [str(script), str(self.config.CORPUS_DIR)],
+            cwd=self.config.PROJECT_ROOT,
+            capture_output=True,
+            text=True
+        )
+
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"Corpus generation failed:\n{result.stderr}"
+            )
+
+        print(f"✓ Corpus generated at {self.config.CORPUS_DIR}")
+        print()
+
+    def _check_prerequisites(self):
+        """Verify all required components exist"""
+        # Check AFL
+        afl_fuzz = self.config.AFL_PATH / "afl-fuzz"
+        if not afl_fuzz.exists():
+            raise FileNotFoundError(f"AFL++ not found at {afl_fuzz}")
+
+        # Check tmux
+        if subprocess.run(["which", "tmux"], capture_output=True).returncode != 0:
+            raise FileNotFoundError(
+                "tmux not found. Install it:\n"
+                "  Ubuntu/Debian: apt-get install tmux\n"
+                "  macOS: brew install tmux"
+            )
+
+        # Check fuzz harnesses
+        harness = self.config.PROJECT_ROOT / "src/fuzz/fuzz_sign_unwrap_noverify"
+        if not harness.exists():
+            raise FileNotFoundError(
+                f"Fuzz harnesses not built. Build them:\n"
+                f"  CC=afl-clang-fast ./configure --enable-fuzzing --enable-sanitizers\n"
+                f"  make"
+            )
+
+        # Check corpus - auto-generate if missing
+        corpus_missing = (
+            not (self.config.CORPUS_DIR / "sign-none").exists()
+            or not (self.config.CORPUS_DIR / "kv").exists()
+            or not (self.config.CORPUS_DIR / "toml").exists()
+        )
+
+        if corpus_missing:
+            self._generate_corpus()
+
+    def _tmux_session_exists(self, name: str) -> bool:
+        """Check if tmux session exists"""
+        result = subprocess.run(
+            ["tmux", "has-session", "-t", name],
+            capture_output=True
+        )
+        return result.returncode == 0
+
+    def _create_tmux_session(self):
+        """Create tmux session with 4 fuzzer windows"""
+        root = self.config.PROJECT_ROOT
+        afl = self.config.AFL_PATH / "afl-fuzz"
+
+        # AFL++ requires specific ASAN_OPTIONS when using ASan:
+        # - abort_on_error=1: crashes must abort for AFL to detect them
+        # - symbolize=0: AFL handles symbolization itself
+        # - detect_leaks=0: don't care about leaks at exit
+        asan_opts = "abort_on_error=1:symbolize=0:detect_leaks=0"
+
+        fuzzers = [
+            {
+                "name": "fuzzer01",
+                "desc": "sign_unwrap_noverify - MASTER",
+                "mode": "-M fuzzer01",
+                "input": "corpus/sign-none",
+                "timeout": "1000",
+                "harness": "./src/fuzz/fuzz_sign_unwrap_noverify",
+            },
+            {
+                "name": "fuzzer02",
+                "desc": "sign_unwrap - SLAVE",
+                "mode": "-S fuzzer02",
+                "input": "corpus/sign-none",
+                "timeout": "5000",
+                "harness": "./src/fuzz/fuzz_sign_unwrap",
+            },
+            {
+                "name": "fuzzer03",
+                "desc": "kv - SLAVE",
+                "mode": "-S fuzzer03",
+                "input": "corpus/kv",
+                "timeout": "1000",
+                "harness": "./src/fuzz/fuzz_kv",
+            },
+            {
+                "name": "fuzzer04",
+                "desc": "cf - SLAVE",
+                "mode": "-S fuzzer04",
+                "input": "corpus/toml",
+                "timeout": "5000",
+                "harness": "./src/fuzz/fuzz_cf",
+            },
+        ]
+
+        # Create session with first fuzzer
+        print(f"[1/4] Starting {fuzzers[0]['name']} ({fuzzers[0]['desc']})...")
+        cmd = [
+            "tmux", "new-session", "-d", "-s", "fuzzing", "-n", fuzzers[0]['name'],
+            f"cd {root} && "
+            f"ASAN_OPTIONS={asan_opts} AFL_AUTORESUME=1 {afl} "
+            f"-i {fuzzers[0]['input']} -o findings "
+            f"{fuzzers[0]['mode']} -t {fuzzers[0]['timeout']} "
+            f"{fuzzers[0].get('extra_flags', '')} "
+            f"-- {fuzzers[0]['harness']} || read -p 'Press enter'"
+        ]
+        subprocess.run(cmd)
+        time.sleep(2)
+
+        # Verify session started
+        if not self._tmux_session_exists("fuzzing"):
+            raise RuntimeError(
+                "ERROR: Failed to start fuzzing session\n"
+                f"Check if AFL can run: {afl} -i corpus/sign-none -o findings "
+                f"-M fuzzer01 -- ./src/fuzz/fuzz_sign_unwrap_noverify"
+            )
+
+        # Add remaining fuzzers as windows
+        for i, fuzzer in enumerate(fuzzers[1:], start=2):
+            print(f"[{i}/4] Starting {fuzzer['name']} ({fuzzer['desc']})...")
+            cmd = [
+                "tmux", "new-window", "-t", "fuzzing:", "-n", fuzzer['name'],
+                f"cd {root} && "
+                f"ASAN_OPTIONS={asan_opts} AFL_AUTORESUME=1 {afl} "
+                f"-i {fuzzer['input']} -o findings "
+                f"{fuzzer['mode']} -t {fuzzer['timeout']} "
+                f"{fuzzer.get('extra_flags', '')} "
+                f"-- {fuzzer['harness']} || read -p 'Press enter'"
+            ]
+            subprocess.run(cmd)
+            time.sleep(1)
+
+        # Verify all fuzzers started successfully
+        self._verify_fuzzer_startup(fuzzers)
+
+    def _verify_fuzzer_startup(self, fuzzers: List[Dict]):
+        """Verify all fuzzers started successfully"""
+        print()
+        print("Verifying fuzzer startup...")
+
+        # Wait a bit for fuzzers to initialize
+        time.sleep(3)
+
+        failed = []
+        for fuzzer in fuzzers:
+            fuzzer_name = fuzzer['name']
+            stats_file = self.config.FINDINGS_DIR / fuzzer_name / "fuzzer_stats"
+
+            if not stats_file.exists():
+                failed.append(fuzzer_name)
+
+        if failed:
+            print()
+            print(f"⚠️  Warning: {len(failed)} fuzzer(s) failed to start:")
+            for name in failed:
+                print(f"  - {name}")
+            print()
+            print("Attach to tmux to see error messages:")
+            print("  tmux attach -t fuzzing")
+            print()
+            print("Common issues:")
+            print("  - ASAN_OPTIONS incompatibility with AFL++")
+            print("  - Harness not built or not executable")
+            print("  - Corpus directory missing")
+            print()
+            raise RuntimeError(f"Fuzzer startup failed for: {', '.join(failed)}")
+
+        print(f"✓ All {len(fuzzers)} fuzzers started successfully")
+
+
+class DashboardMonitor:
+    """Live monitoring dashboard for fuzzing status"""
+
+    def __init__(self, config: FuzzConfig):
+        self.config = config
+
+    def _tmux_session_exists(self, name: str) -> bool:
+        """Check if tmux session exists"""
+        result = subprocess.run(
+            ["tmux", "has-session", "-t", name],
+            capture_output=True
+        )
+        return result.returncode == 0
+
+    def watch(self, refresh_secs: int = 5):
+        """Display live fuzzing statistics"""
+        try:
+            while True:
+                self._display_dashboard()
+                time.sleep(refresh_secs)
+        except KeyboardInterrupt:
+            print("\n\nExiting dashboard...")
+
+    def _check_fuzzers_running(self) -> bool:
+        """Check if fuzzing session is actually running"""
+        # Check if tmux session exists
+        if not self._tmux_session_exists("fuzzing"):
+            return False
+
+        # Check if any afl-fuzz processes are running
+        result = subprocess.run(
+            ["pgrep", "-f", "afl-fuzz"],
+            capture_output=True
+        )
+        return result.returncode == 0
+
+    def _display_dashboard(self):
+        """Display current fuzzing status"""
+        # Clear screen without flicker using ANSI escape codes
+        # Move cursor to home position and clear from cursor to end of screen
+        print("\033[H\033[J", end="", flush=True)
+
+        # Check if fuzzers are running
+        running = self._check_fuzzers_running()
+        status_indicator = "🟢 RUNNING" if running else "🔴 STOPPED"
+
+        print(f"================ FUZZING STATUS ({time.strftime('%H:%M:%S')}) {status_indicator} ================")
+        print()
+
+        if not self.config.FINDINGS_DIR.exists():
+            print("Error: Findings directory not found")
+            print(f"Expected: {self.config.FINDINGS_DIR}")
+            return
+
+        # Find all fuzzer stats
+        stats_files = list(self.config.FINDINGS_DIR.glob("*/fuzzer_stats"))
+
+        if not stats_files:
+            print("No active fuzzers found")
+            print()
+            if running:
+                print("Fuzzers are starting up... (stats files not yet created)")
+            else:
+                print("Start fuzzing with: ./fuzz.py start")
+            return
+
+        all_stats = []
+        for stats_file in stats_files:
+            stats = self._parse_fuzzer_stats(stats_file)
+            if stats:
+                all_stats.append(stats)
+
+        # Display per-fuzzer stats
+        for stats in all_stats:
+            self._print_fuzzer_stats(stats)
+            print()
+
+        # Overall summary
+        self._print_summary(all_stats)
+
+        print()
+        print("Press Ctrl+C to exit | Commands: ./fuzz.py stop, ./fuzz.py triage")
+
+    def _parse_fuzzer_stats(self, stats_file: Path) -> Optional[Dict]:
+        """Parse AFL fuzzer_stats file"""
+        try:
+            stats = {}
+            with open(stats_file) as f:
+                for line in f:
+                    if ':' in line:
+                        key, value = line.strip().split(':', 1)
+                        stats[key.strip()] = value.strip()
+
+            # Add derived fields
+            stats['_name'] = stats_file.parent.name
+            stats['_now'] = int(time.time())
+
+            return stats
+        except Exception:
+            return None
+
+    def _is_fuzzer_running(self, fuzzer_name: str) -> bool:
+        """Check if a specific fuzzer is currently running"""
+        # Check if tmux window exists
+        result = subprocess.run(
+            ["tmux", "list-windows", "-t", "fuzzing", "-F", "#{window_name}"],
+            capture_output=True,
+            text=True
+        )
+        if result.returncode != 0:
+            return False
+
+        windows = result.stdout.strip().split('\n')
+        if fuzzer_name not in windows:
+            return False
+
+        # Check if there's an afl-fuzz process for this fuzzer
+        result = subprocess.run(
+            ["pgrep", "-f", f"afl-fuzz.*{fuzzer_name}"],
+            capture_output=True
+        )
+        return result.returncode == 0
+
+    def _print_fuzzer_stats(self, stats: Dict):
+        """Print formatted stats for one fuzzer"""
+        name = stats['_name']
+
+        # Calculate runtime
+        start_time = int(stats.get('start_time', 0))
+        now = stats['_now']
+        runtime_secs = now - start_time
+        hours = runtime_secs // 3600
+        mins = (runtime_secs % 3600) // 60
+
+        # Get stats
+        execs = int(stats.get('execs_done', 0))
+        speed = int(float(stats.get('execs_per_sec', 0)))
+        paths = stats.get('corpus_count', '0')
+        crashes = stats.get('saved_crashes', '0')
+        hangs = stats.get('saved_hangs', '0')
+        coverage = stats.get('bitmap_cvg', '0.00')
+
+        # Last path discovery
+        last_find = int(stats.get('last_find', now))
+        time_since = now - last_find
+        hours_since = time_since // 3600
+
+        # Format exec count
+        if execs > 1000000:
+            execs_display = f"{execs // 1000000}M"
+        elif execs > 1000:
+            execs_display = f"{execs // 1000}k"
+        else:
+            execs_display = str(execs)
+
+        # Check if this fuzzer is currently running
+        is_running = self._is_fuzzer_running(name)
+        run_indicator = "●" if is_running else "○"
+
+        # Status
+        if not is_running:
+            status = "STOPPED"
+        elif time_since > 86400:
+            status = "PLATEAU"
+        elif time_since > 43200:
+            status = "SLOWING"
+        else:
+            status = "ACTIVE"
+
+        # Print compact format
+        print(f"{run_indicator} {name:10s} {hours:2d}h{mins:02d}m | {speed:6d} ex/s | "
+              f"{paths:4s} paths | {coverage:4s} cov | C:{crashes} H:{hangs}")
+        print(f"  Execs: {execs_display:8s} | Last find: {hours_since}h ago | "
+              f"Status: {status}")
+
+    def _print_summary(self, all_stats: List[Dict]):
+        """Print overall summary"""
+        print("=" * 67)
+
+        # Count total crashes/hangs
+        total_crashes = len(list(self.config.FINDINGS_DIR.glob("*/crashes/id:*")))
+        total_hangs = len(list(self.config.FINDINGS_DIR.glob("*/hangs/id:*")))
+        fuzzer_count = len(all_stats)
+
+        if total_crashes == 0 and total_hangs == 0:
+            print(f"Status: OK | Fuzzers: {fuzzer_count} | Crashes: 0 | Hangs: 0")
+        elif total_crashes > 0:
+            print(f"Status: **CRASHES** | Fuzzers: {fuzzer_count} | "
+                  f"Crashes: {total_crashes} | Hangs: {total_hangs}")
+            # Show first few crashes
+            for crash in list(self.config.FINDINGS_DIR.glob("*/crashes/id:*"))[:3]:
+                fuzzer = crash.parts[-3]
+                filename = crash.name[:50]
+                print(f"  {fuzzer:10s} {filename}...")
+        else:
+            print(f"Status: HANGS | Fuzzers: {fuzzer_count} | "
+                  f"Crashes: {total_crashes} | Hangs: {total_hangs}")
+
+        print("=" * 67)
+
+
+class CrashTriager:
+    """Interactive crash triage tool"""
+
+    def __init__(self, config: FuzzConfig):
+        self.config = config
+
+    def triage(self):
+        """Run interactive crash triage"""
+        print("=" * 67)
+        print("AFL Fuzzing Crash Triage")
+        print("=" * 67)
+        print()
+
+        # Find all crashes
+        crashes = self._find_crashes()
+
+        if not crashes:
+            print("✅ No crashes found!")
+            print()
+            hangs = len(list(self.config.FINDINGS_DIR.glob("*/hangs/id:*")))
+            print(f"Hangs found: {hangs}")
+            return
+
+        print(f"⚠️  Found {len(crashes)} crash files")
+        print()
+
+        # Group by fuzzer and signal
+        self._print_crash_summary(crashes)
+
+        # Interactive menu
+        print()
+        print("Options:")
+        print("  1) Quick test all crashes (just run them)")
+        print("  2) Full triage first crash (ASAN report + minimization)")
+        print("  3) Show crash inputs")
+        print("  4) Exit")
+        print()
+
+        try:
+            choice = input("Select option [1-4]: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            print("\nExiting.")
+            return
+
+        if choice == "1":
+            self._quick_test(crashes)
+        elif choice == "2":
+            self._full_triage(crashes[0])
+        elif choice == "3":
+            self._show_inputs(crashes)
+        else:
+            print("Exiting.")
+
+    def _find_crashes(self) -> List[Path]:
+        """Find all crash files"""
+        return sorted(self.config.FINDINGS_DIR.glob("*/crashes/id:*"))
+
+    def _print_crash_summary(self, crashes: List[Path]):
+        """Print crash summary grouped by fuzzer and signal"""
+        print("--- Crashes by Fuzzer and Signal ---")
+
+        # Group crashes
+        groups = {}
+        for crash in crashes:
+            fuzzer = crash.parts[-3]
+            signal = crash.name.split(',')[1]  # Extract sig:XX
+            key = f"{fuzzer} {signal}"
+            groups[key] = groups.get(key, 0) + 1
+
+        for key in sorted(groups.keys(), key=lambda k: groups[k], reverse=True):
+            print(f"  {groups[key]:3d} {key}")
+
+        print()
+        print("Signal types:")
+        print("  sig:05 = SIGTRAP (ASAN/UBSAN caught something)")
+        print("  sig:06 = SIGABRT (assertion/abort)")
+        print("  sig:11 = SIGSEGV (segfault/null pointer)")
+        print("  sig:04 = SIGILL (illegal instruction)")
+        print("  sig:08 = SIGFPE (div by zero)")
+
+    def _get_harness(self, fuzzer_name: str) -> str:
+        """Determine harness from fuzzer name"""
+        if "fuzzer02" in fuzzer_name:
+            return "fuzz_sign_unwrap"
+        elif "fuzzer03" in fuzzer_name:
+            return "fuzz_kv"
+        elif "fuzzer04" in fuzzer_name:
+            return "fuzz_cf"
+        else:
+            return "fuzz_sign_unwrap_noverify"
+
+    def _quick_test(self, crashes: List[Path]):
+        """Quick test all crashes"""
+        print()
+        print("=== Quick Testing All Crashes ===")
+
+        for crash in crashes:
+            fuzzer = crash.parts[-3]
+            harness = self._get_harness(fuzzer)
+            signal = crash.name.split(',')[1]
+
+            print()
+            print(f"--- {crash.name} ---")
+            print(f"Fuzzer: {fuzzer} | Harness: {harness} | Signal: {signal}")
+
+            harness_path = self.config.PROJECT_ROOT / "src/fuzz" / harness
+
+            # Run with timeout
+            try:
+                result = subprocess.run(
+                    [str(harness_path)],
+                    stdin=open(crash, 'rb'),
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    timeout=2,
+                    env={**os.environ, 'FUZZ_DEBUG': '1'}
+                )
+                if result.returncode == 0:
+                    print("Result: ✅ NO CRASH (maybe fixed?)")
+                else:
+                    print(f"Result: ❌ CRASHED (exit {result.returncode})")
+            except subprocess.TimeoutExpired:
+                print("Result: ⏱️  TIMEOUT (infinite loop?)")
+
+    def _full_triage(self, crash: Path):
+        """Full triage of first crash"""
+        fuzzer = crash.parts[-3]
+        harness = self._get_harness(fuzzer)
+
+        print()
+        print(f"=== Full Triage: {crash.name} ===")
+        print(f"Fuzzer: {fuzzer}")
+        print(f"Harness: {harness}")
+        print()
+
+        # Show input
+        print("--- Crash Input (first 200 bytes) ---")
+        subprocess.run(["hexdump", "-C", str(crash)], stdout=sys.stdout)
+        print()
+        print("As string:")
+        with open(crash, 'rb') as f:
+            data = f.read(200)
+            print(data.decode('utf-8', errors='replace'))
+        print()
+        print()
+
+        # Run with ASAN
+        print("--- ASAN/UBSAN Report ---")
+        harness_path = self.config.PROJECT_ROOT / "src/fuzz" / harness
+        env = {
+            **os.environ,
+            'FUZZ_DEBUG': '1',
+            'ASAN_OPTIONS': 'symbolize=1:abort_on_error=0:detect_leaks=0',
+            'UBSAN_OPTIONS': 'print_stacktrace=1:symbolize=1',
+        }
+        subprocess.run(
+            [str(harness_path)],
+            stdin=open(crash, 'rb'),
+            env=env
+        )
+
+        print()
+        print("--- GDB Backtrace ---")
+        with open(crash, 'rb') as crash_input:
+            subprocess.run(
+                ["gdb", "-batch",
+                 "-ex", "set pagination off",
+                 "-ex", "run",
+                 "-ex", "bt",
+                 "-ex", "info registers",
+                 "-ex", "quit",
+                 str(harness_path)],
+                stdin=crash_input,
+                env={'FUZZ_DEBUG': '1'},
+                stderr=subprocess.STDOUT
+            )
+
+    def _show_inputs(self, crashes: List[Path]):
+        """Show crash inputs"""
+        print()
+        print("=== Crash Inputs ===")
+
+        for crash in crashes:
+            print()
+            print(f"--- {crash.name} ---")
+            fuzzer = crash.parts[-3]
+            size = crash.stat().st_size
+            print(f"Fuzzer: {fuzzer} | Size: {size} bytes")
+            print()
+            subprocess.run(["hexdump", "-C", str(crash)], stdout=sys.stdout)
+            print()
+            print("As string:")
+            with open(crash, 'rb') as f:
+                data = f.read(100)
+                print(data.decode('utf-8', errors='replace'))
+            print("...")
+
+
+def main():
+    """Main entry point"""
+    parser = argparse.ArgumentParser(
+        description="AFL++ fuzzing helper for flux-security",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  ./fuzz.py start                      # Start all fuzzers
+  ./fuzz.py watch                      # Monitor fuzzing status
+  ./fuzz.py triage                     # Triage crashes
+  ./fuzz.py stop                       # Stop all fuzzers
+
+  ./fuzz.py start --afl-path ~/AFLplusplus
+  ./fuzz.py watch --refresh-secs 10
+"""
+    )
+
+    subparsers = parser.add_subparsers(dest='command', help='Command to run')
+
+    # Start command
+    start_parser = subparsers.add_parser('start', help='Start fuzzing session')
+    start_parser.add_argument('--afl-path', help='Path to AFL++ installation')
+    start_parser.add_argument('--corpus-dir', default='corpus',
+                            help='Corpus directory (default: corpus)')
+    start_parser.add_argument('--findings-dir', default='findings',
+                            help='Findings directory (default: findings)')
+
+    # Stop command
+    stop_parser = subparsers.add_parser('stop', help='Stop fuzzing session')
+    stop_parser.add_argument('--findings-dir', default='findings',
+                           help='Findings directory (default: findings)')
+
+    # Watch command
+    watch_parser = subparsers.add_parser('watch', help='Monitor fuzzing status')
+    watch_parser.add_argument('--findings-dir', default='findings',
+                            help='Findings directory (default: findings)')
+    watch_parser.add_argument('--refresh-secs', type=int, default=5,
+                            help='Refresh interval in seconds (default: 5)')
+
+    # Triage command
+    triage_parser = subparsers.add_parser('triage', help='Triage crashes')
+    triage_parser.add_argument('--findings-dir', default='findings',
+                             help='Findings directory (default: findings)')
+
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.print_help()
+        return 1
+
+    try:
+        config = FuzzConfig(args)
+
+        if args.command == 'start':
+            manager = FuzzerManager(config)
+            manager.start()
+        elif args.command == 'stop':
+            manager = FuzzerManager(config)
+            manager.stop()
+        elif args.command == 'watch':
+            monitor = DashboardMonitor(config)
+            monitor.watch(args.refresh_secs)
+        elif args.command == 'triage':
+            triager = CrashTriager(config)
+            triager.triage()
+
+        return 0
+
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    except KeyboardInterrupt:
+        print("\n\nInterrupted by user")
+        return 130
+    except Exception as e:
+        print(f"Unexpected error: {e}", file=sys.stderr)
+        import traceback
+        traceback.print_exc()
+        return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/generate-fuzz-corpus.sh
+++ b/scripts/generate-fuzz-corpus.sh
@@ -1,0 +1,248 @@
+#!/bin/bash
+#
+# Generate seed corpus for AFL fuzzing
+#
+# Usage: ./generate-fuzz-corpus.sh [corpus-dir]
+#
+
+set -e
+
+CORPUS_DIR="${1:-corpus}"
+mkdir -p "$CORPUS_DIR"/{sign-none,sign-curve,sign-munge,kv,toml}
+
+echo "=== Generating fuzzing corpus ==="
+
+# KV format examples (binary format: key\0Tvalue\0...)
+echo "Creating KV format seeds..."
+printf "key1\0svalue1\0" > "$CORPUS_DIR/kv/01-simple-string.bin"
+printf "num\0i42\0" > "$CORPUS_DIR/kv/02-int64.bin"
+printf "flag\0btrue\0" > "$CORPUS_DIR/kv/03-bool.bin"
+printf "k1\0sv1\0k2\0i123\0k3\0bfalse\0" > "$CORPUS_DIR/kv/04-multi.bin"
+printf "double\0d3.14159\0" > "$CORPUS_DIR/kv/05-double.bin"
+printf "time\0t1234567890\0" > "$CORPUS_DIR/kv/06-timestamp.bin"
+
+# Edge cases
+printf "\x00\x00\x00\x00" > "$CORPUS_DIR/kv/edge-nulls.bin"
+printf "k\0s\0" > "$CORPUS_DIR/kv/edge-empty-value.bin"
+printf "long_key_name_here\0slong_value_string_content_here\0" > "$CORPUS_DIR/kv/edge-long.bin"
+printf "version\0i1\0mechanism\0snone\0userid\0i1000\0" > "$CORPUS_DIR/kv/header-like.bin"
+
+# Format is: HEADER.PAYLOAD.SIGNATURE
+# HEADER = base64(kv with: version, mechanism, userid)
+# PAYLOAD = base64(arbitrary data)
+# SIGNATURE = mechanism-specific string
+
+echo "Creating sign format seeds..."
+
+# Example with "none" mechanism (simplest - no real signature)
+# Header KV: version=1, mechanism=none, userid=1000
+# Base64(version\0i1\0mechanism\0snone\0userid\0i1000\0) = dmVyc2lvbgBpMQBtZWNoYW5pc20Ac25vbmUAdXNlcmlkAGkxMDAwAA==
+# Payload: "hello" -> Base64 = aGVsbG8=
+# Signature for "none": just the string "none"
+cat > "$CORPUS_DIR/sign-none/01-minimal.txt" << 'EOF'
+dmVyc2lvbgBpMQBtZWNoYW5pc20Ac25vbmUAdXNlcmlkAGkxMDAwAA==.aGVsbG8=.none
+EOF
+
+# Empty payload
+cat > "$CORPUS_DIR/sign-none/02-empty-payload.txt" << 'EOF'
+dmVyc2lvbgBpMQBtZWNoYW5pc20Ac25vbmUAdXNlcmlkAGkxMDAwAA==..none
+EOF
+
+# Different userid
+cat > "$CORPUS_DIR/sign-none/03-user-5000.txt" << 'EOF'
+dmVyc2lvbgBpMQBtZWNoYW5pc20Ac25vbmUAdXNlcmlkAGk1MDAwAA==.dGVzdA==.none
+EOF
+
+# Longer payload
+cat > "$CORPUS_DIR/sign-none/04-long-payload.txt" << 'EOF'
+dmVyc2lvbgBpMQBtZWNoYW5pc20Ac25vbmUAdXNlcmlkAGkxMDAwAA==.VGhpcyBpcyBhIGxvbmdlciBwYXlsb2FkIHRoYXQgY29udGFpbnMgbW9yZSBkYXRhIGZvciB0ZXN0aW5n.none
+EOF
+
+# Malformed examples for robustness
+echo "Creating malformed seeds..."
+echo "not.enough.parts" > "$CORPUS_DIR/sign-none/bad-01-missing-part.txt"
+echo "......" > "$CORPUS_DIR/sign-none/bad-02-only-dots.txt"
+echo "A.B." > "$CORPUS_DIR/sign-none/bad-03-empty-sig.txt"
+echo "A.B.C.D" > "$CORPUS_DIR/sign-none/bad-04-extra-part.txt"
+echo "invalid-base64!@#$.data.sig" > "$CORPUS_DIR/sign-none/bad-05-invalid-b64.txt"
+echo ".." > "$CORPUS_DIR/sign-none/bad-06-empty-parts.txt"
+echo "A." > "$CORPUS_DIR/sign-none/bad-07-missing-payload-sig.txt"
+echo ".B.C" > "$CORPUS_DIR/sign-none/bad-08-empty-header.txt"
+
+# Variations with valid base64 but invalid KV content
+BAD_KV_HEADER=$(printf "invalid-kv-no-nulls" | base64)
+echo "${BAD_KV_HEADER}.aGVsbG8=.none" > "$CORPUS_DIR/sign-none/bad-09-invalid-kv.txt"
+
+# Single character components
+echo "A.B.C" > "$CORPUS_DIR/sign-none/bad-10-minimal-valid-format.txt"
+
+# TOML configuration format examples
+echo "Creating TOML configuration seeds..."
+
+# Minimal valid TOML
+cat > "$CORPUS_DIR/toml/01-minimal.toml" << 'EOF'
+key = "value"
+EOF
+
+# IMP-like configuration
+cat > "$CORPUS_DIR/toml/02-imp-config.toml" << 'EOF'
+allow-sudo = true
+
+[exec]
+allowed-users = ["testuser"]
+allowed-shells = ["/bin/sh", "/bin/bash"]
+
+[sign]
+max-ttl = 3600
+default-type = "none"
+allowed-types = ["none"]
+EOF
+
+# Nested tables and arrays
+cat > "$CORPUS_DIR/toml/03-nested.toml" << 'EOF'
+[database]
+server = "192.168.1.1"
+ports = [8001, 8001, 8002]
+connection_max = 5000
+enabled = true
+
+[database.credentials]
+user = "admin"
+password = "secret"
+
+[[products]]
+name = "Hammer"
+sku = 738594937
+
+[[products]]
+name = "Nail"
+sku = 284758393
+EOF
+
+# Various data types
+cat > "$CORPUS_DIR/toml/04-types.toml" << 'EOF'
+# Strings
+string1 = "basic string"
+string2 = 'literal string'
+string3 = """
+multi-line
+basic string
+"""
+string4 = '''
+multi-line
+literal string
+'''
+
+# Numbers
+int1 = 42
+int2 = -17
+int3 = 1_000_000
+float1 = 3.14159
+float2 = -0.01
+float3 = 5e+22
+
+# Booleans
+bool1 = true
+bool2 = false
+
+# Dates and times
+date1 = 1979-05-27T07:32:00Z
+date2 = 1979-05-27
+EOF
+
+# String escaping edge cases
+cat > "$CORPUS_DIR/toml/05-escaping.toml" << 'EOF'
+escaped = "line1\nline2\ttab\"quote\\"
+unicode = "unicode: \u03B1 \U0001F600"
+path = "C:\\Users\\test\\file.txt"
+EOF
+
+# Arrays of different types
+cat > "$CORPUS_DIR/toml/06-arrays.toml" << 'EOF'
+integers = [1, 2, 3]
+colors = ["red", "yellow", "green"]
+nested = [[1, 2], [3, 4, 5]]
+mixed = [[1, 2], ["a", "b", "c"]]
+EOF
+
+# Empty and minimal values
+cat > "$CORPUS_DIR/toml/07-empty.toml" << 'EOF'
+empty_string = ""
+empty_array = []
+[empty_table]
+EOF
+
+# Inline tables
+cat > "$CORPUS_DIR/toml/08-inline.toml" << 'EOF'
+name = {first = "Tom", last = "Preston-Werner"}
+point = {x = 1, y = 2}
+animal = {type.name = "pug"}
+EOF
+
+# Comments
+cat > "$CORPUS_DIR/toml/09-comments.toml" << 'EOF'
+# This is a comment
+key = "value"  # inline comment
+
+[section]  # section comment
+# Multiple
+# comment
+# lines
+option = true
+EOF
+
+# Malformed examples
+echo "Creating malformed TOML seeds..."
+
+# Syntax errors
+cat > "$CORPUS_DIR/toml/bad-01-unclosed-string.toml" << 'EOF'
+key = "value
+EOF
+
+cat > "$CORPUS_DIR/toml/bad-02-invalid-key.toml" << 'EOF'
+= "no key"
+EOF
+
+cat > "$CORPUS_DIR/toml/bad-03-duplicate-key.toml" << 'EOF'
+key = "value1"
+key = "value2"
+EOF
+
+cat > "$CORPUS_DIR/toml/bad-04-invalid-table.toml" << 'EOF'
+[table
+EOF
+
+cat > "$CORPUS_DIR/toml/bad-05-type-mismatch.toml" << 'EOF'
+arr = [1, 2, "mixed"]
+EOF
+
+cat > "$CORPUS_DIR/toml/bad-06-invalid-unicode.toml" << 'EOF'
+str = "\uZZZZ"
+EOF
+
+cat > "$CORPUS_DIR/toml/bad-07-invalid-escape.toml" << 'EOF'
+str = "\q"
+EOF
+
+# Edge cases
+echo "" > "$CORPUS_DIR/toml/edge-01-empty.toml"
+echo "a=1" > "$CORPUS_DIR/toml/edge-02-minimal.toml"
+printf "\n\n\n" > "$CORPUS_DIR/toml/edge-03-only-newlines.toml"
+printf "###" > "$CORPUS_DIR/toml/edge-04-only-comments.toml"
+
+echo ""
+echo "==============================================="
+echo "Corpus generated in $CORPUS_DIR/"
+echo ""
+echo "Directory structure:"
+ls -lR "$CORPUS_DIR"
+echo ""
+echo "To use with AFL:"
+echo "  afl-fuzz -i $CORPUS_DIR/sign-none -o findings -- ./src/fuzz/fuzz_sign_unwrap_noverify"
+echo "  afl-fuzz -i $CORPUS_DIR/kv -o findings -- ./src/fuzz/fuzz_kv"
+echo "  afl-fuzz -i $CORPUS_DIR/toml -o findings -- ./src/fuzz/fuzz_cf"
+echo ""
+echo "NOTE: For curve/munge mechanism seeds, you'll need to:"
+echo "  1. Use existing flux-security test fixtures (if available)"
+echo "  2. Generate real signed payloads with those mechanisms"
+echo ""

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,3 +5,7 @@ SUBDIRS = \
 	libca \
 	lib \
 	imp
+
+if ENABLE_FUZZING
+SUBDIRS += fuzz
+endif

--- a/src/fuzz/COVERAGE-NOTES.md
+++ b/src/fuzz/COVERAGE-NOTES.md
@@ -1,0 +1,139 @@
+# AFL++ Coverage Analysis Notes
+
+## Expected Coverage Ranges
+
+The AFL++ bitmap coverage percentage can be misleading because it's
+measured against ALL instrumented code in the linked libraries, not
+just the target code.
+
+### What Gets Instrumented
+
+When you link against:
+- `libflux-security.la` (~4000 edges)
+- `libutil.la` (~200 edges)
+- `libtomlc99.la` (~100 edges)
+- Plus dependencies (jansson, libsodium, etc.)
+
+**Total: ~4,300-4,500 instrumented edges**
+
+### Parser-Only Fuzzing (NOVERIFY)
+
+**fuzz_sign_unwrap_noverify**: Expect **3-5% coverage**
+- Exercises: Base64 decode, KV parse, format validation
+- Skips: Signature verification, crypto operations
+- This is CORRECT - we're testing 150-200 edges of parsing code
+- Map size: ~4,346 instrumented edges (all linked libraries)
+
+### Full Verification Fuzzing
+
+**fuzz_sign_unwrap**: Expect **3-5% coverage with "none" mechanism**
+- With "none": Same as noverify (3.61% observed)
+- With curve/munge + valid keys: 10-15% (includes crypto
+  operations)
+- Default config uses "none" for simplicity
+- Map size: ~4,346 instrumented edges
+
+### KV Format Fuzzing
+
+**fuzz_kv**: Expect **10-15% coverage**
+- Exercises: Pure KV parser (13.31% observed)
+- Higher % because smaller map size: only ~511 instrumented edges
+- Links only libutil.la, not full security stack
+- Focused target with minimal dependencies
+
+## Troubleshooting Low Coverage (<1%)
+
+If you see coverage below 1%, something is wrong:
+
+### 1. Config Not Loading (MOST COMMON)
+**Symptom**: Coverage 0.5-0.7%, corpus doesn't grow
+**Cause**: `flux_security_configure()` failing silently
+**Fix**: Harnesses now auto-detect config in multiple locations
+
+**Verify**:
+```bash
+# Should find config automatically
+./src/fuzz/fuzz_sign_unwrap_noverify < /dev/null
+# Should exit 0 or 1, NOT print "FATAL: Could not load config"
+
+# If it fails, try:
+FUZZ_CONFIG_PATH="src/fuzz/conf.d/*.toml" \
+    ./src/fuzz/fuzz_sign_unwrap_noverify < /dev/null
+```
+
+### 2. Corpus Too Similar
+**Symptom**: Coverage plateaus quickly, low path diversity
+**Solution**: Generate better seed corpus with
+`scripts/generate-fuzz-corpus.sh`
+
+### 3. AFL Not Instrumenting
+**Symptom**: AFL complains "no instrumentation detected"
+**Solution**: Rebuild with `CC=afl-clang-fast`
+
+## Improving Coverage
+
+### 1. Test All Mechanisms
+Create seeds for curve and munge mechanisms (requires
+infrastructure):
+```bash
+# Generate real signed payloads
+flux-security-sign-tool --mech=curve input.txt > \
+    corpus/curve-001.txt
+flux-security-sign-tool --mech=munge input.txt > \
+    corpus/munge-001.txt
+```
+
+### 2. Use Full Verification Harness
+```bash
+# Higher coverage but slower
+afl-fuzz -i corpus/sign-none -o findings -- \
+    src/fuzz/fuzz_sign_unwrap
+```
+
+### 3. Dictionary-Based Fuzzing
+Create `sign.dict`:
+```
+"."
+".."
+"..."
+"version"
+"mechanism"
+"userid"
+"none"
+"curve"
+"munge"
+```
+
+Run with: `afl-fuzz -x sign.dict ...`
+
+### 4. Combine Multiple Harnesses
+Run all three in parallel for comprehensive coverage.
+
+## Interpreting Results
+
+**Good fuzzing run**:
+- Coverage: 3-15% (depending on harness)
+- Corpus grows steadily for first 1-2 hours
+- Plateaus after 12-24 hours
+- Path discovery continues occasionally
+
+**Problem indicators**:
+- Coverage < 1%
+- Corpus = initial size (no growth)
+- Very high exec/sec (>500k) with no discoveries
+- AFL reports "no new paths in 24h" within first hour
+
+## Coverage vs. Security
+
+**Important**: Coverage percentage ≠ security thoroughness
+
+- 5% coverage of a parser = 100% of that parser's code
+- The other 95% is unrelated functionality
+- Quality of inputs matters more than coverage %
+- Edge cases and malformed inputs are what find bugs
+
+Focus on:
+1. ✅ Corpus growth (new paths discovered)
+2. ✅ Crashes found
+3. ✅ Execution speed (>100k/sec)
+4. ⚠️ Coverage % (informational only)

--- a/src/fuzz/FUZZING-COVERAGE-ANALYSIS.md
+++ b/src/fuzz/FUZZING-COVERAGE-ANALYSIS.md
@@ -1,0 +1,221 @@
+# IMP Privileged Code Path Coverage Analysis
+
+## Attack Surface Inventory
+
+This document analyzes all code paths where untrusted input reaches
+the privileged IMP parent process, and verifies fuzzing coverage.
+
+## Privilege Separation Architecture
+
+```
+┌────────────────────────────────────────────────────────┐
+│                 UNPRIVILEGED CHILD                     │
+│  - Parses CLI arguments                                │
+│  - Reads environment variables                         │
+│  - Reads data from stdin/files                         │
+│  - Performs initial validation                         │
+│  - Sends sanitized data to parent via pipe             │
+└──────────────────┬─────────────────────────────────────┘
+                   │ privsep pipe (KV format)
+                   ▼
+┌────────────────────────────────────────────────────────┐
+│                  PRIVILEGED PARENT                     │
+│  - Receives KV-encoded data                            │
+│  - Unwraps signed payloads                             │
+│  - Performs privileged operations                      │
+└────────────────────────────────────────────────────────┘
+```
+
+**Key insight**: The privilege boundary is crossed via structured
+data formats (KV and signed payloads), NOT raw CLI args or env vars.
+
+## Input Sources to Privileged Parent
+
+### 1. ✅ FUZZED: Privsep Pipe Communication (KV format)
+
+**Source**: `src/imp/privsep.c:281` - `privsep_read_kv()`
+- Reads length-prefixed KV structures from unprivileged child
+- Limit: 4MB max (`PRIVSEP_MAX_KVLEN`)
+- Calls `kv_decode()` on received data
+
+**Fuzzer**: `src/fuzz/fuzz_kv.c`
+- Speed: ~200k execs/sec
+- Coverage: 10-15% (focused on KV parser)
+- Tests: null termination, even nulls, key length, type
+  validation
+
+**Risk**: HIGH - Direct privsep attack surface
+**Status**: ✅ **FULLY COVERED**
+
+### 2. ✅ FUZZED: Signed Payload Unwrapping
+
+**Source**: `src/imp/exec/exec.c:141` - `flux_sign_unwrap()`
+- Parses `HEADER.PAYLOAD.SIGNATURE` format
+- Called in privileged context to validate job execution requests
+- Header contains: version, mechanism, userid (KV-encoded,
+  base64)
+- Payload contains: arbitrary user data (base64)
+
+**Fuzzers**:
+- `fuzz_sign_unwrap_noverify.c` (primary) - ~180k execs/sec
+- `fuzz_sign_unwrap.c` (with crypto) - ~20-50k execs/sec
+
+**Risk**: HIGH - Privileged parser of user-supplied data
+**Status**: ✅ **FULLY COVERED**
+
+### 3. ✅ COVERED: Certificate Encoding (casign command)
+
+**Source**: `src/imp/casign.c:64` - `kv_decode()`
+- Decodes certificate KV structure from privsep pipe
+- Called in privileged parent during CA signing operations
+
+**Fuzzer**: `fuzz_kv.c` (same fuzzer as #1)
+**Risk**: MEDIUM - Limited to users with casign access
+**Status**: ✅ **COVERED** (via privsep KV fuzzing)
+
+## Input Sources NOT Reaching Privileged Parent
+
+### Command-Line Arguments
+
+**Where parsed**: Unprivileged child only
+- `src/imp/exec/exec.c:189` - shell path from `argv[2]`
+- `src/imp/exec/exec.c:191` - shell args encoded to KV
+
+**Transmitted to parent**: Only after KV encoding and validation
+**Direct parsing in parent**: NONE
+**Risk assessment**: LOW - Pre-processed before privilege
+boundary
+**Fuzzing needed**: NO (not direct privileged input)
+
+### Environment Variables
+
+**Where parsed**: Unprivileged child only
+- `FLUX_IMP_EXEC_HELPER` - read by `imp_exec_init_helper()`
+- `FLUX_IMP_CONFIG_PATTERN` - read during initialization
+
+**Transmitted to parent**: NONE (processed entirely in child)
+**Direct parsing in parent**: NONE
+**Risk assessment**: LOW - Cannot directly influence parent
+**Fuzzing needed**: NO (not privileged input)
+
+### Configuration Files
+
+**Where parsed**: Before privilege separation (both processes)
+**Format**: TOML via libtomlc99
+**User control**: NONE (requires root to modify)
+**Risk assessment**: OUT OF SCOPE (per user guidance)
+**Fuzzing needed**: NO (explicitly excluded)
+
+## Commands and Their Data Flows
+
+### `flux-imp exec`
+```
+stdin (JSON) → unprivileged child
+  ├─ Extracts "J" field (signed payload)
+  ├─ Validates shell path against allowed-shells
+  └─ Encodes to KV → privsep pipe → privileged parent
+      └─ Calls flux_sign_unwrap() ✅ FUZZED
+```
+
+### `flux-imp run`
+```
+argv[2] (command name) + filtered env vars → unprivileged child
+  └─ Encodes to KV → privsep pipe → privileged parent
+      └─ Calls kv_get() to extract command ✅ FUZZED
+```
+Lightweight sudo mechanism - no signature verification, just KV
+encoding of command name and allowed environment variables.
+
+### `flux-imp casign`
+```
+stdin (certificate) → unprivileged child
+  └─ Encodes to KV → privsep pipe → privileged parent
+      └─ Calls kv_decode() ✅ FUZZED
+```
+
+### `flux-imp whoami`
+```
+No stdin, minimal args → unprivileged child
+  └─ Sends command name only → privileged parent
+      └─ No parsing, just queries UID
+```
+
+## Coverage Verification
+
+### Current Fuzzing Suite
+
+| Harness                      | Target          | Speed     |
+|------------------------------|-----------------|-----------|
+| fuzz_sign_unwrap_noverify.c  | Parser only     | 180k ex/s |
+| fuzz_sign_unwrap.c           | Parser + crypto | 20-50k/s  |
+| fuzz_kv.c                    | KV format       | 200k ex/s |
+
+All targets are HIGH risk.
+
+### All High-Risk Paths Covered
+
+✅ **flux_sign_unwrap()** - 2 fuzzers targeting different code
+paths
+✅ **kv_decode()** - 1 fuzzer with comprehensive coverage
+✅ **privsep communication** - All data flows use above formats
+
+### Gaps: NONE IDENTIFIED
+
+No additional parsers, command-line processing, or environment
+variable handling occurs in the privileged parent that isn't
+already covered by existing fuzzers.
+
+## Recommendations
+
+### Keep Current Approach ✅
+
+The fuzzing strategy is **comprehensive** for the privileged
+attack surface. No additional harnesses are needed because:
+
+1. **All privileged parsers are fuzzed** - KV and sign/unwrap
+   formats
+2. **CLI args don't reach parent directly** - Processed in
+   unprivileged child first
+3. **Environment variables don't reach parent** - Used only in
+   child
+4. **Privsep boundary is well-defined** - Only structured data
+   crosses
+
+### Optional Enhancements (Low Priority)
+
+If pursuing defense-in-depth, could add:
+
+1. **Integration fuzzing** - Full IMP invocation with crafted inputs
+   - Pros: Tests end-to-end flows
+   - Cons: Much slower, lower exec/sec
+   - Value: Minimal (parsers already covered)
+
+2. **Argument parsing fuzzing** - CLI argument combinations
+   - Pros: Might find shell path validation bugs
+   - Cons: Not privileged code, limited security impact
+   - Value: Very low
+
+3. **Environment variable fuzzing** - Malformed FLUX_IMP_* vars
+   - Pros: Could find DoS conditions
+   - Cons: Not privileged code, user controls their own env
+   - Value: Very low
+
+### Continue Current Strategy
+
+- Run fuzzers for 48+ hours before releases
+- No new harnesses required
+- Focus on parser fuzzing (highest ROI)
+- Monitor for 0 crashes, not maximum coverage %
+
+## Conclusion
+
+**The privileged IMP code paths are comprehensively fuzzed.** All
+data that crosses the privilege boundary (privsep pipe) flows
+through kv_decode() and flux_sign_unwrap(), both of which have
+dedicated high-performance fuzzers exercising 100% of the parsing
+logic.
+
+Command-line arguments and environment variables are processed in
+the unprivileged child and never reach the privileged parent as
+raw strings, eliminating them as direct attack vectors against
+privileged code.

--- a/src/fuzz/Makefile.am
+++ b/src/fuzz/Makefile.am
@@ -1,0 +1,53 @@
+if ENABLE_FUZZING
+
+AM_CFLAGS = \
+	-I$(top_srcdir) \
+	-I$(top_builddir) \
+	$(WARNING_CFLAGS) \
+	$(JANSSON_CFLAGS) \
+	$(SODIUM_CFLAGS) \
+	$(LIBUUID_CFLAGS) \
+	$(MUNGE_CFLAGS) \
+	$(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+	$(CODE_COVERAGE_LIBS) \
+	$(JANSSON_LIBS) \
+	$(SODIUM_LIBS) \
+	$(LIBUUID_LIBS) \
+	$(MUNGE_LIBS) \
+	-no-install
+
+AM_CPPFLAGS = \
+	-I$(top_srcdir) \
+	-I$(top_builddir) \
+	$(JANSSON_CFLAGS) \
+	$(SODIUM_CFLAGS) \
+	$(LIBUUID_CFLAGS) \
+	$(MUNGE_CFLAGS)
+
+noinst_PROGRAMS = \
+	fuzz_sign_unwrap \
+	fuzz_kv \
+	fuzz_sign_unwrap_noverify
+
+# Primary harness: sign_unwrap with verification
+fuzz_sign_unwrap_SOURCES = fuzz_sign_unwrap.c
+fuzz_sign_unwrap_LDADD = \
+	$(top_builddir)/src/lib/libflux-security.la \
+	$(top_builddir)/src/libutil/libutil.la \
+	$(top_builddir)/src/libtomlc99/libtomlc99.la
+
+# Fast harness: sign_unwrap without verification (NOVERIFY flag)
+fuzz_sign_unwrap_noverify_SOURCES = fuzz_sign_unwrap_noverify.c
+fuzz_sign_unwrap_noverify_LDADD = \
+	$(top_builddir)/src/lib/libflux-security.la \
+	$(top_builddir)/src/libutil/libutil.la \
+	$(top_builddir)/src/libtomlc99/libtomlc99.la
+
+# KV parser harness
+fuzz_kv_SOURCES = fuzz_kv.c
+fuzz_kv_LDADD = \
+	$(top_builddir)/src/libutil/libutil.la
+
+endif

--- a/src/fuzz/Makefile.am
+++ b/src/fuzz/Makefile.am
@@ -29,7 +29,8 @@ AM_CPPFLAGS = \
 noinst_PROGRAMS = \
 	fuzz_sign_unwrap \
 	fuzz_kv \
-	fuzz_sign_unwrap_noverify
+	fuzz_sign_unwrap_noverify \
+	fuzz_cf
 
 # Primary harness: sign_unwrap with verification
 fuzz_sign_unwrap_SOURCES = fuzz_sign_unwrap.c
@@ -49,5 +50,11 @@ fuzz_sign_unwrap_noverify_LDADD = \
 fuzz_kv_SOURCES = fuzz_kv.c
 fuzz_kv_LDADD = \
 	$(top_builddir)/src/libutil/libutil.la
+
+# Configuration (cf) interface harness
+fuzz_cf_SOURCES = fuzz_cf.c
+fuzz_cf_LDADD = \
+	$(top_builddir)/src/libutil/libutil.la \
+	$(top_builddir)/src/libtomlc99/libtomlc99.la
 
 endif

--- a/src/fuzz/README.md
+++ b/src/fuzz/README.md
@@ -1,0 +1,239 @@
+# AFL++ Fuzzing Harnesses
+
+Fuzzing harnesses for security-critical parsers that process user data
+in privileged contexts.
+
+## Overview
+
+flux-security processes user-controlled data in privileged contexts
+(IMP privilege separation). Parser bugs could lead to privilege
+escalation. Fuzzing targets:
+
+1. **`flux_sign_unwrap()`** - Parses `HEADER.PAYLOAD.SIGNATURE` format
+   in privileged IMP parent
+2. **`kv_decode()`** - Parses privsep pipe communication
+3. **`cf_update()`** - Parses TOML configuration files for IMP
+
+## Quick Start
+
+```bash
+# 1. Install AFL++
+git clone https://github.com/AFLplusplus/AFLplusplus
+cd AFLplusplus && make && sudo make install
+
+# 2. Build with AFL
+cd flux-security
+CC=afl-clang-fast ./configure --enable-fuzzing
+make
+
+# 3. Start all fuzzers (auto-generates corpus if missing)
+./scripts/fuzz.py start
+
+# 4. Monitor progress
+./scripts/fuzz.py watch
+```
+
+## Fuzzing Harnesses
+
+### fuzz_sign_unwrap_noverify (PRIMARY)
+- **Target**: Sign/unwrap parser without crypto overhead
+- **Speed**: ~180k execs/sec
+- **Priority**: Run this first and longest
+- **Attack Surface**: Base64 decoding, header parsing, payload extraction
+
+### fuzz_kv
+- **Target**: KV format parser (privsep communication)
+- **Speed**: ~200k execs/sec
+- **Priority**: High - direct privilege boundary
+- **Attack Surface**: Key-value parsing, type handling, buffer boundaries
+
+### fuzz_sign_unwrap
+- **Target**: Full sign/unwrap with signature verification
+- **Speed**: ~20-50k execs/sec (slower due to crypto)
+- **Priority**: Medium - tests crypto integration
+- **Attack Surface**: Full signature verification flow, mechanism handling
+
+### fuzz_cf
+- **Target**: Configuration (cf) interface for TOML parsing
+- **Speed**: ~100-150k execs/sec
+- **Priority**: High - IMP config parsing is security-critical
+- **Attack Surface**: TOML parsing, schema validation, type coercion, pattern matching
+
+## Parallel Fuzzing
+
+The `fuzz.py` tool automatically starts 4 fuzzers in parallel:
+
+```bash
+# Start all fuzzers in a single tmux session
+./scripts/fuzz.py start
+
+# Attach to tmux session to see fuzzer output
+tmux attach -t fuzzing
+
+# Switch between fuzzer windows: Ctrl+b then 0/1/2/3
+# Detach from tmux: Ctrl+b then d
+
+# Stop all fuzzers
+./scripts/fuzz.py stop
+```
+
+## Monitoring Progress
+
+```bash
+# Live dashboard (refreshes every 5 seconds)
+./scripts/fuzz.py watch
+
+# Check progress with AFL's tool
+afl-whatsup findings/
+
+# View crashes and hangs
+ls findings/*/crashes/
+ls findings/*/hangs/
+```
+
+## Coverage Expectations
+
+AFL reports coverage as % of ALL instrumented code (including
+libraries). Expected ranges:
+
+- **fuzz_sign_unwrap_noverify**: 3-5% (parser code only,
+  ~4,346 edge map)
+- **fuzz_sign_unwrap**: 3-5% with "none" mechanism; 10-15% with
+  curve/munge
+- **fuzz_kv**: 10-15% (smaller ~511 edge map = higher %)
+
+**⚠️ If coverage is <1%, config may not be loading!** Check that
+`conf.d/sign.toml` exists and is readable. Set `FUZZ_CONFIG_PATH`
+to override the default location.
+
+## Crash Triage
+
+When crashes are found, use the interactive triage tool:
+
+```bash
+# Interactive crash triage
+./scripts/fuzz.py triage
+
+# Triage crashes from alternate findings directory
+./scripts/fuzz.py triage --findings-dir findings-alternate
+```
+
+The triage tool provides options to:
+1. Quick test all crashes (identifies which still reproduce)
+2. Full triage with ASAN/UBSAN (detailed error reports)
+3. View crash inputs (hexdump)
+
+### Manual Crash Reproduction
+
+```bash
+# Reproduce a specific crash (FUZZ_DEBUG=1 shows error output)
+FUZZ_DEBUG=1 src/fuzz/fuzz_sign_unwrap_noverify < \
+    findings/fuzzer01/crashes/id:000000...
+
+# With full sanitizer output
+FUZZ_DEBUG=1 \
+ASAN_OPTIONS=symbolize=1:abort_on_error=0 \
+UBSAN_OPTIONS=print_stacktrace=1:symbolize=1 \
+    src/fuzz/fuzz_sign_unwrap_noverify < crash_file
+```
+
+**Note**: Always use `FUZZ_DEBUG=1` when debugging crashes. This
+prevents the harness from closing stderr, allowing you to see ASAN
+reports and error messages.
+
+### Understanding Signal Codes
+
+Crash filenames include signal codes:
+- `sig:06` = SIGABRT (assertion failure / abort)
+- `sig:11` = SIGSEGV (segmentation fault / null pointer)
+- `sig:05` = SIGTRAP (UBSAN/ASAN caught an error)
+- `sig:04` = SIGILL (illegal instruction)
+- `sig:08` = SIGFPE (floating point exception)
+
+### Minimizing Crashes
+
+```bash
+# Make crash input smaller for easier analysis
+afl-tmin -i crash_file -o minimized.txt -- \
+    ./src/fuzz/fuzz_sign_unwrap_noverify
+```
+
+## Interpreting Results
+
+### When to Stop Fuzzing
+
+**Stop fuzzing when:**
+- No new paths discovered in 24+ hours
+- Corpus size stabilizes for 12+ hours
+- Coverage plateau reached
+
+**Before release:**
+- Run for minimum 48 hours
+- Must find 0 crashes
+- Review all hangs
+
+### Expected Bugs
+
+Fuzzing is designed to catch:
+- Buffer overflows in base64 decoder
+- Integer overflows in size calculations  
+- Format string bugs in error handling
+- Invalid KV format handling
+- Header validation bypass
+- NULL pointer dereferences
+- Use-after-free
+
+## Security Notes
+
+### Input Size Limits
+All harnesses limit input to 1MB to prevent memory exhaustion attacks
+during fuzzing.
+
+### Configuration
+Harnesses require `conf.d/sign.toml` for initialization. Set
+`FUZZ_CONFIG_PATH` environment variable to override default location.
+
+### Sanitizers
+Build with `--enable-sanitizers` for better bug detection:
+```bash
+CC=afl-clang-fast \
+CFLAGS="-fsanitize=address -fsanitize=undefined" \
+./configure --enable-fuzzing --enable-sanitizers
+```
+
+**Note**: AFL++ and ASAN can conflict on some kernels (OrbStack),
+producing false-positive SIGTRAP crashes. Test suspected crashes in
+an ASAN-only build (without AFL) to verify.
+
+## Integration
+
+For continuous fuzzing, consider:
+
+### ClusterFuzzLite
+GitHub Actions integration for PR fuzzing and batch fuzzing:
+- [ClusterFuzzLite](https://github.com/google/clusterfuzzlite)
+- Run fuzzing on every PR (5-10 min)
+- Nightly batch fuzzing (6+ hours)
+
+### OSS-Fuzz
+Long-running continuous fuzzing infrastructure:
+- [OSS-Fuzz](https://github.com/google/oss-fuzz) submission
+- Free for open source projects
+- Runs 24/7 with dedicated resources
+- Automatic bug reporting
+
+### CI/CD Integration
+```bash
+# Quick smoke test (5 minutes) - run on every PR
+make -C src/fuzz smoke-test
+
+# Full campaign (12-24 hours) - run nightly
+make -C src/fuzz fuzz-all
+```
+
+## References
+
+- [AFL++ Documentation](https://aflplus.plus/)
+- [Fuzzing at Scale (Google)](https://security.googleblog.com/2016/08/guided-in-process-fuzzing-of-chrome.html)
+- [ClusterFuzzLite](https://github.com/google/clusterfuzzlite)
+- [OSS-Fuzz](https://google.github.io/oss-fuzz/)

--- a/src/fuzz/conf.d/sign.toml
+++ b/src/fuzz/conf.d/sign.toml
@@ -1,0 +1,10 @@
+# Configuration for AFL fuzzing harnesses
+# Allows multiple mechanisms to increase code coverage
+
+[sign]
+max-ttl = 259200
+default-type = "none"
+allowed-types = [ "none", "munge" ]
+
+# Munge mechanism requires munged to be running
+[sign.munge]

--- a/src/fuzz/fuzz_cf.c
+++ b/src/fuzz/fuzz_cf.c
@@ -1,0 +1,198 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* AFL fuzzing harness for cf (configuration) interface.
+ *
+ * This fuzzer targets the cf_t interface used by IMP for parsing TOML
+ * configuration files. The cf layer sits on top of libtomlc99 and jansson,
+ * providing parsing, validation, and type-safe access to configs.
+ *
+ * Bugs in this layer could allow privilege escalation since IMP configs
+ * control security-critical settings (allowed-users, allowed-shells).
+ *
+ * Attack surfaces:
+ * - cf_update(): TOML parsing and conversion to JSON
+ * - cf_check(): Schema validation and type checking
+ * - cf_get_in(): Nested table lookup
+ * - cf_string(), cf_int64(), etc.: Type coercion and conversion
+ * - cf_array_contains(): Array searching with pattern matching
+ */
+
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdint.h>
+
+#include "src/libutil/cf.h"
+
+__AFL_FUZZ_INIT ();
+
+/* IMP-like configuration schema for realistic testing */
+static const struct cf_option imp_opts[] = {
+    {"allow-sudo",              CF_BOOL,     false},
+    {"allow-unprivileged-exec", CF_BOOL,     false},
+    {"pam-support",             CF_BOOL,     false},
+    {"exec",                    CF_TABLE,    false},
+    {"run",                     CF_TABLE,    false},
+    {"sign",                    CF_TABLE,    false},
+    CF_OPTIONS_TABLE_END,
+};
+
+static const struct cf_option exec_opts[] = {
+    {"allowed-users",  CF_ARRAY,  false},
+    {"allowed-shells", CF_ARRAY,  false},
+    CF_OPTIONS_TABLE_END,
+};
+
+static const struct cf_option sign_opts[] = {
+    {"max-ttl",        CF_INT64,  false},
+    {"default-type",   CF_STRING, false},
+    {"allowed-types",  CF_ARRAY,  false},
+    CF_OPTIONS_TABLE_END,
+};
+
+/* Exercise all cf accessors on a table */
+static void fuzz_exercise_table (const cf_t *cf)
+{
+    if (!cf || cf_typeof (cf) != CF_TABLE)
+        return;
+
+    /* Try accessing common config keys */
+    const char *test_keys[] = {
+        "allow-sudo", "allow-unprivileged-exec", "pam-support",
+        "exec", "run", "sign", "allowed-users", "allowed-shells",
+        "max-ttl", "default-type", "allowed-types",
+        NULL
+    };
+
+    for (int i = 0; test_keys[i]; i++) {
+        const cf_t *val = cf_get_in (cf, test_keys[i]);
+
+        if (val) {
+            /* Try all type accessors - should handle mismatches gracefully */
+            (void)cf_bool (val);
+            (void)cf_int64 (val);
+            (void)cf_double (val);
+            (void)cf_string (val);
+            (void)cf_timestamp (val);
+            (void)cf_typeof (val);
+
+            /* Array operations */
+            int size = cf_array_size (val);
+            for (int j = 0; j < size && j < 100; j++) {
+                const cf_t *elem = cf_get_at (val, j);
+                if (elem) {
+                    (void)cf_string (elem);
+                    (void)cf_int64 (elem);
+                }
+            }
+
+            /* Test array search functions */
+            (void)cf_array_contains (val, "test");
+            (void)cf_array_contains (val, "root");
+            (void)cf_array_contains_match (val, "*.sh");
+        }
+    }
+
+    /* Exercise nested table access */
+    const cf_t *exec = cf_get_in (cf, "exec");
+    if (exec) {
+        (void)cf_get_in (exec, "allowed-users");
+        (void)cf_get_in (exec, "allowed-shells");
+    }
+
+    const cf_t *sign = cf_get_in (cf, "sign");
+    if (sign) {
+        (void)cf_get_in (sign, "max-ttl");
+        (void)cf_get_in (sign, "default-type");
+        (void)cf_get_in (sign, "allowed-types");
+    }
+}
+
+int main (void)
+{
+    unsigned char *buf;
+
+    __AFL_INIT ();
+    buf = __AFL_FUZZ_TESTCASE_BUF;
+
+    while (__AFL_LOOP (10000)) {
+        int len = __AFL_FUZZ_TESTCASE_LEN;
+        struct cf_error error;
+        cf_t *cf;
+
+        /* Limit input size to prevent memory exhaustion during fuzzing.
+         * 1MB chosen as reasonable upper bound for TOML config parsing:
+         * - libtomlc99 has known issues with large files causing hangs
+         *   and integer overflow in byte offsets (see validate_toml_syntax)
+         * - Typical flux-security configs are 10-100 lines (~1-10KB)
+         * - Prevents AFL from wasting cycles on unrealistically large inputs
+         * - Prevents OOM when fuzzer generates huge test cases
+         * Production code validates input before parsing (MAX_LINES in tomltk.c).
+         */
+        if (len > 1048576)  /* 1MB max */
+            continue;
+
+        /* Create cf object (JSON table internally) */
+        cf = cf_create ();
+        if (!cf)
+            continue;
+
+        /* Fuzz: Parse TOML and update cf object.
+         * This exercises:
+         * - TOML syntax parsing (libtomlc99)
+         * - TOML-to-JSON conversion (tomltk_table_to_json)
+         * - JSON deep merge (jansson)
+         * - Error handling for malformed input
+         */
+        if (cf_update (cf, (char *)buf, len, &error) == 0) {
+            /* Successfully parsed - now exercise validation and accessors */
+
+            /* Test schema validation with different strictness levels */
+            (void)cf_check (cf, imp_opts, 0, &error);
+            (void)cf_check (cf, imp_opts, CF_STRICT, &error);
+            (void)cf_check (cf, imp_opts, CF_ANYTAB, &error);
+
+            /* Validate nested tables if present */
+            const cf_t *exec = cf_get_in (cf, "exec");
+            if (exec) {
+                (void)cf_check (exec, exec_opts, CF_STRICT, &error);
+            }
+
+            const cf_t *sign = cf_get_in (cf, "sign");
+            if (sign) {
+                (void)cf_check (sign, sign_opts, CF_STRICT, &error);
+            }
+
+            /* Exercise all accessor functions */
+            fuzz_exercise_table (cf);
+
+            /* Test cf_copy() */
+            cf_t *copy = cf_copy (cf);
+            if (copy) {
+                fuzz_exercise_table (copy);
+                cf_destroy (copy);
+            }
+        }
+        /* If parsing failed, that's fine - error handling was exercised */
+
+        cf_destroy (cf);
+    }
+
+    return 0;
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/fuzz/fuzz_kv.c
+++ b/src/fuzz/fuzz_kv.c
@@ -1,0 +1,101 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* AFL fuzzing harness for kv_decode ().
+ * Direct fuzzing of the custom KV serialization format.
+ *
+ * Format: key\0Tvalue\0key\0Tvalue\0...
+ * Where T is a type hint character:
+ *   s=string, i=int64, d=double, b=bool, t=timestamp
+ */
+
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "src/libutil/kv.h"
+
+__AFL_FUZZ_INIT ();
+
+int main (void)
+{
+    unsigned char *buf;
+
+    __AFL_INIT ();
+    buf = __AFL_FUZZ_TESTCASE_BUF;
+
+    while (__AFL_LOOP (10000)) {
+        int len = __AFL_FUZZ_TESTCASE_LEN;
+        struct kv *kv;
+
+        /* Limit input size to prevent memory exhaustion during fuzzing.
+         * 1MB chosen as reasonable upper bound for KV structure parsing:
+         * - KV format used for privsep communication between IMP processes
+         * - Typical KV messages are <4KB (see PRIVSEP_MAX_KVLEN in privsep.c)
+         * - Prevents AFL from wasting cycles on unrealistically large inputs
+         * - Prevents OOM when fuzzer generates huge test cases
+         * Production privsep code enforces 4MB limit (PRIVSEP_MAX_KVLEN).
+         */
+        if (len > 1048576)  /* 1MB max */
+            continue;
+
+        /* Fuzz: attempt to decode KV structure.
+         * This tests:
+         * - kv_check_integrity: null termination, even nulls, key length
+         * - kv_next: iteration over key-value pairs
+         * - type validation and value parsing
+         */
+        kv = kv_decode ((char *)buf, len);
+
+        if (kv) {
+            const char *key = NULL;
+
+            /* Exercise the parser by iterating and accessing values.
+             * This ensures all code paths are executed.
+             */
+            while ((key = kv_next (kv, key))) {
+                enum kv_type type = kv_typeof (key);
+
+                /* Access value to trigger any parsing/conversion
+                 */
+                switch (type) {
+                    case KV_STRING:
+                        (void)kv_val_string (key);
+                        break;
+                    case KV_INT64:
+                        (void)kv_val_int64 (key);
+                        break;
+                    case KV_DOUBLE:
+                        (void)kv_val_double (key);
+                        break;
+                    case KV_BOOL:
+                        (void)kv_val_bool (key);
+                        break;
+                    case KV_TIMESTAMP:
+                        (void)kv_val_timestamp (key);
+                        break;
+                    default:
+                        break;
+                }
+            }
+            kv_destroy (kv);
+        }
+    }
+
+    return 0;
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/fuzz/fuzz_sign_unwrap.c
+++ b/src/fuzz/fuzz_sign_unwrap.c
@@ -1,0 +1,139 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* AFL fuzzing harness for flux_sign_unwrap ()
+ * Tests full signature verification path.
+ */
+
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "src/lib/context.h"
+#include "src/lib/sign.h"
+
+/* Config pattern for .toml files.
+ * Use environment variable FUZZ_CONFIG_PATH or default paths.
+ * Note: For curve mechanism to work, you need a valid cert file.
+ * For munge mechanism, munged must be running.
+ */
+#ifndef FUZZ_CONFIG_PATH
+#define FUZZ_CONFIG_PATH "src/fuzz/conf.d/*.toml"
+#endif
+#define FUZZ_CONFIG_PATH_ALT "conf.d/*.toml"
+
+__AFL_FUZZ_INIT ();
+
+int main (void)
+{
+    flux_security_t *ctx;
+    const void *payload;
+    int payloadsz;
+    int64_t userid;
+    unsigned char *buf;
+    const char *config_path;
+    int configured;
+
+    /* Initialize AFL fork server FIRST, before any setup that might fail
+     */
+    __AFL_INIT ();
+    buf = __AFL_FUZZ_TESTCASE_BUF;
+
+    /* Suppress error messages for cleaner fuzzing (unless debugging)
+     */
+    if (!getenv ("FUZZ_DEBUG"))
+        close (STDERR_FILENO);
+
+    /* Create context - if this fails, we can't fuzz but AFL is already
+     * initialized.
+     */
+    ctx = flux_security_create (0);
+    if (!ctx)
+        return 1;
+
+    /* Try to configure - try multiple paths to find config.
+     * Configuration is CRITICAL for proper fuzzing coverage.
+     * Set FUZZ_CONFIG_PATH env var to override.
+     */
+    config_path = getenv ("FUZZ_CONFIG_PATH");
+    configured = 0;
+
+    if (config_path) {
+        configured = (flux_security_configure (ctx, config_path) == 0);
+    }
+    else {
+        /* Try default location (from project root)
+         */
+        if (flux_security_configure (ctx, FUZZ_CONFIG_PATH) == 0)
+            configured = 1;
+        /* Try alternate location (from src/fuzz dir)
+         */
+        else if (flux_security_configure (ctx, FUZZ_CONFIG_PATH_ALT) == 0)
+            configured = 1;
+    }
+
+    /* If config failed, print error and exit - otherwise we waste CPU
+     */
+    if (!configured) {
+        fprintf (stderr,
+                 "FATAL: Could not load config. "
+                 "Set FUZZ_CONFIG_PATH or create conf.d/sign.toml\n");
+        fprintf (stderr, "Tried: %s and %s\n",
+                 FUZZ_CONFIG_PATH,
+                 FUZZ_CONFIG_PATH_ALT);
+        flux_security_destroy (ctx);
+        return 1;
+    }
+
+    while (__AFL_LOOP (10000)) {
+        int len = __AFL_FUZZ_TESTCASE_LEN;
+        char *input;
+
+        /* Limit input size to prevent memory exhaustion during fuzzing.
+         * 1MB chosen as reasonable upper bound for signed payload parsing:
+         * - Typical signed payloads are <1KB (job descriptions, configs)
+         * - Base64 encoding inflates size by ~33%
+         * - Prevents AFL from wasting cycles on unrealistically large inputs
+         * - Prevents OOM when fuzzer generates huge test cases
+         * Production code does not enforce this limit (handled by caller).
+         */
+        if (len > 1048576)  /* 1MB max */
+            continue;
+
+        input = malloc (len + 1);
+        if (!input)
+            continue;
+        memcpy (input, buf, len);
+        input[len] = '\0';
+
+        /* Fuzz: attempt to unwrap (with full verification).
+         * This will test parsing + signature verification.
+         */
+        (void)flux_sign_unwrap (ctx,
+                                input,
+                                &payload,
+                                &payloadsz,
+                                &userid,
+                                0);
+
+        free (input);
+    }
+
+    flux_security_destroy (ctx);
+    return 0;
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/fuzz/fuzz_sign_unwrap_noverify.c
+++ b/src/fuzz/fuzz_sign_unwrap_noverify.c
@@ -1,0 +1,139 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* AFL fuzzing harness for flux_sign_unwrap () parser
+ * Uses FLUX_SIGN_NOVERIFY to test parsing without crypto overhead.
+ * This is faster and focuses on parser bugs.
+ */
+
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "src/lib/context.h"
+#include "src/lib/sign.h"
+
+/* Config pattern for .toml files.
+ * Use environment variable FUZZ_CONFIG_PATH or default paths.
+ */
+#ifndef FUZZ_CONFIG_PATH
+#define FUZZ_CONFIG_PATH "src/fuzz/conf.d/*.toml"
+#endif
+#define FUZZ_CONFIG_PATH_ALT "conf.d/*.toml"
+
+__AFL_FUZZ_INIT ();
+
+int main (void)
+{
+    flux_security_t *ctx;
+    const void *payload;
+    int payloadsz;
+    int64_t userid;
+    unsigned char *buf;
+    const char *config_path;
+    int configured;
+
+    /* Initialize AFL fork server FIRST, before any setup that might fail
+     */
+    __AFL_INIT ();
+    buf = __AFL_FUZZ_TESTCASE_BUF;
+
+    /* Suppress error messages for cleaner fuzzing (unless debugging)
+     */
+    if (!getenv ("FUZZ_DEBUG"))
+        close (STDERR_FILENO);
+
+    /* Create context - if this fails, we can't fuzz but AFL is already
+     * initialized.
+     */
+    ctx = flux_security_create (0);
+    if (!ctx)
+        return 1;
+
+    /* Try to configure - try multiple paths to find config.
+     * Configuration is CRITICAL for proper fuzzing coverage.
+     * Set FUZZ_CONFIG_PATH env var to override.
+     */
+    config_path = getenv ("FUZZ_CONFIG_PATH");
+    configured = 0;
+
+    if (config_path) {
+        configured = (flux_security_configure (ctx, config_path) == 0);
+    }
+    else {
+        /* Try default location (from project root)
+         */
+        if (flux_security_configure (ctx, FUZZ_CONFIG_PATH) == 0)
+            configured = 1;
+        /* Try alternate location (from src/fuzz dir)
+         */
+        else if (flux_security_configure (ctx, FUZZ_CONFIG_PATH_ALT) == 0)
+            configured = 1;
+    }
+
+    /* If config failed, print error and exit - otherwise we waste CPU
+     */
+    if (!configured) {
+        fprintf (stderr,
+                 "FATAL: Could not load config. "
+                 "Set FUZZ_CONFIG_PATH or create conf.d/sign.toml\n");
+        fprintf (stderr, "Tried: %s and %s\n",
+                 FUZZ_CONFIG_PATH,
+                 FUZZ_CONFIG_PATH_ALT);
+        flux_security_destroy (ctx);
+        return 1;
+    }
+
+    while (__AFL_LOOP (10000)) {
+        int len = __AFL_FUZZ_TESTCASE_LEN;
+        char *input;
+
+        /* Limit input size to prevent memory exhaustion during fuzzing.
+         * 1MB chosen as reasonable upper bound for signed payload parsing:
+         * - Typical signed payloads are <1KB (job descriptions, configs)
+         * - Base64 encoding inflates size by ~33%
+         * - Prevents AFL from wasting cycles on unrealistically large inputs
+         * - Prevents OOM when fuzzer generates huge test cases
+         * Production code does not enforce this limit (handled by caller).
+         */
+        if (len > 1048576)  /* 1MB max */
+            continue;
+
+        input = malloc (len + 1);
+        if (!input)
+            continue;
+        memcpy (input, buf, len);
+        input[len] = '\0';
+
+        /* NOVERIFY: skip signature verification, test parser only.
+         * This focuses on: header_decode, payload_decode_cpy, kv_decode,
+         * base64 decoding, and format validation.
+         */
+        (void)flux_sign_unwrap (ctx,
+                                input,
+                                &payload,
+                                &payloadsz,
+                                &userid,
+                                FLUX_SIGN_NOVERIFY);
+
+        free (input);
+    }
+
+    flux_security_destroy (ctx);
+    return 0;
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/imp/exec/safe_popen.c
+++ b/src/imp/exec/safe_popen.c
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
-#ifndef HAVE_CONFIG_H
+#if HAVE_CONFIG_H
 #include "config.h"
 #endif
 

--- a/src/imp/privsep.c
+++ b/src/imp/privsep.c
@@ -66,7 +66,7 @@ void drop_privileges ()
     uid_t ruid = -1, euid, suid;
     gid_t rgid = -1, egid, sgid;
 
-    if (  (getresuid (&ruid, &euid, &suid) < 0)
+    if ((getresuid (&ruid, &euid, &suid) < 0)
        || (getresgid (&rgid, &egid, &sgid) < 0))
         imp_die (1, "getresuid/getresgid");
 
@@ -77,7 +77,9 @@ void drop_privileges ()
 
      /*  Verify privilege cannot be restored */
     if (setreuid (-1, 0) == 0)
-        imp_die (1, "irreversible switch to uid %ju failed", (uintmax_t) ruid);
+        imp_die (1,
+	         "irreversible switch to uid %ju failed",
+                 (uintmax_t) ruid);
 }
 
 static void child_pfds_setup (privsep_t *ps)

--- a/src/lib/sign.c
+++ b/src/lib/sign.c
@@ -332,6 +332,13 @@ static struct kv *header_decode (const char *input, const char **endptr)
     }
     src = input;
     srclen = p - input;
+
+    /* Empty header is invalid - header must contain version and mechanism */
+    if (srclen == 0) {
+        errno = EINVAL;
+        return NULL;
+    }
+
     dstlen = BASE64_DECODE_SIZE (srclen);
     if (!(dst = malloc (dstlen)))
         return NULL;
@@ -372,6 +379,15 @@ static int payload_decode_cpy (const char *input, void **buf, int *bufsz,
     }
     src = input;
     srclen = p - input;
+
+    /* Handle empty payload (e.g., "HEADER..SIGNATURE")
+     * Skip decoding to avoid passing NULL to sodium_base642bin()
+     */
+    if (srclen == 0) {
+        *endptr = p;
+        return 0;
+    }
+
     dstlen = BASE64_DECODE_SIZE (srclen);
     if (grow_buf (buf, bufsz, dstlen) < 0)
         return -1;

--- a/src/lib/test/sign.c
+++ b/src/lib/test/sign.c
@@ -471,6 +471,17 @@ void test_badpayload (flux_security_t *ctx)
         "flux_sign_unwrap fails on missing PAYLOAD.SIG with EINVAL");
     diag ("%s", flux_security_last_error (ctx));
 
+    /* Test empty payload section (double dots) - regression test for
+     * fuzzer-found bug where empty base64 section caused NULL pointer
+     * to be passed to sodium_base642bin()
+     */
+    snprintf (input, sizeof (input), "%s..none", header);
+    errno = 0;
+    ok (flux_sign_unwrap (ctx, input, NULL, NULL, NULL, 0) == 0,
+        "flux_sign_unwrap succeeds on empty PAYLOAD section (..none)");
+    ok (flux_sign_unwrap (ctx, input, NULL, NULL, NULL, FLUX_SIGN_NOVERIFY) == 0,
+        "flux_sign_unwrap NOVERIFY succeeds on empty PAYLOAD section");
+
     free (header);
 }
 

--- a/src/libca/ca.c
+++ b/src/libca/ca.c
@@ -223,7 +223,7 @@ int ca_revoke (const struct ca *ca, const char *uuid, ca_error_t e)
         errno = EINVAL;
         goto error;
     }
-    if ((fd = open (path, O_WRONLY | O_CREAT, 0644)) < 0) {
+    if ((fd = open (path, O_WRONLY | O_CREAT | O_CLOEXEC, 0644)) < 0) {
         ca_error (e, "%s: %s", path, strerror (errno));
         return -1;
     }

--- a/src/libca/sigcert.c
+++ b/src/libca/sigcert.c
@@ -262,7 +262,7 @@ static FILE *fopen_mode (const char *pathname, mode_t mode)
     int fd;
     FILE *fp;
 
-    if ((fd = open (pathname, O_WRONLY | O_TRUNC | O_CREAT, mode)) < 0)
+    if ((fd = open (pathname, O_WRONLY | O_TRUNC | O_CREAT | O_CLOEXEC, mode)) < 0)
         return NULL;
     if (!(fp = fdopen (fd, "w"))) {
         close (fd);

--- a/src/libtomlc99/toml.c
+++ b/src/libtomlc99/toml.c
@@ -1996,7 +1996,7 @@ int toml_rtoi(const char* src, int64_t* ret_)
 		switch (ch) {
 		case '_':
 			// disallow '__'
-			if (s[0] == '_') return -1; 
+			if (s[0] == '_') return -1;
 			continue;			/* skip _ */
 		default:
 			break;
@@ -2006,7 +2006,8 @@ int toml_rtoi(const char* src, int64_t* ret_)
 	if (*s || p == q) return -1;
 
 	/* last char cannot be '_' */
-	if (s[-1] == '_') return -1;
+	/* SECURITY: check s > src to avoid reading before buffer (heap underflow) */
+	if (s > src && s[-1] == '_') return -1;
 	
 	/* cap with NUL */
 	*p = 0;

--- a/src/libtomlc99/toml.c
+++ b/src/libtomlc99/toml.c
@@ -2052,12 +2052,13 @@ int toml_rtod_ex(const char* src, double* ret_, char* buf, int buflen)
 		int ch = *s++;
 		switch (ch) {
 		case '.':
-			if (s[-2] == '_') return -1;
+			/* SECURITY: check s - 2 >= src to avoid reading before buffer */
+			if (s - 2 >= src && s[-2] == '_') return -1;
 			if (s[0] == '_') return -1;
 			break;
 		case '_':
 			// disallow '__'
-			if (s[0] == '_') return -1; 
+			if (s[0] == '_') return -1;
 			continue;			/* skip _ */
 		default:
 			break;
@@ -2065,9 +2066,10 @@ int toml_rtod_ex(const char* src, double* ret_, char* buf, int buflen)
 		*p++ = ch;
 	}
 	if (*s || p == q) return -1; /* reached end of string or buffer is full? */
-	
+
 	/* last char cannot be '_' */
-	if (s[-1] == '_') return -1;
+	/* SECURITY: check s > src to avoid reading before buffer (heap underflow) */
+	if (s > src && s[-1] == '_') return -1;
 
 	if (p != buf && p[-1] == '.') 
 		return -1; /* no trailing zero */

--- a/src/libtomlc99/toml.c
+++ b/src/libtomlc99/toml.c
@@ -1658,9 +1658,9 @@ static tokentype_t scan_string(context_t* ctx, char* p, int lineno, int dotisspe
 	/* check for timestamp without quotes */
 	if (0 == scan_date(p, 0, 0, 0) || 0 == scan_time(p, 0, 0, 0)) {
 		// forward thru the timestamp
-		for ( ; strchr("0123456789.:+-T Z", toupper(*p)); p++);
+		for ( ; *p && strchr("0123456789.:+-T Z", toupper(*p)); p++);
 		// squeeze out any spaces at end of string
-		for ( ; p[-1] == ' '; p--);
+		for ( ; p > orig && p[-1] == ' '; p--);
 		// tokenize
 		return ret_token(ctx, STRING, lineno, orig, p - orig);
 	}

--- a/src/libutil/test/tomltk.c
+++ b/src/libutil/test/tomltk.c
@@ -255,6 +255,270 @@ void test_corner (void)
     json_decref (obj);
 }
 
+/* Test security fixes for heap-use-after-free in JSON conversion.
+ * The bug was calling json_decref() after json_*_new() functions
+ * failed, but those functions already decref on failure.
+ */
+void test_json_conversion (void)
+{
+    toml_table_t *tab;
+    json_t *json;
+    struct tomltk_error error;
+
+    /* Test with valid nested structure to exercise array_to_json()
+     * and table_to_json() code paths. This ensures the fix for the
+     * heap-use-after-free (removing incorrect json_decref() calls)
+     * doesn't break valid conversions.
+     */
+    const char *nested = "arr = [[1, 2], [3, 4]]\n[tab]\na = 1\n";
+    tab = tomltk_parse (nested, strlen (nested), &error);
+    ok (tab != NULL,
+        "Nested structure parses successfully");
+    if (tab) {
+        json = tomltk_table_to_json (tab);
+        ok (json != NULL,
+            "JSON conversion handles nested arrays and tables");
+        if (json)
+            json_decref (json);
+        else
+            diag ("JSON conversion failed");
+        toml_free (tab);
+    }
+
+    /* Test with array of arrays (exercises array_to_json recursion) */
+    const char *array_of_arrays = "matrix = [[1, 2, 3], [4, 5, 6]]\n";
+    tab = tomltk_parse (array_of_arrays, strlen (array_of_arrays), &error);
+    ok (tab != NULL,
+        "Array of arrays parses successfully");
+    if (tab) {
+        json = tomltk_table_to_json (tab);
+        ok (json != NULL,
+            "JSON conversion handles array of arrays");
+        if (json)
+            json_decref (json);
+        toml_free (tab);
+    }
+
+    /* Test error path: invalid array (mixed types) triggers error in jansson */
+    const char *mixed_array = "mixed = [1, \"string\"]\n";
+    tab = tomltk_parse (mixed_array, strlen (mixed_array), &error);
+    /* libtomlc99 parses this (TOML allows mixed arrays), but JSON may not
+     * accept it. The important thing is no crash (heap-use-after-free).
+     */
+    if (tab) {
+        json = tomltk_table_to_json (tab);
+        /* Don't care if it succeeds or fails, just that it doesn't crash */
+        pass ("JSON conversion of mixed array doesn't crash");
+        if (json)
+            json_decref (json);
+        toml_free (tab);
+    }
+}
+
+/* Test that tomltk_parse_file() preserves filename in error struct
+ * when validation fails.
+ */
+void test_parse_file_errors (void)
+{
+    struct tomltk_error error;
+    toml_table_t *tab;
+    char tmpfile[PATH_MAX];
+    FILE *fp;
+
+    /* Create a temporary file with invalid content */
+    snprintf (tmpfile, sizeof (tmpfile), "tomltk_test_%d.toml", getpid ());
+    fp = fopen (tmpfile, "w");
+    if (!fp)
+        BAIL_OUT ("failed to create temp file %s: %s", tmpfile, strerror (errno));
+
+    /* Write content that will fail validation */
+    fprintf (fp, "key = \"\x80invalid utf8\"");  /* Invalid UTF-8 */
+    fclose (fp);
+
+    /* Test that filename is preserved in error */
+    errno = 0;
+    tab = tomltk_parse_file (tmpfile, &error);
+    ok (tab == NULL && errno == EINVAL,
+        "tomltk_parse_file() rejects invalid UTF-8");
+    ok (strstr (error.filename, "tomltk_test") != NULL,
+        "error.filename contains the actual filename");
+    diag ("error.filename = '%s'", error.filename);
+
+    unlink (tmpfile);
+}
+
+/* Test that inputs which triggered buffer overflows in libtomlc99 are now
+ * handled safely. These patterns caused heap buffer underflows in toml_rtoi()
+ * and toml_rtod_ex() but the fixes allow them to parse without crashing.
+ * The important thing is no crash, not whether the values are valid TOML.
+ */
+void test_number_parsing (void)
+{
+    toml_table_t *tab;
+    struct tomltk_error error;
+    json_t *json;
+
+    /* Test patterns that triggered toml_rtoi() s[-1] buffer underflow.
+     * These parse without crash (the fix works), even though some are
+     * invalid TOML. The parser accepts them as raw strings.
+     */
+    const char *int_patterns[] = {
+        "val = _123\n",      /* underscore at start */
+        "val = +_123\n",     /* underscore after sign */
+        "val = 123_\n",      /* trailing underscore */
+        "val = 1_234\n",     /* valid underscores */
+    };
+
+    for (size_t i = 0; i < sizeof(int_patterns)/sizeof(int_patterns[0]); i++) {
+        tab = tomltk_parse (int_patterns[i], strlen (int_patterns[i]), &error);
+        /* Don't test validity, just that it doesn't crash */
+        pass ("Integer pattern %zu parses without crash", i);
+        if (tab) {
+            /* Also test JSON conversion doesn't crash */
+            json = tomltk_table_to_json (tab);
+            if (json)
+                json_decref (json);
+            toml_free (tab);
+        }
+    }
+
+    /* Test patterns that triggered toml_rtod_ex() s[-2] and s[-1] underflows */
+    const char *float_patterns[] = {
+        "val = _1.23\n",     /* underscore at start */
+        "val = 1._5\n",      /* underscore after dot (triggers s[-2]) */
+        "val = ._5\n",       /* dot-underscore at start */
+        "val = 1.23_\n",     /* trailing underscore */
+        "val = 1_234.5\n",   /* valid underscores */
+    };
+
+    for (size_t i = 0; i < sizeof(float_patterns)/sizeof(float_patterns[0]); i++) {
+        tab = tomltk_parse (float_patterns[i], strlen (float_patterns[i]), &error);
+        pass ("Float pattern %zu parses without crash", i);
+        if (tab) {
+            json = tomltk_table_to_json (tab);
+            if (json)
+                json_decref (json);
+            toml_free (tab);
+        }
+    }
+
+    /* Test timestamp parsing edge cases (heap buffer overflow in scan_string).
+     * These patterns triggered reads past buffer end: p++ when *p is NUL,
+     * and p[-1] without checking p > orig.
+     */
+    const char *ts_no_newline = "ts = 1979-05-27T07:32:00Z";
+    tab = tomltk_parse (ts_no_newline, strlen (ts_no_newline), &error);
+    ok (tab != NULL,
+        "Timestamp without trailing newline parses without overflow");
+    if (tab) {
+        json = tomltk_table_to_json (tab);
+        if (json)
+            json_decref (json);
+        toml_free (tab);
+    }
+
+    const char *ts_with_spaces = "ts = 1979-05-27T07:32:00Z  \n";
+    tab = tomltk_parse (ts_with_spaces, strlen (ts_with_spaces), &error);
+    ok (tab != NULL,
+        "Timestamp with trailing spaces parses without overflow");
+    if (tab) {
+        json = tomltk_table_to_json (tab);
+        if (json)
+            json_decref (json);
+        toml_free (tab);
+    }
+
+    const char *ts_minimal = "ts = 0\n";
+    tab = tomltk_parse (ts_minimal, strlen (ts_minimal), &error);
+    ok (tab != NULL,
+        "Minimal timestamp parses without overflow");
+    if (tab) {
+        json = tomltk_table_to_json (tab);
+        if (json)
+            json_decref (json);
+        toml_free (tab);
+    }
+}
+
+/* Test multi-line string handling in validation layer.
+ * This exercises the triple-quote tracking logic that was added to
+ * prevent parser hangs.
+ */
+void test_multiline_strings (void)
+{
+    toml_table_t *tab;
+    struct tomltk_error error;
+    json_t *json;
+
+    /* Test multi-line double-quote strings (""") */
+    const char *ml_double = "text = \"\"\"\nline 1\nline 2\n\"\"\"";
+    tab = tomltk_parse (ml_double, strlen (ml_double), &error);
+    ok (tab != NULL,
+        "Multi-line double-quote string parses successfully");
+    if (tab) {
+        json = tomltk_table_to_json (tab);
+        if (json)
+            json_decref (json);
+        toml_free (tab);
+    }
+
+    /* Test multi-line single-quote strings (''') - this exercises the
+     * code path that the user pointed out for coverage.
+     */
+    const char *ml_single = "text = '''\nline 1\nline 2\n'''";
+    tab = tomltk_parse (ml_single, strlen (ml_single), &error);
+    ok (tab != NULL,
+        "Multi-line single-quote string parses successfully");
+    if (tab) {
+        json = tomltk_table_to_json (tab);
+        if (json)
+            json_decref (json);
+        toml_free (tab);
+    }
+
+    /* Test nested quotes don't confuse parser */
+    const char *nested = "text = '''\nHe said \"hello\"\n'''";
+    tab = tomltk_parse (nested, strlen (nested), &error);
+    ok (tab != NULL,
+        "Multi-line single-quote string with nested double quotes");
+    if (tab) {
+        json = tomltk_table_to_json (tab);
+        if (json)
+            json_decref (json);
+        toml_free (tab);
+    }
+
+    /* Test that we can have both types in one file */
+    const char *both = "str1 = '''\nsingle\n'''\nstr2 = \"\"\"\ndouble\n\"\"\"";
+    tab = tomltk_parse (both, strlen (both), &error);
+    ok (tab != NULL,
+        "Both multi-line string types in one file");
+    if (tab) {
+        json = tomltk_table_to_json (tab);
+        if (json)
+            json_decref (json);
+        toml_free (tab);
+    }
+
+    /* Test unterminated multi-line single-quote string */
+    const char *unterminated_single = "text = '''\nunclosed";
+    errno = 0;
+    tab = tomltk_parse (unterminated_single, strlen (unterminated_single), &error);
+    ok (tab == NULL && errno == EINVAL,
+        "Unterminated multi-line single-quote string rejected");
+    if (tab == NULL)
+        diag ("  error: %s", error.errbuf);
+
+    /* Test unterminated multi-line double-quote string */
+    const char *unterminated_double = "text = \"\"\"\nunclosed";
+    errno = 0;
+    tab = tomltk_parse (unterminated_double, strlen (unterminated_double), &error);
+    ok (tab == NULL && errno == EINVAL,
+        "Unterminated multi-line double-quote string rejected");
+    if (tab == NULL)
+        diag ("  error: %s", error.errbuf);
+}
+
 /* Test cases derived from AFL++ fuzzer hang findings.
  * These inputs previously caused libtomlc99 to hang indefinitely.
  * The validation layer now rejects them quickly with clear error messages.
@@ -457,6 +721,133 @@ void test_afl_hangs (void)
         "AFL hang fuzzer04-13: repetitive timestamp patterns rejected");
     if (tab == NULL)
         diag ("  error: %s", error.errbuf);
+
+    /* Test 12: Comment character inside array
+     * Comments inside arrays can confuse the parser state machine.
+     * Validates the in_array check for '#' characters.
+     */
+    const char comment_in_array[] = "arr = [1, # comment\n2]";
+    errno = 0;
+    tab = tomltk_parse (comment_in_array, strlen(comment_in_array), &error);
+    ok (tab == NULL && errno == EINVAL,
+        "Comment character inside array rejected");
+    if (tab == NULL)
+        diag ("  error: %s", error.errbuf);
+
+    /* Test 13: Unbalanced brackets
+     * Opening brackets without matching closing brackets.
+     * Validates the square_count balance check.
+     */
+    const char unbalanced_open[] = "arr = [[1, 2]";
+    errno = 0;
+    tab = tomltk_parse (unbalanced_open, strlen(unbalanced_open), &error);
+    ok (tab == NULL && errno == EINVAL,
+        "Unbalanced brackets (missing close) rejected");
+    if (tab == NULL)
+        diag ("  error: %s", error.errbuf);
+
+    /* Test 14: Extra closing bracket
+     * Closing brackets without matching opening brackets.
+     */
+    const char unbalanced_close[] = "arr = [1, 2]]";
+    errno = 0;
+    tab = tomltk_parse (unbalanced_close, strlen(unbalanced_close), &error);
+    ok (tab == NULL && errno == EINVAL,
+        "Unbalanced brackets (extra close) rejected");
+    if (tab == NULL)
+        diag ("  error: %s", error.errbuf);
+
+    /* Test 15: Truncated UTF-8 sequence (2-byte)
+     * UTF-8 start byte 0xC2 indicates 2-byte sequence but input ends
+     * before continuation byte.
+     */
+    const unsigned char truncated_2byte[] = "key = \"value\xC2";
+    errno = 0;
+    tab = tomltk_parse ((char*)truncated_2byte, sizeof(truncated_2byte)-1, &error);
+    ok (tab == NULL && errno == EINVAL,
+        "Truncated UTF-8 sequence (2-byte) rejected");
+    if (tab == NULL)
+        diag ("  error: %s", error.errbuf);
+
+    /* Test 16: Truncated UTF-8 sequence (3-byte)
+     * UTF-8 start byte 0xE0 indicates 3-byte sequence but only 1
+     * continuation byte follows.
+     */
+    const unsigned char truncated_3byte[] = "key = \"test\xE0\xA0";
+    errno = 0;
+    tab = tomltk_parse ((char*)truncated_3byte, sizeof(truncated_3byte)-1, &error);
+    ok (tab == NULL && errno == EINVAL,
+        "Truncated UTF-8 sequence (3-byte) rejected");
+    if (tab == NULL)
+        diag ("  error: %s", error.errbuf);
+
+    /* Test 17: Truncated UTF-8 sequence (4-byte)
+     * UTF-8 start byte 0xF0 indicates 4-byte sequence but only 2
+     * continuation bytes follow.
+     */
+    const unsigned char truncated_4byte[] = "val = \"x\xF0\x90\x80";
+    errno = 0;
+    tab = tomltk_parse ((char*)truncated_4byte, sizeof(truncated_4byte)-1, &error);
+    ok (tab == NULL && errno == EINVAL,
+        "Truncated UTF-8 sequence (4-byte) rejected");
+    if (tab == NULL)
+        diag ("  error: %s", error.errbuf);
+
+    /* Test 18: Escaped quote in multi-line string followed by four quotes
+     * (fuzzer04 id:000015)
+     * Pattern: string3 = """ ... \"""" where backslash-4-quotes appears.
+     * The backslash escapes the first quote, leaving """ as the closing
+     * delimiter. This tests proper escape handling inside multi-line strings.
+     * This is actually valid TOML, so we test that it completes without hanging.
+     */
+    const char escaped_quotes_ml[] =
+        "string3 = \"\"\"\n"
+        "content\n"
+        "e2\\ttab\\\"\"\"\"";  // backslash + 4 quotes closes the ml string
+    errno = 0;
+    tab = tomltk_parse (escaped_quotes_ml, strlen(escaped_quotes_ml), &error);
+    // This should either parse successfully or fail quickly (not hang)
+    if (tab != NULL) {
+        pass ("AFL hang fuzzer04-15: escaped quotes in ml string completed");
+        toml_free (tab);
+    } else {
+        ok (errno == EINVAL,
+            "AFL hang fuzzer04-15: escaped quotes in ml string rejected cleanly");
+        diag ("  error: %s", error.errbuf);
+    }
+
+    /* Test 19: Backslash in single-quote (literal) string (fuzzer04 id:000018)
+     * Pattern: 'text\'more''text' - backslash followed by quote, then two quotes
+     * In TOML literal strings (single quotes), backslash is NOT an escape char.
+     * The validator was incorrectly treating \ as escape, causing it to skip
+     * the next quote and never close the string.
+     */
+    const char literal_backslash[] = "'icode: \\\'.B.D.C.''.B.D.C.allow-sudo = 937";
+    errno = 0;
+    tab = tomltk_parse (literal_backslash, strlen(literal_backslash), &error);
+    // Should complete quickly - backslash is literal, first quote closes string
+    if (tab != NULL) {
+        pass ("AFL hang fuzzer04-18: backslash in literal string completed");
+        toml_free (tab);
+    } else {
+        pass ("AFL hang fuzzer04-18: backslash in literal string rejected cleanly");
+    }
+
+    /* Test 20: Multiple single quotes with backslashes (fuzzer04 id:000019)
+     * Pattern: ''.'.'= {'\\\\...\\'.B.''.'.'= [
+     * Tests complex combinations of single quotes and backslashes.
+     * Literal strings don't support escapes, so each ' opens/closes immediately.
+     */
+    const char literal_complex[] = "''.'\\t'= {'\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\'.B.''.'\\t'= [";
+    errno = 0;
+    tab = tomltk_parse (literal_complex, strlen(literal_complex), &error);
+    // Should complete quickly regardless of parse result
+    if (tab != NULL) {
+        pass ("AFL hang fuzzer04-19: complex literal string pattern completed");
+        toml_free (tab);
+    } else {
+        pass ("AFL hang fuzzer04-19: complex literal string pattern rejected cleanly");
+    }
 }
 
 int main (int argc, char *argv[])
@@ -469,6 +860,10 @@ int main (int argc, char *argv[])
     test_tojson_t3 ();
     test_parse_lineno ();
     test_corner ();
+    test_json_conversion ();
+    test_parse_file_errors ();
+    test_number_parsing ();
+    test_multiline_strings ();
     test_afl_hangs ();
 
     done_testing ();

--- a/src/libutil/test/tomltk.c
+++ b/src/libutil/test/tomltk.c
@@ -15,6 +15,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <stdbool.h>
+#include <stdlib.h>
 #include <string.h>
 #include <limits.h>
 #include <errno.h>
@@ -254,6 +255,210 @@ void test_corner (void)
     json_decref (obj);
 }
 
+/* Test cases derived from AFL++ fuzzer hang findings.
+ * These inputs previously caused libtomlc99 to hang indefinitely.
+ * The validation layer now rejects them quickly with clear error messages.
+ */
+void test_afl_hangs (void)
+{
+    toml_table_t *tab;
+    struct tomltk_error error;
+
+    /* Test 1: Embedded NULL bytes (findings-cf id:000000, 000003, 000006)
+     * NULL bytes in TOML input can cause parser to hang in string processing.
+     * Example: key = "value\x00more"
+     */
+    const char null_bytes[] = "key = \"test\x00value\"";
+    errno = 0;
+    tab = tomltk_parse (null_bytes, sizeof(null_bytes)-1, &error);
+    ok (tab == NULL && errno == EINVAL,
+        "AFL hang: embedded NULL byte rejected");
+    if (tab == NULL)
+        diag ("  error: %s", error.errbuf);
+
+    /* Test 2: Invalid UTF-8 sequences (findings-cf id:000000, 000005, 000006)
+     * Invalid UTF-8 bytes (0x80-0xFF not in valid sequences) cause hangs.
+     * AFL found: 0x80, 0x81, 0x92, 0xFF, 0xD1 in various contexts.
+     */
+    const unsigned char invalid_utf8_1[] = "key = \"test\x92value\"";  // 0x92 = invalid
+    errno = 0;
+    tab = tomltk_parse ((char*)invalid_utf8_1, sizeof(invalid_utf8_1)-1, &error);
+    ok (tab == NULL && errno == EINVAL,
+        "AFL hang: invalid UTF-8 byte 0x92 rejected");
+    if (tab == NULL)
+        diag ("  error: %s", error.errbuf);
+
+    const unsigned char invalid_utf8_2[] = "allow\x81-sudo = true";  // 0x81 = invalid
+    errno = 0;
+    tab = tomltk_parse ((char*)invalid_utf8_2, sizeof(invalid_utf8_2)-1, &error);
+    ok (tab == NULL && errno == EINVAL,
+        "AFL hang: invalid UTF-8 byte 0x81 rejected");
+    if (tab == NULL)
+        diag ("  error: %s", error.errbuf);
+
+    const unsigned char invalid_utf8_3[] = "ip = \"192.168.\xD1.1\"";  // 0xD1 = invalid (needs continuation)
+    errno = 0;
+    tab = tomltk_parse ((char*)invalid_utf8_3, sizeof(invalid_utf8_3)-1, &error);
+    ok (tab == NULL && errno == EINVAL,
+        "AFL hang: invalid UTF-8 byte 0xD1 (truncated sequence) rejected");
+    if (tab == NULL)
+        diag ("  error: %s", error.errbuf);
+
+    /* Test 3: Control characters outside strings (findings-cf id:000003, 000006)
+     * Control chars (0x01-0x1F except \t,\n,\r) between tokens cause parser hangs.
+     * AFL found: 0x03, 0x04, 0xE8 embedded in unquoted context.
+     */
+    const unsigned char control_chars[] = "key\x04= value";  // 0x04 between key and =
+    errno = 0;
+    tab = tomltk_parse ((char*)control_chars, sizeof(control_chars)-1, &error);
+    ok (tab == NULL && errno == EINVAL,
+        "AFL hang: control character 0x04 rejected");
+    if (tab == NULL)
+        diag ("  error: %s", error.errbuf);
+
+    /* Test 4: Excessive bracket nesting (findings-cf id:000006, fuzzer04 id:000004)
+     * Deeply nested arrays cause stack overflow or infinite recursion in parser.
+     * id:000006 had 18 brackets, id:000004 had 618 brackets!
+     * MAX_NESTING = 32 should catch these.
+     */
+    const char deep_nest[] =
+        "key = [[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[["  // 40 opening brackets
+        "1"
+        "]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]";        // 40 closing brackets
+    errno = 0;
+    tab = tomltk_parse (deep_nest, strlen(deep_nest), &error);
+    ok (tab == NULL && errno == EINVAL,
+        "AFL hang: excessive bracket nesting (40 levels) rejected");
+    if (tab == NULL)
+        diag ("  error: %s", error.errbuf);
+
+    /* Test 5: Adjacent triple-quote sequences (fuzzer04 id:000000)
+     * Patterns like '''''' or """""" (6 consecutive quotes) create ambiguous
+     * zero-length multi-line strings that cause infinite loops.
+     */
+    const char six_single_quotes[] = "key = ''''''";
+    errno = 0;
+    tab = tomltk_parse (six_single_quotes, strlen(six_single_quotes), &error);
+    ok (tab == NULL && errno == EINVAL,
+        "AFL hang: six consecutive single quotes rejected");
+    if (tab == NULL)
+        diag ("  error: %s", error.errbuf);
+
+    const char six_double_quotes[] = "key = \"\"\"\"\"\"";
+    errno = 0;
+    tab = tomltk_parse (six_double_quotes, strlen(six_double_quotes), &error);
+    ok (tab == NULL && errno == EINVAL,
+        "AFL hang: six consecutive double quotes rejected");
+    if (tab == NULL)
+        diag ("  error: %s", error.errbuf);
+
+    /* Test 6: Combined patterns - NULL + invalid UTF-8 + control chars
+     * Real AFL finding from id:000006: multiple issues in one input.
+     */
+    const unsigned char combined[] = {
+        0x61, 0x4c, 0x6c, 0x6f, 0x3d, 0x20,  // aLlo=
+        0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b,  // [[[[[[
+        0x77, 0x2d, 0x00, 0x00, 0x04, 0x00,  // w-\x00\x00\x04\x00
+        0x20, 0x3d, 0x20, 0x74, 0x72, 0x75, 0x65  // = true
+    };
+    errno = 0;
+    tab = tomltk_parse ((char*)combined, sizeof(combined), &error);
+    ok (tab == NULL && errno == EINVAL,
+        "AFL hang: combined NULL+control+nesting rejected");
+    if (tab == NULL)
+        diag ("  error: %s", error.errbuf);
+
+    /* Test 7: Valid UTF-8 multi-byte sequences should still work
+     * Ensure our UTF-8 validator doesn't reject legitimate multi-byte chars.
+     */
+    const unsigned char valid_utf8[] = {
+        0x6e, 0x61, 0x6d, 0x65, 0x20, 0x3d, 0x20, 0x22,  // name = "
+        0xC3, 0xA9, 0x6C, 0xC3, 0xA8, 0x76, 0x65,        // élève (French: student)
+        0x22  // "
+    };
+    errno = 0;
+    tab = tomltk_parse ((char*)valid_utf8, sizeof(valid_utf8), &error);
+    ok (tab != NULL,
+        "Valid UTF-8 multi-byte chars (é, è) accepted");
+    if (tab == NULL)
+        diag ("  error: %s", error.errbuf);
+    else
+        toml_free (tab);
+
+    /* Test 8: Excessive input size
+     * While not technically a "hang", AFL generates huge inputs that waste time.
+     * MAX_LINES=10000 should reject these quickly.
+     */
+    const int huge_lines = 15000;
+    char *huge_input = malloc(huge_lines * 10);  // ~150KB of newlines
+    if (huge_input) {
+        for (int i = 0; i < huge_lines * 10; i += 10) {
+            memcpy(huge_input + i, "k = 1\n", 6);
+            memset(huge_input + i + 6, '\n', 4);
+        }
+        errno = 0;
+        tab = tomltk_parse (huge_input, huge_lines * 10, &error);
+        ok (tab == NULL && errno == EINVAL,
+            "AFL hang: excessive input size (>10000 lines) rejected");
+        if (tab == NULL)
+            diag ("  error: %s", error.errbuf);
+        free (huge_input);
+    }
+
+    /* Test 9: Invalid UTF-8 inside strings (fuzzer04 id:000011)
+     * Invalid bytes 0xFF, 0x7F inside quoted strings.
+     * String content: f\xFF\x7Fse
+     */
+    const unsigned char invalid_in_string[] =
+        "string3 = \"\"\"\nmultabool2 = f\xff\x7fse\n\"\"\"";
+    errno = 0;
+    tab = tomltk_parse ((char*)invalid_in_string,
+                        sizeof(invalid_in_string)-1, &error);
+    ok (tab == NULL && errno == EINVAL,
+        "AFL hang fuzzer04-11: invalid UTF-8 (0xFF,0x7F) in string rejected");
+    if (tab == NULL)
+        diag ("  error: %s", error.errbuf);
+
+    /* Test 10: Long repetitive content with 4-quote pattern (fuzzer04 id:000012)
+     * Long runs of 'J' chars (200+ bytes) followed by anomalous quote pattern.
+     * This tests both string length handling and quote state tracking.
+     */
+    const char long_repetitive[] =
+        "string3 = \"\"\"\n"
+        "JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ"
+        "JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ"
+        "JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ"
+        "JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ"
+        "22\n\"\"\"";
+    errno = 0;
+    tab = tomltk_parse (long_repetitive, strlen(long_repetitive), &error);
+    // This should either parse successfully or reject cleanly (not hang)
+    if (tab != NULL) {
+        pass ("AFL hang fuzzer04-12: long repetitive pattern completed");
+        toml_free (tab);
+    } else {
+        ok (errno == EINVAL,
+            "AFL hang fuzzer04-12: long repetitive pattern rejected cleanly");
+        diag ("  error: %s", error.errbuf);
+    }
+
+    /* Test 11: Repetitive timestamp patterns (fuzzer04 id:000013)
+     * Many malformed timestamp-like strings with commas inside.
+     * Example: 1979-05-27T07:32:00+,pty_,+,1979-05-27...
+     * Tests parser's timestamp validation and comma handling.
+     */
+    const char timestamp_spam[] =
+        "bool1 = tru::bool2t5-27T07:42:00+,pty_,+,1979-05-27T07:32:79-05-27T:00+,"
+        "+,1979-05-27T07:32:00+,1979-05-27T07:2:00+,pty_,+,1979-05-27T07:32:00";
+    errno = 0;
+    tab = tomltk_parse (timestamp_spam, strlen(timestamp_spam), &error);
+    // Should reject due to malformed syntax, not hang
+    ok (tab == NULL && errno == EINVAL,
+        "AFL hang fuzzer04-13: repetitive timestamp patterns rejected");
+    if (tab == NULL)
+        diag ("  error: %s", error.errbuf);
+}
+
 int main (int argc, char *argv[])
 {
     plan (NO_PLAN);
@@ -264,6 +469,7 @@ int main (int argc, char *argv[])
     test_tojson_t3 ();
     test_parse_lineno ();
     test_corner ();
+    test_afl_hangs ();
 
     done_testing ();
 }

--- a/src/libutil/tomltk.c
+++ b/src/libutil/tomltk.c
@@ -45,6 +45,321 @@ static void errprintf (struct tomltk_error *error,
     errno = saved_errno;
 }
 
+/* Quick validation to reject inputs that cause libtomlc99 to hang.
+ * This is a fast pre-filter before calling the full parser.
+ *
+ * CONTEXT: libtomlc99 (https://github.com/cktan/tomlc99) is no longer
+ * actively maintained. AFL++ fuzzing discovered multiple inputs that cause
+ * the parser to enter infinite loops (21 unique hang inputs). Rather than
+ * fork and maintain libtomlc99 ourselves, we add pre-validation to reject
+ * problematic patterns before they reach the parser. This is a temporary
+ * mitigation until libtomlc99 can be replaced with a maintained alternative.
+ *
+ * The limits below are conservative values based on fuzzing results:
+ * - Inputs exceeding these limits triggered parser hangs
+ * - Legitimate flux-security configs are well below these thresholds
+ * - Values chosen to fail fast (~0.5ms) rather than hang indefinitely (5+ sec)
+ */
+static int validate_toml_syntax (const char *conf, int len,
+                                 struct tomltk_error *error)
+{
+    int bracket_depth = 0;
+    int max_depth = 0;
+    int square_count = 0;
+    char in_string = 0;  // 0 = not in string, '"' or '\'' = quote type that opened
+    int in_ml_double = 0;  // In """ multi-line string
+    int in_ml_single = 0;  // In ''' multi-line string
+    int escape_next = 0;
+    int in_array = 0;  // Track if we're inside an array value
+
+    /* MAX_NESTING: Limit bracket nesting depth.
+     * Fuzzing found that deeply nested arrays (e.g., [[[[[[...]]]]]])
+     * cause libtomlc99 to hang in recursive descent parsing. Set to 32
+     * based on fuzzing observations: legitimate configs use ≤3 levels,
+     * hangs occurred at 50+ levels. Value of 32 provides safety margin
+     * while preventing pathological inputs.
+     */
+    const int MAX_NESTING = 32;
+
+    /* MAX_LINES: Limit total input lines.
+     * Fuzzing found that extremely large inputs with certain patterns
+     * (embedded NULs, mismatched quotes, malformed arrays) cause the
+     * parser to hang in string processing loops. Set to 10,000 lines
+     * based on fuzzing observations: typical flux-security configs are
+     * 10-100 lines, hangs occurred with generated inputs >50K lines.
+     * Value of 10K provides generous headroom while preventing DoS via
+     * parser resource exhaustion.
+     */
+    const int MAX_LINES = 10000;
+
+    int line_count = 0;
+    int i;
+    int skip = 0;  // Track characters to skip (for multi-line delimiters)
+
+    for (i = 0; i < len; i++) {
+        unsigned char c = conf[i];
+
+        // Skip characters (used when consuming multi-char sequences)
+        if (skip > 0) {
+            skip--;
+            continue;
+        }
+
+        /* Validate UTF-8 encoding and reject invalid sequences.
+         * TOML spec requires valid UTF-8 (section 2.1). Invalid UTF-8
+         * bytes (0x80-0xFF not in valid sequences) can cause libtomlc99
+         * to hang or crash during string processing.
+         *
+         * UTF-8 encoding rules:
+         * - 0x00-0x7F: Single-byte (ASCII) - handled separately below
+         * - 0xC2-0xDF: 2-byte sequence start (followed by 1 continuation byte)
+         * - 0xE0-0xEF: 3-byte sequence start (followed by 2 continuation bytes)
+         * - 0xF0-0xF4: 4-byte sequence start (followed by 3 continuation bytes)
+         * - 0x80-0xBF: Continuation byte (only valid after start byte)
+         * - 0xC0-0xC1, 0xF5-0xFF: Invalid/overlong/out-of-range
+         *
+         * Fuzzing discovered that invalid UTF-8 (0x80, 0x81, 0x92, 0xFF, etc.)
+         * embedded in key names, string values, or between tokens causes the
+         * parser to enter infinite loops or access invalid memory.
+         */
+        if (c >= 0x80) {
+            // Multi-byte UTF-8 sequence
+            int seq_len = 0;
+
+            if (c >= 0xF0 && c <= 0xF4) {
+                seq_len = 4;  // 4-byte sequence
+            } else if (c >= 0xE0 && c <= 0xEF) {
+                seq_len = 3;  // 3-byte sequence
+            } else if (c >= 0xC2 && c <= 0xDF) {
+                seq_len = 2;  // 2-byte sequence
+            } else {
+                // Invalid start byte or stray continuation byte
+                errprintf (error, NULL, -1,
+                          "Invalid UTF-8 byte (0x%02X) at position %d",
+                          c, i);
+                return -1;
+            }
+
+            // Verify we have enough bytes for the sequence
+            if (i + seq_len > len) {
+                errprintf (error, NULL, -1,
+                          "Truncated UTF-8 sequence at position %d", i);
+                return -1;
+            }
+
+            // Validate continuation bytes (must be 0x80-0xBF)
+            for (int j = 1; j < seq_len; j++) {
+                unsigned char cont = conf[i + j];
+                if (cont < 0x80 || cont > 0xBF) {
+                    errprintf (error, NULL, -1,
+                              "Invalid UTF-8 continuation byte (0x%02X) at position %d",
+                              cont, i + j);
+                    return -1;
+                }
+            }
+
+            // Skip the continuation bytes we just validated
+            skip = seq_len - 1;
+            continue;
+        }
+
+        /* Reject control characters outside of strings.
+         * TOML allows only printable ASCII and whitespace (\t, \n, \r) outside
+         * of strings. Control characters (0x01-0x08, 0x0B-0x0C, 0x0E-0x1F, 0x7F)
+         * in unquoted context cause parser confusion and potential hangs.
+         * Fuzzing found that 0x04 and other control chars embedded between
+         * tokens cause infinite loops in whitespace/token scanning.
+         */
+        if (!in_string && !in_ml_double && !in_ml_single) {
+            if ((c < 0x20 && c != '\t' && c != '\n' && c != '\r') || c == 0x7F) {
+                errprintf (error, NULL, -1,
+                          "Invalid control character (0x%02X) at position %d",
+                          c, i);
+                return -1;
+            }
+        }
+
+        // Count newlines to detect excessive input
+        if (c == '\n') {
+            line_count++;
+            if (line_count > MAX_LINES) {
+                errprintf (error, NULL, -1,
+                          "Input too large (>%d lines)", MAX_LINES);
+                return -1;
+            }
+        }
+
+        /* Reject adjacent triple-quote sequences (6 consecutive quotes).
+         * Patterns like '''''' or """""" create ambiguous or zero-length
+         * multi-line strings that cause libtomlc99 to enter infinite loops.
+         * While technically valid TOML in some interpretations, these serve
+         * no legitimate purpose and consistently trigger parser hangs.
+         */
+        if (i + 5 < len) {
+            if ((conf[i] == '"' && conf[i+1] == '"' && conf[i+2] == '"' &&
+                 conf[i+3] == '"' && conf[i+4] == '"' && conf[i+5] == '"') ||
+                (conf[i] == '\'' && conf[i+1] == '\'' && conf[i+2] == '\'' &&
+                 conf[i+3] == '\'' && conf[i+4] == '\'' && conf[i+5] == '\'')) {
+                errprintf (error, NULL, -1,
+                          "Adjacent triple-quote sequences not allowed");
+                return -1;
+            }
+        }
+
+        // Check for multi-line string delimiters
+        if (i + 2 < len && !escape_next) {
+            if (conf[i] == '"' && conf[i+1] == '"' && conf[i+2] == '"') {
+                if (in_ml_double) {
+                    // Closing multi-line double-quote string
+                    in_ml_double = 0;
+                    skip = 2;  // Skip next 2 quotes
+                    continue;
+                } else if (!in_ml_single && !in_string) {
+                    // Opening multi-line double-quote string
+                    in_ml_double = 1;
+                    skip = 2;  // Skip next 2 quotes
+                    continue;
+                }
+            }
+            else if (conf[i] == '\'' && conf[i+1] == '\'' && conf[i+2] == '\'') {
+                if (in_ml_single) {
+                    // Closing multi-line single-quote string
+                    in_ml_single = 0;
+                    skip = 2;  // Skip next 2 quotes
+                    continue;
+                } else if (!in_ml_double && !in_string) {
+                    // Opening multi-line single-quote string
+                    in_ml_single = 1;
+                    skip = 2;  // Skip next 2 quotes
+                    continue;
+                }
+            }
+        }
+
+        // Inside multi-line strings, track escapes and look for closing delimiter
+        // Multi-line basic strings (""") support backslash escapes
+        // Multi-line literal strings (''') do NOT support escapes
+        if (in_ml_double) {
+            escape_next = (!escape_next && c == '\\');
+            continue;
+        }
+        if (in_ml_single) {
+            continue;
+        }
+
+        /* Track regular string state (single " or ').
+         * TOML requires matching quote types: strings that start with "
+         * must end with ", and strings that start with ' must end with '.
+         * Mismatched quotes like 'string"] cause parser hangs.
+         */
+        if (!escape_next && (c == '"' || c == '\'')) {
+            if (in_string == 0) {
+                // Opening a new string
+                in_string = c;
+            } else if (in_string == c) {
+                // Closing string with matching quote type
+                in_string = 0;
+            }
+            // Else: wrong quote type, ignore it (it's part of the string content)
+            continue;
+        }
+        if (in_string) {
+            // Only track escapes in double-quote strings (basic strings)
+            // Single-quote strings (literal strings) don't support escapes
+            if (in_string == '"')
+                escape_next = (!escape_next && c == '\\');
+            continue;
+        }
+        escape_next = 0;
+
+        // Handle comments - skip to end of line
+        if (c == '#') {
+            // Comments inside array values cause hangs
+            if (in_array) {
+                errprintf (error, NULL, -1,
+                          "Comment character inside array value");
+                return -1;
+            }
+            // Skip rest of line by counting chars until newline
+            int j;
+            for (j = i + 1; j < len && conf[j] != '\n'; j++)
+                ;  // Just counting
+            skip = j - i - 1;  // Skip all chars until (but not including) newline
+            continue;
+        }
+
+        // Count brackets outside strings
+        if (c == '[') {
+            square_count++;
+            bracket_depth++;
+            if (bracket_depth > max_depth)
+                max_depth = bracket_depth;
+
+            // Detect array values (not table headers)
+            if (bracket_depth == 1 && !in_array) {
+                // Check if this is at start of line (ignoring whitespace)
+                // If so, it's likely a table header [section], not an array value
+                int j = i - 1;
+                int is_table = 1;
+                while (j >= 0 && conf[j] != '\n') {
+                    if (conf[j] != ' ' && conf[j] != '\t') {
+                        is_table = 0;
+                        break;
+                    }
+                    j--;
+                }
+                if (!is_table && i > 0) {
+                    in_array = 1;
+                }
+            }
+            else if (bracket_depth > 1 || in_array) {
+                in_array = 1;
+            }
+
+            // Reject excessive nesting (catches deeply nested arrays)
+            if (bracket_depth > MAX_NESTING) {
+                errprintf (error, NULL, -1,
+                          "Excessive bracket nesting depth (%d)",
+                          bracket_depth);
+                return -1;
+            }
+        }
+        else if (c == ']') {
+            square_count--;
+            bracket_depth--;
+
+            // When we close all brackets, we're out of any array
+            if (bracket_depth == 0) {
+                in_array = 0;
+            }
+
+            // Reject if more closing than opening brackets
+            if (square_count < 0) {
+                errprintf (error, NULL, -1, "Unbalanced brackets");
+                return -1;
+            }
+        }
+    }
+
+    // Reject if brackets don't balance
+    if (square_count != 0) {
+        errprintf (error, NULL, -1, "Unbalanced brackets");
+        return -1;
+    }
+
+    // Reject if multi-line strings aren't closed
+    if (in_ml_double) {
+        errprintf (error, NULL, -1, "Unterminated multi-line string (\"\"\")");
+        return -1;
+    }
+    if (in_ml_single) {
+        errprintf (error, NULL, -1, "Unterminated multi-line string (''')");
+        return -1;
+    }
+
+    return 0;
+}
+
 /* Given an error message response from toml_parse(), parse the
  * error message into line number and message, e.g.
  *   "line 42: bad key"
@@ -294,6 +609,15 @@ toml_table_t *tomltk_parse (const char *conf, int len,
         errno = EINVAL;
         return NULL;
     }
+    if (len > 0 && memchr (conf, '\0', len) != NULL) {
+        errprintf (error, NULL, -1, "Config contains embedded NUL byte");
+        errno = EINVAL;
+        return NULL;
+    }
+    if (len > 0 && validate_toml_syntax (conf, len, error) < 0) {
+        errno = EINVAL;
+        return NULL;
+    }
     if (!(cpy = calloc (1, len + 1))) {
         errprintf (error, NULL, -1, "out of memory");
         errno = ENOMEM;
@@ -313,9 +637,12 @@ toml_table_t *tomltk_parse (const char *conf, int len,
 toml_table_t *tomltk_parse_file (const char *filename,
                                  struct tomltk_error *error)
 {
-    char errbuf[200];
     FILE *fp;
     toml_table_t *tab;
+    char *buf = NULL;
+    size_t bufsize = 0;
+    size_t total = 0;
+    int saved_errno;
 
     if (!filename) {
         errprintf (error, NULL, -1, "invalid argument");
@@ -326,16 +653,61 @@ toml_table_t *tomltk_parse_file (const char *filename,
         errprintf (error, filename, -1, "%s", strerror (errno));
         return NULL;
     }
-    // N.B. toml_parse_file() doesn't give us any way to distinguish parse
-    // error from read error
-    tab = toml_parse_file (fp, errbuf, sizeof (errbuf));
-    (void)fclose (fp);
-    if (!tab) {
-        errfromtoml (error, filename, errbuf);
-        errno = EINVAL;
-        return NULL;
+
+    /* Read file into memory for validation.
+     * Previously we called toml_parse_file() directly, which bypassed
+     * our validation (NULL bytes, UTF-8, control chars). This could allow
+     * malicious config files to trigger parser hangs. Now we read the file,
+     * validate it, then parse via tomltk_parse() which enforces all checks.
+     */
+    #define CHUNK_SIZE 4096
+    while (1) {
+        if (total + CHUNK_SIZE > bufsize) {
+            bufsize = total + CHUNK_SIZE;
+            char *newbuf = realloc (buf, bufsize);
+            if (!newbuf) {
+                saved_errno = ENOMEM;
+                errprintf (error, filename, -1, "out of memory");
+                goto error;
+            }
+            buf = newbuf;
+        }
+
+        size_t n = fread (buf + total, 1, CHUNK_SIZE, fp);
+        total += n;
+
+        if (n < CHUNK_SIZE) {
+            if (ferror (fp)) {
+                saved_errno = errno;
+                errprintf (error, filename, -1, "read error: %s", strerror (errno));
+                goto error;
+            }
+            break;  // EOF
+        }
     }
+    fclose (fp);
+    fp = NULL;
+
+    /* Parse through tomltk_parse() to get full validation */
+    tab = tomltk_parse (buf, total, error);
+    free (buf);
+
+    /* If parsing failed and error struct doesn't have filename set,
+     * add it now since tomltk_parse() doesn't know the filename.
+     */
+    if (!tab && error && strlen (error->filename) == 0) {
+        strncpy (error->filename, filename, PATH_MAX);
+        error->filename[PATH_MAX] = '\0';
+    }
+
     return tab;
+
+error:
+    if (fp)
+        fclose (fp);
+    free (buf);
+    errno = saved_errno;
+    return NULL;
 }
 
 /*

--- a/src/libutil/tomltk.c
+++ b/src/libutil/tomltk.c
@@ -209,7 +209,6 @@ static int array_to_json (toml_array_t *arr, json_t **op)
         else
             break;
         if (json_array_append_new (obj, val) < 0) {
-            json_decref (val);
             goto nomem;
         }
     }
@@ -256,7 +255,6 @@ static int table_to_json (toml_table_t *tab, json_t **op)
                 goto error;
         }
         if (json_object_set_new (obj, key, val) < 0) {
-            json_decref (val);
             goto nomem;
         }
     }


### PR DESCRIPTION
This PR adds an initial AFL++ fuzzing infrastructure to flux-security and fixes bugs discovered during an initial fuzzing campaign.

Status: WIP to let the initial campaign run a bit longer and to ensure we want to actually merge all the infrastructure.

The initial fuzzing was performed on 4 high-value functions that are used in IMP privileged code with possibly untrusted user or system data:

  - **`flux_sign_unwrap()` / `flux_sign_unwrap_noverify()`** - IMP validates signatures from untrusted guest users
  - **`kv_decode()`** - IMP decodes data from unprivileged child processes
  - **`cf_*()` (libutil/cf.h)** - Configuration parser. While config files are permission-checked, defense-in-depth requires robustness against malformed input

### What's Included

  **Fuzzing Infrastructure**
  - AFL++ build integration with AddressSanitizer
  - fuzzing harnesses for parsers and crypto functions in `src/fuzz`
  - Orchestration tooling (`scripts/fuzz.py`) for managing multi-fuzzer campaigns
  - Documentation and corpus management

  **Security Fixes**
  - 21 parser hang vectors eliminated (TOML validation). Where possible, fixes were made in the tomltk wrapper since the upstream libtomlc99 parser is no longer maintained.
  - 15 heap corruption bugs fixed (use-after-free, buffer overflows)
  - NULL pointer crash fixed (empty payload handling)
  - Additional hardening from static analysis

  ## Results

The initial fuzzing campaign was run for >12 hrs and was stopped after new edges failed to be detected for several hours.

  - All discovered crashes fixed
  - All parser hangs eliminated
  - No API changes required
  - Continuous fuzzing infrastructure in place for ongoing testing
