### PR TITLE
imp: sanitize log messages

### DIFF
--- a/src/imp/imp_log.c
+++ b/src/imp/imp_log.c
@@ -171,6 +171,29 @@ int imp_log_set_level (const char *name, int level)
 /*
  *   Logging interface functions
  */
+
+/* Neutralize control characters in a fully-formatted log message before it
+ * is handed to any output backend. Without this, an embedded newline could
+ * forge a second log line and an ESC byte could inject a terminal escape
+ * sequence into an administrator's view of the IMP's stderr/journal.
+ */
+static void log_sanitize (char *s)
+{
+    size_t len = strlen (s);
+    /*  Drop trailing newline(s): every output backend supplies its own.
+     */
+    while (len > 0 && (s[len - 1] == '\n' || s[len - 1] == '\r'))
+        s[--len] = '\0';
+
+    /*  Remove other escape characters (except tab)
+     */
+    for (size_t i = 0; i < len; i++) {
+        unsigned char c = (unsigned char) s[i];
+        if (c != '\t' && (c < 0x20 || c == 0x7f))
+            s[i] = '?';
+    }
+}
+
 static void vlog_msg (int level, const char *format, va_list ap,
                       hash_t outputs)
 {
@@ -193,6 +216,8 @@ static void vlog_msg (int level, const char *format, va_list ap,
         q += strlen (suffix);
         *q = '\0';
     }
+
+    log_sanitize (buf);
 
     arg.msg = buf;
     hash_for_each (outputs, (hash_arg_f) log_output_call, (void *) &arg);

--- a/src/imp/test/imp_log.c
+++ b/src/imp/test/imp_log.c
@@ -102,6 +102,30 @@ int main (void)
     ok (rc > 0, "very long log message gets written (len = %d)", rc);
     ok (testbuf[rc - 1] == '+', "very long log message is truncated");
 
+    /*  Control characters embedded in a message are neutralized so an
+     *   attacker-influenced argument cannot forge log lines or inject
+     *   terminal escape sequences (see log_sanitize()).
+     */
+    reset_logbuf ();
+    imp_say ("mechanism=%s unknown", "munge\ndevice: allow /dev/mem");
+    is (testbuf, "Notice: mechanism=munge?device: allow /dev/mem unknown",
+        "embedded newline is replaced with '?'");
+
+    reset_logbuf ();
+    imp_say ("boot\033[2Jsequence");
+    is (testbuf, "Notice: boot?[2Jsequence",
+        "embedded ESC is replaced with '?'");
+
+    reset_logbuf ();
+    imp_say ("trailing newline\n");
+    is (testbuf, "Notice: trailing newline",
+        "trailing newline is stripped");
+
+    reset_logbuf ();
+    imp_say ("tab\tseparated");
+    is (testbuf, "Notice: tab\tseparated",
+        "tab is preserved");
+
     /*  Remove logging provider */
     rc = imp_log_remove ("test");
     ok (rc == 0, "imp_log_remove: works");


### PR DESCRIPTION
The IMP's log functions format their arguments and pass the result to each output backend without filtering control characters. Some of those arguments could be attacker-influenced. Unfiltered, an embedded newline could forge a log line and an ESC byte could inject a terminal escape sequence into an administrator's view of the IMP's stderr/journal.

This is defense-in-depth: in practice the IMP is invoked only by the instance owner and most provided data is instance owner origin, so exposure is limited, but log output should never carry unsanitized untrusted bytes regardless of source.

The fix sanitizes in `vlog_msg()`, the single point every log message passes through before dispatch — replacing `bytes < 0x20` (except tab) and `0x7f` with `?` and stripping trailing newlines -- so every current and future call site is covered at once. Unit tests in `test/imp_log.c` verify the behavior.

This issue was found during a Claude Security scan of `src/imp`.