### PR TITLE
MAINTAINERS.md: drop non-maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,28 +6,5 @@ to this project, please refer to [CONTRIBUTING](CONTRIBUTING.md).
 
 | Maintainer       | GitHub ID                                             | Affiliation |
 | ---------------- | ----------------------------------------------------- | ----------- |
-| Al Chu           | [chu11](https://github.com/chu11)                     | LLNL        |
-| Chris Dunlap     | [dun](https://github.com/dun)                         | LLNL        |
-| Chris Moussa     | [cmoussa1](https://github.com/cmoussa1)               | LLNL        |
-| Elsa Gonsiorowski| [gonsie](https://github.com/gonsie)                   | LLNL        |
-| James Corbett    | [jameshcorbett](https://github.com/jameshcorbett)     | LLNL        |
 | Jim Garlick      | [garlick](https://github.com/garlick)                 | LLNL        |
-| Jae-seung Yeom   | [JaeseungYeom](https://github.com/JaeseungYeom)       | LLNL        |
 | Mark Grondona    | [grondo](https://github.com/grondo)                   | LLNL        |
-| Daniel Milroy    | [milroy](https://github.com/milroy)                   | LLNL        |
-| Tapasya Patki    | [tpatki](https://github.com/tpatki)                   | LLNL        |
-| Tom Scogland     | [trws](https://github.com/trws)                       | LLNL        |
-| Vanessa Sochat   | [vsoch](https://github.com/vsoch)                     | LLNL        |
-| Becky Springmeyer| [springme](https://github.com/springme)               | LLNL        |
-| William Hobbs    | [wihobbs](https://github.com/wihobbs)                 | LLNL        |
-| Sam Maloney      | [sam-maloney](https://github.com/sam-maloney)         | FZJ-JSC     |
-
-## Maintainers Emeritus
-
-| Maintainer       | GitHub ID                                             | Affiliation |
-| ---------------- | ----------------------------------------------------- | ----------- |
-| Dong Ahn         | [dongahn](https://github.com/dongahn)                 | NVIDIA      |
-| Don Lipari       | [lipari](https://github.com/lipari)                   | independent |
-| Chris Morrone    | [morrone](https://github.com/morrone)                 | LLNL        |
-| Stephen Herbein  | [steVwonder](https://github.com/steVwonder)           | NVIDIA      |
-


### PR DESCRIPTION
Problem: MAINTAINERS.md was copied from another repo with the assumption that the 'core' team had admin access, but that was not the case. Only organization owners had access here.

Cut back the MAINTAINERS.md list to Mark and Jim.