### PR TITLE
doc: organize docs so some internals notes can be added

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -90,6 +90,8 @@ EXTRA_DIST = \
 	manpages.py \
 	domainrefs.py \
 	index.rst \
+	index_man.rst \
+	guide/internals.rst \
 	requirements.txt \
 	man3/index.rst \
 	man5/index.rst \

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -22,6 +22,9 @@
 #
 import os
 import sys
+import pathlib
+sys.path.append(str(pathlib.Path(__file__).absolute().parent))
+
 from manpages import man_pages
 import docutils.nodes
 

--- a/doc/guide/internals.rst
+++ b/doc/guide/internals.rst
@@ -1,0 +1,6 @@
+Resources for Flux Developers
+=============================
+
+.. toctree::
+   :maxdepth: 1
+

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,19 +1,52 @@
-Documentation for flux-security
-===============================
+flux-security
+=============
+
+flux-security provides the security infrastructure required for multi-user
+Flux instances.  It includes a signing library that allows Flux to
+authenticate job requests across nodes, and a setuid helper called the IMP
+(Independent Minister of Privilege) that enables Flux to launch jobs as
+arbitrary users without requiring the broker to run as root.
+
+flux-security is a required companion to flux-core in production HPC
+deployments where Flux is deployed as a multi-user system service.  It is
+designed with a minimal privilege footprint: the IMP is the only component
+that runs as root, and it does so only for the narrow operations required
+to launch and signal jobs on behalf of authenticated
+users.
+
+Related Information
+===================
+
+flux-security is designed to be deployed alongside flux-core.  Those wishing
+to understand Flux security in a broader context may benefit from the
+following material:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Description
+     - Links
+
+   * - Main Flux Documentation Pages
+     - `Github <https://github.com/flux-framework>`_
+
+       `Docs <https://flux-framework.readthedocs.io/en/latest/index.html>`_
+
+   * - flux-core — the primary Flux framework project
+     - `Github <https://github.com/flux-framework/flux-core>`_
+
+       `Docs <https://flux-framework.readthedocs.io/projects/flux-core>`_
+
+   * - Flux Request for Comments Specifications
+     - `Github <https://github.com/flux-framework/rfc>`_
+
+       `Docs <https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/index.html>`_
+
+Table of Contents
+=================
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
 
-
-.. _man-pages:
-
-flux-security Manual Pages
-==========================
-
-.. toctree::
-   :maxdepth: 2
-
-   man3/index
-   man5/index
-   man8/index
+   index_man
+   guide/internals

--- a/doc/index_man.rst
+++ b/doc/index_man.rst
@@ -1,0 +1,11 @@
+.. _man-pages:
+
+Manual Pages
+============
+
+.. toctree::
+   :maxdepth: 1
+
+   man3/index
+   man5/index
+   man8/index

--- a/doc/man3/index.rst
+++ b/doc/man3/index.rst
@@ -1,12 +1,8 @@
-man3
-====
+Section 3 - C Library Functions
+================================
 
 .. toctree::
-  :caption: C Library Functions
-  :maxdepth: 1
+   :maxdepth: 1
+   :glob:
 
-  flux_security_create
-  flux_sign_wrap
-  flux_sign_unwrap
-  flux_security_last_error
-  flux_security_aux_set
+   *

--- a/doc/man5/index.rst
+++ b/doc/man5/index.rst
@@ -1,10 +1,8 @@
-man5
-====
+Section 5 - File Formats and Conventions
+=========================================
 
 .. toctree::
-  :caption: File formats and conventions
-  :maxdepth: 1
+   :maxdepth: 1
+   :glob:
 
-  flux-config-security
-  flux-config-security-imp
-  flux-config-security-sign
+   *

--- a/doc/man8/index.rst
+++ b/doc/man8/index.rst
@@ -1,8 +1,8 @@
-man8
-====
+Section 8 - System Administration
+===================================
 
 .. toctree::
-  :caption: System commands
-  :maxdepth: 1
+   :maxdepth: 1
+   :glob:
 
-  flux-imp
+   *


### PR DESCRIPTION
I wanted to get the docs organized similar to flux-core with a "Resources for Flux Developers" section that could be amended with device containment info as that is developed.