### PR TITLE
imp: add log-level TOML config key

### DIFF
--- a/doc/man5/flux-config-security-imp.rst
+++ b/doc/man5/flux-config-security-imp.rst
@@ -99,6 +99,12 @@ allow-sudo
    Set to true if the IMP should simulate a setuid installation when run
    under :linux:man8:`sudo`. This option is only useful for testing.
 
+log-level
+   Set the logging verbosity to ``warning``, ``info`` (default), or
+   ``debug``. Setting ``debug`` enables diagnostic messages useful for
+   testing and troubleshooting. This option should not be set in
+   production.
+
 EXAMPLE
 =======
 

--- a/src/imp/imp.c
+++ b/src/imp/imp.c
@@ -35,6 +35,7 @@ extern int imp_conf_init (cf_t *cf, struct cf_error *error);
 /*  Static prototypes:
  */
 static void initialize_logging ();
+static void initialize_log_level (cf_t *conf);
 static int  imp_state_init (struct imp_state *imp, int argc, char **argv);
 static cf_t * imp_conf_load (const char *pattern);
 static bool imp_is_privileged ();
@@ -58,6 +59,8 @@ int main (int argc, char *argv[])
      */
     if (!(imp.conf = imp_conf_load (imp_get_config_pattern ())))
         imp_die (1, "Failed to load configuration");
+
+    initialize_log_level (imp.conf);
 
     /*  Get current IMP cgroup information:
      */
@@ -118,6 +121,34 @@ static void initialize_logging (void)
         fprintf (stderr, "flux-imp: Fatal: Failed to initialize logging.\n");
         exit (1);
     }
+}
+
+static int parse_log_level (const char *s)
+{
+    if (strcmp (s, "debug") == 0)
+        return IMP_LOG_DEBUG;
+    if (strcmp (s, "info") == 0)
+        return IMP_LOG_INFO;
+    if (strcmp (s, "warning") == 0)
+        return IMP_LOG_WARNING;
+    return -1;
+}
+
+static void initialize_log_level (cf_t *conf)
+{
+    const cf_t *cf;
+    const char *s;
+    int level;
+
+    if (!(cf = cf_get_in (conf, "log-level")))
+        return;
+    s = cf_string (cf);
+    if ((level = parse_log_level (s)) < 0) {
+        imp_warn ("unknown log-level '%s', ignoring", s);
+        return;
+    }
+    imp_log_set_level (NULL, level);
+    imp_log_set_level ("stderr", level);
 }
 
 static int imp_state_init (struct imp_state *imp, int argc, char *argv[])

--- a/t/t1000-imp-basic.t
+++ b/t/t1000-imp-basic.t
@@ -94,4 +94,15 @@ test_expect_success SUID_ENABLED 'flux-imp setuid ignores SUDO_USER' '
 	EOF
 	test_cmp expected.whoami.no output.whoami.no
 '
+test_expect_success 'log-level = debug is accepted' '
+	printf "log-level = \"debug\"\n" > loglevel-debug.toml &&
+	( export FLUX_IMP_CONFIG_PATTERN=loglevel-debug.toml &&
+	  $flux_imp version )
+'
+test_expect_success 'unknown log-level generates a warning' '
+	printf "log-level = \"verbose\"\n" > loglevel-bad.toml &&
+	( export FLUX_IMP_CONFIG_PATTERN=loglevel-bad.toml &&
+	  $flux_imp version 2>loglevel-bad.err ) &&
+	grep "unknown log-level" loglevel-bad.err
+'
 test_done


### PR DESCRIPTION
Problem: There is no way to enable IMP debug log output from the installed IMP executable.
    
Add a top-level `log-level` config key that accepts "warning", "info",  or "debug". When set, it overrides the default (info) level.
